### PR TITLE
Allow Str for Grid Caption

### DIFF
--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1786,7 +1786,7 @@ def grid(actors, captions=None, caption_offset=(0, -100, 0), cell_padding=0,
     ----------
     actors : list of `vtkProp3D` objects
         Actors to be layout in a grid manner.
-    captions : list of `vtkProp3D` objects
+    captions : list of `vtkProp3D` objects or list of str
         Objects serving as captions (can be any `vtkProp3D` object, not
         necessarily text). There should be one caption per actor. By
         default, there are no captions.
@@ -1829,7 +1829,10 @@ def grid(actors, captions=None, caption_offset=(0, -100, 0), cell_padding=0,
 
             # Offset accordingly the caption w.r.t.
             # the center of the associated actor.
-            caption = shallow_copy(caption)
+            if isinstance(caption, str):
+                caption = text_3d(caption, justification='center')
+            else:
+                caption = shallow_copy(caption)
             caption.SetPosition(actor_center + caption_offset)
 
             actor_with_caption = Container()

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -867,15 +867,15 @@ def test_grid(_interactive=False):
     texts.append(text_actor3)
 
     actors.append(shallow_copy(contour_actor1))
-    text_actor1 = actor.text_3d('cube 4', justification='center')
+    text_actor1 = 'cube 4'
     texts.append(text_actor1)
 
     actors.append(shallow_copy(contour_actor2))
-    text_actor2 = actor.text_3d('cube 5', justification='center')
+    text_actor2 = 'cube 5'
     texts.append(text_actor2)
 
     actors.append(shallow_copy(contour_actor3))
-    text_actor3 = actor.text_3d('cube 6', justification='center')
+    text_actor3 = 'cube 6'
     texts.append(text_actor3)
 
     # show the grid without the captions


### PR DESCRIPTION
This is a simple PR to allow a list of str as a grid captions for `actor.grid` and `ui.GridUI`.
Both can be mixed. It is convenient.

