### PR TITLE
Directional color odfs

### DIFF
--- a/fury/actor.py
+++ b/fury/actor.py
@@ -915,7 +915,7 @@ def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
 
     if global_cm:
         if colormap is None:
-            raise IOError("if global_cm=True, colormap must be defined"
+            raise IOError("if global_cm=True, colormap must be defined")
         else:
             cols = create_colormap(all_ms.ravel(), colormap)
     else:

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -914,7 +914,7 @@ def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
     cells.SetCells(ncells, all_faces_vtk)
 
     if global_cm:
-        if colormap == None:
+        if colormap is None:
             raise IOError("if global_cm=True, colormap must be defined"
         else:
             cols = create_colormap(all_ms.ravel(), colormap)

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -847,8 +847,9 @@ def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
     radial_scale : bool
         Scale sphere points according to odf values.
     colormap : None or str
-        If None then white color is used. Otherwise the name of colormap is
-        given. Matplotlib colormaps are supported (e.g., 'inferno').
+        If None then sphere vertices are used to compute orientation-based
+        color. Otherwise the name of colormap is given. Matplotlib colormaps
+        are supported (e.g., 'inferno').
     global_cm : bool
         If True the colormap will be applied in all ODFs. If False
         it will be applied individually at each voxel (default False).

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -912,33 +912,36 @@ def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
     cells = vtk.vtkCellArray()
     cells.SetCells(ncells, all_faces_vtk)
 
-    if colormap is not None:
-        if global_cm:
-            cols = create_colormap(all_ms.ravel(), colormap)
-        else:
-            cols = np.zeros((ijk.shape[0],) + sphere.vertices.shape,
-                            dtype='f4')
-            for k in range(ijk.shape[0]):
-                tmp = create_colormap(all_ms[k].ravel(), colormap)
-                cols[k] = tmp.copy()
+    #if colormap is not None:
+    if global_cm:
+        cols = create_colormap(all_ms.ravel(), colormap)
+    elif colormap is not None:
+        cols = np.zeros((ijk.shape[0],) + sphere.vertices.shape,
+                        dtype='f4')
+        for k in range(ijk.shape[0]):
+            tmp = create_colormap(all_ms[k].ravel(), colormap)
+            cols[k] = tmp.copy()
 
-            cols = np.ascontiguousarray(
-                np.reshape(cols, (cols.shape[0] * cols.shape[1],
-                           cols.shape[2])), dtype='f4')
+        cols = np.ascontiguousarray(
+            np.reshape(cols, (cols.shape[0] * cols.shape[1],
+                       cols.shape[2])), dtype='f4')
+    else:
+        cols = np.absolute(sphere.vertices)
 
-        vtk_colors = numpy_support.numpy_to_vtk(
-            np.asarray(255 * cols),
-            deep=True,
-            array_type=vtk.VTK_UNSIGNED_CHAR)
+    vtk_colors = numpy_support.numpy_to_vtk(
+        np.asarray(255 * cols),
+        deep=True,
+        array_type=vtk.VTK_UNSIGNED_CHAR)
 
-        vtk_colors.SetName("Colors")
+    vtk_colors.SetName("Colors")
+
 
     polydata = vtk.vtkPolyData()
     polydata.SetPoints(points)
     polydata.SetPolys(cells)
 
-    if colormap is not None:
-        polydata.GetPointData().SetScalars(vtk_colors)
+    #if colormap is not None:
+    polydata.GetPointData().SetScalars(vtk_colors)
 
     mapper = vtk.vtkPolyDataMapper()
     mapper.SetInputData(polydata)

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -914,6 +914,8 @@ def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
     cells.SetCells(ncells, all_faces_vtk)
 
     if global_cm:
+        if colormap == None:
+            raise IOError("if global_cm=True, colormap must be defined"
         cols = create_colormap(all_ms.ravel(), colormap)
     else:
         cols = np.zeros((ijk.shape[0],) + sphere.vertices.shape,

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -916,7 +916,8 @@ def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
     if global_cm:
         if colormap == None:
             raise IOError("if global_cm=True, colormap must be defined"
-        cols = create_colormap(all_ms.ravel(), colormap)
+        else:
+            cols = create_colormap(all_ms.ravel(), colormap)
     else:
         cols = np.zeros((ijk.shape[0],) + sphere.vertices.shape,
                         dtype='f4')

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -925,7 +925,6 @@ def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
                 tmp = orient2rgb(sphere.vertices)
             cols[k] = tmp.copy()
 
-
         cols = np.ascontiguousarray(
             np.reshape(cols, (cols.shape[0] * cols.shape[1],
                        cols.shape[2])), dtype='f4')
@@ -936,7 +935,6 @@ def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
         array_type=vtk.VTK_UNSIGNED_CHAR)
 
     vtk_colors.SetName("Colors")
-
 
     polydata = vtk.vtkPolyData()
     polydata.SetPoints(points)

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -916,18 +916,19 @@ def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
     if global_cm:
         cols = create_colormap(all_ms.ravel(), colormap)
     else:
-        if colormap is not None:
-            cols = np.zeros((ijk.shape[0],) + sphere.vertices.shape,
-                            dtype='f4')
-            for k in range(ijk.shape[0]):
+        cols = np.zeros((ijk.shape[0],) + sphere.vertices.shape,
+                        dtype='f4')
+        for k in range(ijk.shape[0]):
+            if colormap is not None:
                 tmp = create_colormap(all_ms[k].ravel(), colormap)
-                cols[k] = tmp.copy()
-        else:
-            cols = np.absolute(sphere.vertices)
+            else:
+                tmp = np.absolute(sphere.vertices)
+            cols[k] = tmp.copy()
+
 
         cols = np.ascontiguousarray(
             np.reshape(cols, (cols.shape[0] * cols.shape[1],
-                       cols.shape[2])), dtype='f4')        
+                       cols.shape[2])), dtype='f4')
 
     vtk_colors = numpy_support.numpy_to_vtk(
         np.asarray(255 * cols),

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -6,7 +6,7 @@ from vtk.util import numpy_support
 
 import fury.shaders
 from fury import layout
-from fury.colormap import colormap_lookup_table, create_colormap
+from fury.colormap import colormap_lookup_table, create_colormap, orient2rgb
 from fury.utils import (lines_to_vtk_polydata, set_input, apply_affine,
                         numpy_to_vtk_points, numpy_to_vtk_colors,
                         set_polydata_vertices, set_polydata_triangles)
@@ -922,7 +922,7 @@ def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
             if colormap is not None:
                 tmp = create_colormap(all_ms[k].ravel(), colormap)
             else:
-                tmp = np.absolute(sphere.vertices)
+                tmp = orient2rgb(sphere.vertices)
             cols[k] = tmp.copy()
 
 

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -912,7 +912,6 @@ def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
     cells = vtk.vtkCellArray()
     cells.SetCells(ncells, all_faces_vtk)
 
-    #if colormap is not None:
     if global_cm:
         cols = create_colormap(all_ms.ravel(), colormap)
     else:
@@ -942,7 +941,6 @@ def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
     polydata.SetPoints(points)
     polydata.SetPolys(cells)
 
-    #if colormap is not None:
     polydata.GetPointData().SetScalars(vtk_colors)
 
     mapper = vtk.vtkPolyDataMapper()

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -915,18 +915,19 @@ def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
     #if colormap is not None:
     if global_cm:
         cols = create_colormap(all_ms.ravel(), colormap)
-    elif colormap is not None:
-        cols = np.zeros((ijk.shape[0],) + sphere.vertices.shape,
-                        dtype='f4')
-        for k in range(ijk.shape[0]):
-            tmp = create_colormap(all_ms[k].ravel(), colormap)
-            cols[k] = tmp.copy()
+    else:
+        if colormap is not None:
+            cols = np.zeros((ijk.shape[0],) + sphere.vertices.shape,
+                            dtype='f4')
+            for k in range(ijk.shape[0]):
+                tmp = create_colormap(all_ms[k].ravel(), colormap)
+                cols[k] = tmp.copy()
+        else:
+            cols = np.absolute(sphere.vertices)
 
         cols = np.ascontiguousarray(
             np.reshape(cols, (cols.shape[0] * cols.shape[1],
-                       cols.shape[2])), dtype='f4')
-    else:
-        cols = np.absolute(sphere.vertices)
+                       cols.shape[2])), dtype='f4')        
 
     vtk_colors = numpy_support.numpy_to_vtk(
         np.asarray(255 * cols),

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -539,6 +539,18 @@ def test_odf_slicer(interactive=False):
     if interactive:
         window.show(scene)
 
+    # colormap=None and global_cm=False results in directionally encoded colors
+    scene.clear()
+    scene.add(odf_actor)
+    scene.add(fa_actor)
+    odfs[:, :, :] = 1
+    mask = np.ones(odfs.shape[:3])
+    odf_actor = actor.odf_slicer(odfs, None, mask=mask,
+                                 sphere=sphere, scale=.25,
+                                 colormap=None,
+                                 norm=False, global_cm=False)
+
+
     report = window.analyze_scene(scene)
     npt.assert_equal(report.actors, 1)
     npt.assert_equal(report.actors_classnames[0], 'vtkLODActor')


### PR DESCRIPTION
This adds an option to color each point on each ODF by the direction on the sphere, so similarly oriented peaks have the same color. This is a common, and in my opinion extremely helpful, way to visualize multiple ODFs. 

Similar to how the same functionality is implemented in `peak_slicer`, this option is implemented by setting `colormap=None`. Currently, this throws an error if `colormap=None` and `global_cm=True`, but these are already sort of conflicting commands. 

Here are comparative visualizations, using the CSD example in the DIPY gallery: (http://nipy.org/dipy/examples_built/reconst_csd.html#example-reconst-csd)

`colormap='Plasma'`
![csd_odfs](https://user-images.githubusercontent.com/29939343/54385565-4c7ab300-466d-11e9-81b6-90b92a1bc934.png)

`colormap='None'`
![csd_dec_odfs](https://user-images.githubusercontent.com/29939343/54385571-4f75a380-466d-11e9-8c95-d0632745aad6.png)