### PR TITLE
Add vtk.util.colors for backward compability

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,20 @@
+
+ignore:
+  - "setup.py"
+  - "*/setup.py"
+  - "*/data/fetcher.py"
+  - "*/tests/*"
+
+coverage:
+  status:
+    project:
+      default:
+        # Drops on the order 0.01% are typical even when no change occurs
+        # Having this threshold set a little higher (0.1%) than that makes it 
+        # a little more tolerant to fluctuations
+        target: auto
+        threshold: 0.1%
+    patch:
+      default:
+        target: auto
+        threshold: 0.1%

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,6 +2,7 @@
 ignore:
   - "setup.py"
   - "*/setup.py"
+  - "_version.py"
   - "*/data/fetcher.py"
   - "*/tests/*"
 

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,12 @@
 
+comment:
+  layout: "reach, diff, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: no        # [yes :: must have a base report to post]
+  require_head: yes       # [yes :: must have a head report to post]
+  branches: null
+
 ignore:
   - "setup.py"
   - "*/setup.py"

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+branch = True
+source = dipy
+include = */fury/*
+omit =
+    */setup.py
+[report]
+show_missing = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -4,5 +4,6 @@ source = fury
 include = */fury/*
 omit =
     */setup.py
+    */_version.py
 [report]
 show_missing = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 branch = True
-source = dipy
+source = fury
 include = */fury/*
 omit =
     */setup.py

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Description
+[Please provide a general introduction to the issue/proposal.]
+
+[If reporting a bug, attach the entire traceback from Python and follow the way to reproduce below]
+[If proposing an enhancement/new feature, provide links to related articles, reference examples, etc.]
+
+
+## Way to reproduce
+[If reporting a bug, please include the following important information:]
+- [ ] Code example
+- [ ] Relevant images (if any)
+- [ ] Operating system and version (run `python -c "import platform; print(platform.platform())"`)
+- [ ] Python version (run `python -c "import sys; print("Python", sys.version)"`)
+- [ ] dipy version (run `python -c "import fury; print(fury.__version__)"`)
+- [ ] dependency version (numpy, scipy, vtk)
+    * import numpy; print("NumPy", numpy.__version__)
+    * import scipy; print("SciPy", scipy.__version__)
+    * import fury; print("fury", fury.__version__)

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## Description
 [Please provide a general introduction to the issue/proposal.]
 
-[If reporting a bug, attach the entire traceback from Python and follow the way to reproduce below]
+[If reporting a bug, attach the entire traceback from Python and follow the way to reproduce below.]
 [If proposing an enhancement/new feature, provide links to related articles, reference examples, etc.]
 
 

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Contribute
 
 We love contributions!
 
-Whatever your experience level, every new contributors are welcomed!
+Whatever your experience level, all new contributors are welcomed!
 
 You've discovered a bug or something else you want to change - excellent! Create an `issue <https://github.com/fury-gl/fury/issues/new>`_!
 

--- a/README.rst
+++ b/README.rst
@@ -23,45 +23,57 @@ FURY is package for scientific visualization with Python.
 - **Free software:** 3-clause BSD license
 
 
-# Installation
+Installation
+-------------
 
-### **from binaries:**
+**from binaries:**
+~~~~~~~~~~~~~~~~~~
 
     pip install fury
 
-### **from source:**
+**from source:**
+~~~~~~~~~~~~~~~~
 
 **Step 1.** Get latest source by cloning this repo:
 
+    ```
     git clone https://github.com/fury-gl/fury.git
+    ```
 
 **Step 2.** Install requirements:
 
+    ```
     pip install -r requirements/default.txt
+    ```
 
 **Step 3.** Install fury via 
 
+    ```
     pip install .
+    ```
 
 or
 
+    ```
     pip install -e .
+    ```
 
 **Step 4:** Enjoy!
 
 For more information, see also [installation page on fury.gl](https://fury.gl/stable/installation.html)
 
 
-# Contribute
+Contribute
+----------
 
 We love contributions!
 
 Whatever your experience level, every new contributors are welcomed!
 
-You've discovered a bug or something else you want to change - excellent! Create an [issue](https://github.com/fury-gl/fury/issues/new)!
+You've discovered a bug or something else you want to change - excellent! Create an `issue<https://github.com/fury-gl/fury/issues/new>`_!
 
 You've worked out a way to fix it – even better! submit a Pull Request!
 
 You want to tell us about it – best of all!
 
-Start at the [contributing guide](CONTRIBUTING.rst)!
+Start at the `contributing guide<CONTRIBUTING.rst>`_!

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ from binaries
 from source
 ~~~~~~~~~~~
 
-**Step 1.** Get latest source by cloning this repo::
+**Step 1.** Get the latest source by cloning this repo::
 
     git clone https://github.com/fury-gl/fury.git
 

--- a/README.rst
+++ b/README.rst
@@ -22,19 +22,16 @@ FURY is package for scientific visualization with Python.
 - **Issue tracker:** https://github.com/fury-gl/fury/issues
 - **Free software:** 3-clause BSD license
 
-
-------------
 Installation
 ------------
 
+from binaries
+~~~~~~~~~~~~~
 
-**from binaries:**
-~~~~~~~~~~~~~~~~~~
+    pip install fury
 
-`pip install fury`
-
-**from source:**
-~~~~~~~~~~~~~~~~
+from source
+~~~~~~~~~~~
 
 **Step 1.** Get latest source by cloning this repo::
 
@@ -56,8 +53,6 @@ or::
 
 For more information, see also `installation page on fury.gl <https://fury.gl/stable/installation.html>`_
 
-
-----------
 Contribute
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -23,45 +23,41 @@ FURY is package for scientific visualization with Python.
 - **Free software:** 3-clause BSD license
 
 
+------------
 Installation
--------------
+------------
+
 
 **from binaries:**
 ~~~~~~~~~~~~~~~~~~
 
-```
-pip install fury
-```
+`pip install fury`
 
 **from source:**
 ~~~~~~~~~~~~~~~~
 
-**Step 1.** Get latest source by cloning this repo:
-```
-git clone https://github.com/fury-gl/fury.git
-```
+**Step 1.** Get latest source by cloning this repo::
 
-**Step 2.** Install requirements:
-```
-pip install -r requirements/default.txt
-```
+    git clone https://github.com/fury-gl/fury.git
 
-**Step 3.** Install fury via 
-```
-pip install .
-```
+**Step 2.** Install requirements::
 
-or
+    pip install -r requirements/default.txt
 
-```
-pip install -e .
-```
+**Step 3.** Install fury via::
+
+    pip install .
+
+or::
+
+    pip install -e .
 
 **Step 4:** Enjoy!
 
-For more information, see also [installation page on fury.gl](https://fury.gl/stable/installation.html)
+For more information, see also `installation page on fury.gl <https://fury.gl/stable/installation.html>`_
 
 
+----------
 Contribute
 ----------
 
@@ -69,7 +65,7 @@ We love contributions!
 
 Whatever your experience level, every new contributors are welcomed!
 
-You've discovered a bug or something else you want to change - excellent! Create an `issue<https://github.com/fury-gl/fury/issues/new>`_!
+You've discovered a bug or something else you want to change - excellent! Create an `issue <https://github.com/fury-gl/fury/issues/new>`_!
 
 You've worked out a way to fix it – even better! submit a Pull Request!
 

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,3 @@
-===============================
-FURY
-===============================
-
 .. image:: https://img.shields.io/travis/fury-gl/fury.svg
         :target: https://travis-ci.org/fury-gl/fury
 
@@ -12,12 +8,60 @@ FURY
         :target: https://codecov.io/gh/fury-gl/fury
 
 
-Free Unified Rendering in Python
+=======================================
+FURY - Free Unified Rendering in Python
+=======================================
 
-* Free software: 3-clause BSD license
-* Documentation: https://fury.gl
 
-Features
---------
+FURY is package for scientific visualization with Python.
 
-* TODO
+- **Website and Documentation:** https://fury.gl
+- **Mailing list:** https://mail.python.org/mailman3/lists/fury.python.org
+- **Official source code repo:** https://github.com/fury-gl/fury.git
+- **Download releases:** https://pypi.org/project/fury/
+- **Issue tracker:** https://github.com/fury-gl/fury/issues
+- **Free software:** 3-clause BSD license
+
+
+# Installation
+
+### **from binaries:**
+
+    pip install fury
+
+### **from source:**
+
+**Step 1.** Get latest source by cloning this repo:
+
+    git clone https://github.com/fury-gl/fury.git
+
+**Step 2.** Install requirements:
+
+    pip install -r requirements/default.txt
+
+**Step 3.** Install fury via 
+
+    pip install .
+
+or
+
+    pip install -e .
+
+**Step 4:** Enjoy!
+
+For more information, see also [installation page on fury.gl](https://fury.gl/stable/installation.html)
+
+
+# Contribute
+
+We love contributions!
+
+Whatever your experience level, every new contributors are welcomed!
+
+You've discovered a bug or something else you want to change - excellent! Create an [issue](https://github.com/fury-gl/fury/issues/new)!
+
+You've worked out a way to fix it – even better! submit a Pull Request!
+
+You want to tell us about it – best of all!
+
+Start at the [contributing guide](CONTRIBUTING.rst)!

--- a/README.rst
+++ b/README.rst
@@ -66,4 +66,4 @@ You've worked out a way to fix it – even better! Submit a Pull Request!
 
 You want to tell us about it – best of all!
 
-Start at the `contributing guide <CONTRIBUTING.rst>`_!
+Start with the `contributing guide <CONTRIBUTING.rst>`_!

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,6 @@
         :target: https://codecov.io/gh/fury-gl/fury
 
 
-=======================================
 FURY - Free Unified Rendering in Python
 =======================================
 
@@ -23,15 +22,18 @@ FURY is a package for scientific visualization with Python.
 - **Free software:** 3-clause BSD license
 
 Installation
-------------
+============
 
-from binaries
-~~~~~~~~~~~~~
+
+1. from binaries
+~~~~~~~~~~~~~~~~
+
+.. code-block::
 
     pip install fury
 
-from source
-~~~~~~~~~~~
+2. from source
+~~~~~~~~~~~~~~
 
 **Step 1.** Get the latest source by cloning this repo::
 
@@ -54,7 +56,8 @@ or::
 For more information, see also `installation page on fury.gl <https://fury.gl/stable/installation.html>`_
 
 Contribute
-----------
+==========
+
 
 We love contributions!
 

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ FURY - Free Unified Rendering in Python
 =======================================
 
 
-FURY is a package for scientific visualization with Python.
+FURY is a software library for scientific visualization in Python
 
 - **Website and Documentation:** https://fury.gl
 - **Mailing list:** https://mail.python.org/mailman3/lists/fury.python.org
@@ -61,12 +61,8 @@ Contribute
 
 We love contributions!
 
-Whatever your experience level, all new contributors are welcomed!
-
 You've discovered a bug or something else you want to change - excellent! Create an `issue <https://github.com/fury-gl/fury/issues/new>`_!
 
 You've worked out a way to fix it – even better! Submit a Pull Request!
-
-You want to tell us about it – best of all!
 
 Start with the `contributing guide <CONTRIBUTING.rst>`_!

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ FURY - Free Unified Rendering in Python
 =======================================
 
 
-FURY is package for scientific visualization with Python.
+FURY is a package for scientific visualization with Python.
 
 - **Website and Documentation:** https://fury.gl
 - **Mailing list:** https://mail.python.org/mailman3/lists/fury.python.org

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Whatever your experience level, all new contributors are welcomed!
 
 You've discovered a bug or something else you want to change - excellent! Create an `issue <https://github.com/fury-gl/fury/issues/new>`_!
 
-You've worked out a way to fix it – even better! submit a Pull Request!
+You've worked out a way to fix it – even better! Submit a Pull Request!
 
 You want to tell us about it – best of all!
 

--- a/README.rst
+++ b/README.rst
@@ -29,34 +29,33 @@ Installation
 **from binaries:**
 ~~~~~~~~~~~~~~~~~~
 
-    pip install fury
+```
+pip install fury
+```
 
 **from source:**
 ~~~~~~~~~~~~~~~~
 
 **Step 1.** Get latest source by cloning this repo:
-
-    ```
-    git clone https://github.com/fury-gl/fury.git
-    ```
+```
+git clone https://github.com/fury-gl/fury.git
+```
 
 **Step 2.** Install requirements:
-
-    ```
-    pip install -r requirements/default.txt
-    ```
+```
+pip install -r requirements/default.txt
+```
 
 **Step 3.** Install fury via 
-
-    ```
-    pip install .
-    ```
+```
+pip install .
+```
 
 or
 
-    ```
-    pip install -e .
-    ```
+```
+pip install -e .
+```
 
 **Step 4:** Enjoy!
 
@@ -76,4 +75,4 @@ You've worked out a way to fix it – even better! submit a Pull Request!
 
 You want to tell us about it – best of all!
 
-Start at the `contributing guide<CONTRIBUTING.rst>`_!
+Start at the `contributing guide <CONTRIBUTING.rst>`_!

--- a/fury/window.py
+++ b/fury/window.py
@@ -7,7 +7,7 @@ from warnings import warn
 import numpy as np
 from scipy import ndimage
 import vtk
-from vtk.util import numpy_support
+from vtk.util import numpy_support, colors
 
 from fury.tmpdirs import InTemporaryDirectory
 


### PR DESCRIPTION
Some examples do not work on `Dipy` because `fury.window.colors` do not exist.

The aim of this PR is to fix this small issue.

I use this opportunity to:
- Update readme
- Add codecov.yml
- Add coveragerc
- Add Issue template