### PR TITLE
Re-enable transparency test, change colors

### DIFF
--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -249,46 +249,46 @@ def test_order_transparent():
 
     lines = [np.array([[-1, 0, 0.], [1, 0, 0.]]),
              np.array([[-1, 1, 0.], [1, 1, 0.]])]
-    colors = np.array([[1., 0., 0.], [0., .5, 0.]])
+    colors = np.array([[1., 0., 0.], [0., 1., 0.]])
     stream_actor = actor.streamtube(lines, colors, linewidth=0.3, opacity=0.5)
 
-    # scene.add(stream_actor)
+    scene.add(stream_actor)
 
-    # scene.reset_camera()
+    scene.reset_camera()
 
-    # # green in front
-    # scene.elevation(90)
-    # scene.camera().OrthogonalizeViewUp()
-    # scene.reset_clipping_range()
+    # green in front
+    scene.elevation(90)
+    scene.camera().OrthogonalizeViewUp()
+    scene.reset_clipping_range()
 
-    # scene.reset_camera()
+    scene.reset_camera()
 
-    # not_xvfb = os.environ.get("TEST_WITH_XVFB", False)
+    not_xvfb = os.environ.get("TEST_WITH_XVFB", False)
 
-    # if not_xvfb:
-    #     arr = window.snapshot(scene, fname='green_front.png',
-    #                           offscreen=True, order_transparent=False)
-    # else:
-    #     arr = window.snapshot(scene, fname='green_front.png',
-    #                           offscreen=False, order_transparent=False)
+    if not_xvfb:
+        arr = window.snapshot(scene, fname='green_front.png',
+                              offscreen=True, order_transparent=False)
+    else:
+        arr = window.snapshot(scene, fname='green_front.png',
+                              offscreen=False, order_transparent=False)
 
-    # # therefore the green component must have a higher value (in RGB terms)
-    # npt.assert_equal(arr[150, 150][1] > arr[150, 150][0], True)
+    # therefore the green component must have a higher value (in RGB terms)
+    npt.assert_equal(arr[150, 150][1] > arr[150, 150][0], True)
 
-    # # red in front
-    # scene.elevation(-180)
-    # scene.camera().OrthogonalizeViewUp()
-    # scene.reset_clipping_range()
+    # red in front
+    scene.elevation(-180)
+    scene.camera().OrthogonalizeViewUp()
+    scene.reset_clipping_range()
 
-    # if not_xvfb:
-    #     arr = window.snapshot(scene, fname='red_front.png',
-    #                           offscreen=True, order_transparent=True)
-    # else:
-    #     arr = window.snapshot(scene, fname='red_front.png',
-    #                           offscreen=False, order_transparent=True)
+    if not_xvfb:
+        arr = window.snapshot(scene, fname='red_front.png',
+                              offscreen=True, order_transparent=True)
+    else:
+        arr = window.snapshot(scene, fname='red_front.png',
+                              offscreen=False, order_transparent=True)
 
-    # # therefore the red component must have a higher value (in RGB terms)
-    # npt.assert_equal(arr[150, 150][0] > arr[150, 150][1], True)
+    # therefore the red component must have a higher value (in RGB terms)
+    npt.assert_equal(arr[150, 150][0] > arr[150, 150][1], True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
While investigating #6, I found that `test_order_transparent` had been mostly commented out. When I un-commented it, one of the assertions failed. When the green line was in front, the test expected the pixel's green component to be larger than the red component. In reality, it was smaller by 1, despite the image looking correct. I changed the green line's color from [0, 0.5, 0] to [0, 1., 0] and now the tests pass, both in offscreen and onscreen rendering.