### PR TITLE
[NF] Add get_info function

### DIFF
--- a/fury/__init__.py
+++ b/fury/__init__.py
@@ -38,9 +38,9 @@ def get_info(verbose=False):
                 sys_version=sys.version,
                 sys_executable=sys.executable,
                 sys_platform=sys.platform,
-                np_version=numpy.__version__,
+                numpy_version=numpy.__version__,
                 scipy_version=scipy.__version__,
-                vtk_version=vtk.vtkVersion.GetVTKSourceVersion())
+                vtk_version=vtk.vtkVersion.GetVTKVersion())
 
     d_mpl = dict(matplotlib_version=mpl.__version__) if have_mpl else {}
     d_dipy = dict(dipy_version=dipy.__version__) if have_dipy else {}

--- a/fury/__init__.py
+++ b/fury/__init__.py
@@ -5,7 +5,53 @@ import warnings
 from fury._version import get_versions
 
 __version__ = get_versions()['version']
+__revision_id__ = get_versions()['full-revisionid']
 del get_versions
+
+
+def get_info(verbose=False):
+    """Return dict describing the context of this package.
+
+    Parameters
+    ------------
+    pkg_path : str
+       path containing __init__.py for package
+    Returns
+    ----------
+    context : dict
+       with named parameters of interest
+
+    """
+    from fury.optpkg import optional_package
+    from os.path import dirname
+    import sys
+    import numpy
+    import scipy
+    import vtk
+
+    mpl, have_mpl, _ = optional_package('matplotlib')
+    dipy, have_dipy, _ = optional_package('dipy')
+
+    info = dict(fury_version=__version__,
+                pkg_path=dirname(__file__),
+                commit_hash=__revision_id__,
+                sys_version=sys.version,
+                sys_executable=sys.executable,
+                sys_platform=sys.platform,
+                np_version=numpy.__version__,
+                scipy_version=scipy.__version__,
+                vtk_version=vtk.vtkVersion.GetVTKSourceVersion())
+
+    d_mpl = dict(matplotlib_version=mpl.__version__) if have_mpl else {}
+    d_dipy = dict(dipy_version=dipy.__version__) if have_dipy else {}
+
+    info.update(d_mpl)
+    info.update(d_dipy)
+
+    if verbose:
+        print('\n'.join(['{0}: {1}'.format(k, v) for k, v in info.items()]))
+
+    return info
 
 # Ignore this specific warning below from vtk < 8.2.
 # FutureWarning: Conversion of the second argument of issubdtype from

--- a/fury/__init__.py
+++ b/fury/__init__.py
@@ -53,6 +53,7 @@ def get_info(verbose=False):
 
     return info
 
+
 # Ignore this specific warning below from vtk < 8.2.
 # FutureWarning: Conversion of the second argument of issubdtype from
 # `complex` to `np.complexfloating` is deprecated. In future, it will be

--- a/fury/tests/test_optpkg.py
+++ b/fury/tests/test_optpkg.py
@@ -9,7 +9,7 @@ from types import ModuleType
 
 def test_get_info():
     expected_keys = ['fury_version', 'pkg_path', 'commit_hash', 'sys_version',
-                     'sys_executable', 'sys_platform', 'np_version',
+                     'sys_executable', 'sys_platform', 'numpy_version',
                      'scipy_version', 'vtk_version']
     info = get_info()
     current_keys = info.keys()

--- a/fury/tests/test_optpkg.py
+++ b/fury/tests/test_optpkg.py
@@ -1,9 +1,21 @@
 """Function for testing optpkg module."""
 
 import numpy.testing as npt
+from fury import get_info
 from fury.testing import assert_true, assert_false
 from fury.optpkg import is_tripwire, TripWire, TripWireError, optional_package
 from types import ModuleType
+
+
+def test_get_info():
+    expected_keys = ['fury_version', 'pkg_path', 'commit_hash', 'sys_version',
+                     'sys_executable', 'sys_platform', 'np_version',
+                     'scipy_version', 'vtk_version']
+    info = get_info()
+    current_keys = info.keys()
+    for ek in expected_keys:
+        assert_true(ek in current_keys)
+        assert_true(info[ek] not in [None, ''])
 
 
 def test_is_tripwire():


### PR DESCRIPTION
This PR is adding an utility function. The result of `get_info` is:

```
In [1]: from fury import get_info

In [2]: get_info()
Out[2]: 
{'fury_version': '0.1.4.post133+gc1d89c5',
 'pkg_path': 'C:\\Users\\skoudoro\\Devel\\fury\\fury',
 'commit_hash': 'c1d89c58bafd5b60bea0ba545ece0d89d0d93bb0',
 'sys_version': '3.6.6 | packaged by conda-forge | (default, Jul 26 2018, 11:48:23) [MSC v.1900 64 bit (AMD64)]',
 'sys_executable': 'C:\\Users\\skoudoro\\AppData\\Local\\Continuum\\Anaconda3\\envs\\fury-dev-3\\python.exe',
 'sys_platform': 'win32',
 'np_version': '1.15.4',
 'scipy_version': '1.1.0',
 'vtk_version': 'vtk version 8.1.1',
 'matplotlib_version': '3.0.2',
 'dipy_version': '0.16.0dev'}

In [3]: 
```