### PR TITLE
BUG: Fix `TensorSlicerActor` actor opacity property not being enforced.

### DIFF
--- a/fury/actor.py
+++ b/fury/actor.py
@@ -922,7 +922,6 @@ def tensor_slicer(evals, evecs, affine=None, mask=None, sphere=None, scale=2.2,
                                                 sphere=sphere,
                                                 scale=scale,
                                                 norm=norm,
-                                                opacity=opacity,
                                                 scalar_colors=scalar_colors)
             self.SetMapper(self.mapper)
 
@@ -941,12 +940,13 @@ def tensor_slicer(evals, evecs, affine=None, mask=None, sphere=None, scale=2.2,
     tensor_actor.display_extent(0, szx - 1, 0, szy - 1,
                                 int(np.floor(szz/2)), int(np.floor(szz/2)))
 
+    tensor_actor.GetProperty().SetOpacity(opacity)
+
     return tensor_actor
 
 
 def _tensor_slicer_mapper(evals, evecs, affine=None, mask=None, sphere=None,
-                          scale=2.2, norm=True, opacity=1.,
-                          scalar_colors=None):
+                          scale=2.2, norm=True, scalar_colors=None):
     """Helper function for slicing tensor fields
 
     Parameters
@@ -965,8 +965,6 @@ def _tensor_slicer_mapper(evals, evecs, affine=None, mask=None, sphere=None,
         Distance between spheres.
     norm : bool
         Normalize `sphere_values`.
-    opacity : float
-        Takes values from 0 (fully transparent) to 1 (opaque)
     scalar_colors : (3,) or (X, 3) or (X, Y, 3) or (X, Y, Z, 3) ndarray
         RGB colors used to show the tensors
         Default None, color the ellipsoids using ``color_fa``

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -585,13 +585,16 @@ def test_tensor_slicer(interactive=False):
     scene = window.Scene()
 
     tensor_actor = actor.tensor_slicer(mevals, mevecs, affine=affine,
-                                       sphere=sphere,  scale=.3)
+                                       sphere=sphere,  scale=.3, opacity=0.4)
     I, J, K = mevals.shape[:3]
     scene.add(tensor_actor)
     scene.reset_camera()
     scene.reset_clipping_range()
 
     tensor_actor.display_extent(0, 1, 0, J, 0, K)
+    if interactive:
+        window.show(scene, reset_camera=False)
+
     tensor_actor.GetProperty().SetOpacity(1.0)
     if interactive:
         window.show(scene, reset_camera=False)


### PR DESCRIPTION
Fix `TensorSlicerActor` actor opacity property not being enforced.

The method `tensor_slicer` returns an instance of a `TensorSlicerActor`
actor, and receives, among others the `opacity` that needs to be applied
to the actor as a parameter. However, the parameter was being passed to
the `_tensor_slicer_mapper` method, which returns a mapper, and thus was
not effectively using the `opacity` property.

Now the `opacity` parameter is no longer passed to the
`_tensor_slicer_mapper` and it is set as a `vtk::Property` to the
`TensorSlicerActor` instance.

The corresponding actor test is modified so that the `opacity` property
is effectively exercised.