### PR TITLE
Change Miniconda version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     - sourceline: ppa:oibaf/graphics-drivers
     update: true
     packages:
+    - libbz2-dev
     - libglew-dev
     - freeglut3-dev
     - libxi-dev

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -13,8 +13,7 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
     sudo chown root /tmp/.X11-unix/
     wget http://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
 else
-    # wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    wget http://repo.continuum.io/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh -O miniconda.sh;
+    wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
 fi
 
 chmod +x miniconda.sh && ./miniconda.sh -b -p ${ENV_DIR}/miniconda

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -13,7 +13,8 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
     sudo chown root /tmp/.X11-unix/
     wget http://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
 else
-    wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    # wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    wget http://repo.continuum.io/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh -O miniconda.sh;
 fi
 
 chmod +x miniconda.sh && ./miniconda.sh -b -p ${ENV_DIR}/miniconda


### PR DESCRIPTION
I think the last Miniconda release have an issue with bzip2 and python27.

This a test to confirm or not my assumption.