### PR TITLE
Add cones as glyphs

### DIFF
--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1451,6 +1451,99 @@ def sphere(centers, colors, radii=1., theta=16, phi=16,
     return actor
 
 
+def cone(centers, directions, colors, heights=1., resolutions=10,
+         vertices=None, faces=None):
+    """Visualize one or many cones with different colors and radii
+
+    Parameters
+    ----------
+    centers : ndarray, shape (N, 3)
+    colors : ndarray (N,3) or (N, 4) or tuple (3,) or tuple (4,)
+        RGB or RGBA (for opacity) R, G, B and A should be at the range [0, 1]
+    radii : float or ndarray, shape (N,)
+    theta : int
+    phi : int
+    vertices : ndarray, shape (N, 3)
+    faces : ndarray, shape (M, 3)
+        If faces is None then a sphere is created based on theta and phi angles
+        If not then a sphere is created with the provided vertices and faces.
+
+    Returns
+    -------
+    vtkActor
+
+    Examples
+    --------
+    >>> from fury import window, actor
+    >>> scene = window.Scene()
+    >>> centers = np.random.rand(5, 3)
+    >>> directions = np.random.rand(5, 3)
+    >>> heights = np.random.rand(5)
+    >>> cone_actor = actor.cone(centers, directions, window.colors.coral, heights)
+    >>> scene.add(cone_actor)
+    >>> # window.show(scene)
+
+    """
+
+    if np.array(colors).ndim == 1:
+        colors = np.tile(colors, (len(centers), 1))
+
+    pts = numpy_to_vtk_points(np.ascontiguousarray(centers))
+    cols = numpy_to_vtk_colors(255 * np.ascontiguousarray(colors))
+    cols.SetName('colors')
+    if isinstance(heights, np.ndarray):
+        heights_fa = numpy_support.numpy_to_vtk(np.asarray(heights),
+                                                deep=True,
+                                                array_type=vtk.VTK_DOUBLE)
+        heights_fa.SetName('heights')
+    directions_fa = numpy_support.numpy_to_vtk(np.asarray(directions),
+                                               deep=True,
+                                               array_type=vtk.VTK_DOUBLE)
+    directions_fa.SetName('directions')
+
+    polydata_centers = vtk.vtkPolyData()
+    polydata_cone = vtk.vtkPolyData()
+
+    if faces is None:
+        src = vtk.vtkConeSource()
+        src.SetResolution(resolutions)
+        if isinstance(heights, int):
+            src.SetHeight(heights)
+    else:
+        set_polydata_vertices(polydata_cone, vertices)
+        set_polydata_triangles(polydata_cone, faces)
+
+    polydata_centers.SetPoints(pts)
+    polydata_centers.GetPointData().AddArray(cols)
+    polydata_centers.GetPointData().AddArray(directions_fa)
+    polydata_centers.GetPointData().SetActiveVectors('directions')
+    if isinstance(heights, np.ndarray):
+        polydata_centers.GetPointData().AddArray(heights_fa)
+        polydata_centers.GetPointData().SetActiveScalars('heights')
+
+    glyph = vtk.vtkGlyph3D()
+    if faces is None:
+        glyph.SetSourceConnection(src.GetOutputPort())
+    else:
+        glyph.SetSourceData(polydata_cone)
+
+    glyph.SetInputData(polydata_centers)
+    glyph.SetOrient(True)
+    glyph.SetScaleModeToScaleByScalar()
+    glyph.SetVectorModeToUseVector()
+    glyph.Update()
+
+    mapper = vtk.vtkPolyDataMapper()
+    mapper.SetInputData(glyph.GetOutput())
+    mapper.SetScalarModeToUsePointFieldData()
+    mapper.SelectColorArray('colors')
+
+    actor = vtk.vtkActor()
+    actor.SetMapper(mapper)
+
+    return actor
+
+
 def label(text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.2),
           color=(1, 1, 1)):
     """Create a label actor.

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1479,7 +1479,7 @@ def cone(centers, directions, colors, heights=1., resolutions=10,
     >>> centers = np.random.rand(5, 3)
     >>> directions = np.random.rand(5, 3)
     >>> heights = np.random.rand(5)
-    >>> cone_actor = actor.cone(centers, directions, window.colors.coral, heights)
+    >>> cone_actor = actor.cone(centers, directions, (1, 1, 1), heights)
     >>> scene.add(cone_actor)
     >>> # window.show(scene)
 

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1395,7 +1395,6 @@ def sphere(centers, colors, radii=1., theta=16, phi=16,
     >>> # window.show(scene)
 
     """
-
     if np.array(colors).ndim == 1:
         colors = np.tile(colors, (len(centers), 1))
 
@@ -1451,22 +1450,26 @@ def sphere(centers, colors, radii=1., theta=16, phi=16,
     return actor
 
 
-def cone(centers, directions, colors, heights=1., resolutions=10,
+def cone(centers, directions, colors, heights=1., resolution=10,
          vertices=None, faces=None):
     """Visualize one or many cones with different colors and radii
 
     Parameters
     ----------
     centers : ndarray, shape (N, 3)
+    directions : ndarray, shape (N, 3)
+        The orientation vector of the cone.
     colors : ndarray (N,3) or (N, 4) or tuple (3,) or tuple (4,)
         RGB or RGBA (for opacity) R, G, B and A should be at the range [0, 1]
-    radii : float or ndarray, shape (N,)
-    theta : int
-    phi : int
+    heights : ndarray, shape (N)
+        The height of the cone.
+    resolution : int
+        The resolution of the cone.
     vertices : ndarray, shape (N, 3)
     faces : ndarray, shape (M, 3)
-        If faces is None then a sphere is created based on theta and phi angles
-        If not then a sphere is created with the provided vertices and faces.
+        If faces is None then a cone is created based on directions, heights
+        and resolution. If not then a cone is created with the provided
+        vertices and faces.
 
     Returns
     -------
@@ -1484,7 +1487,6 @@ def cone(centers, directions, colors, heights=1., resolutions=10,
     >>> # window.show(scene)
 
     """
-
     if np.array(colors).ndim == 1:
         colors = np.tile(colors, (len(centers), 1))
 
@@ -1506,7 +1508,7 @@ def cone(centers, directions, colors, heights=1., resolutions=10,
 
     if faces is None:
         src = vtk.vtkConeSource()
-        src.SetResolution(resolutions)
+        src.SetResolution(resolution)
         if isinstance(heights, int):
             src.SetHeight(heights)
     else:

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -546,7 +546,6 @@ def test_odf_slicer(interactive=False):
                                  colormap=None,
                                  norm=False, global_cm=False)
 
-
     report = window.analyze_scene(scene)
     npt.assert_equal(report.actors, 1)
     npt.assert_equal(report.actors_classnames[0], 'vtkLODActor')
@@ -827,18 +826,50 @@ def test_cones(interactive=False):
     xyzr = np.array([[0, 0, 0, 10], [100, 0, 0, 25], [200, 0, 0, 50]])
     dirs = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 1]])
     colors = np.array([[1, 0, 0, 0.3], [0, 1, 0, 0.4], [0, 0, 1., 0.99]])
+    heights = np.array([5, 7, 10])
 
     scene = window.Scene()
     cone_actor = actor.cone(centers=xyzr[:, :3], directions=dirs,
-                            heights=10, colors=colors[:])
+                            heights=heights, colors=colors[:])
     scene.add(cone_actor)
 
     if interactive:
         window.show(scene, order_transparent=True)
-
     arr = window.snapshot(scene)
     report = window.analyze_snapshot(arr,
                                      colors=colors)
+    npt.assert_equal(report.objects, 3)
+
+    colors = np.array([1.0, 1.0, 1.0, 1.0])
+    heights = 10
+    resolution = 8
+
+    scene.clear()
+    cone_actor = actor.cone(centers=xyzr[:, :3], directions=dirs,
+                            heights=10, colors=colors[:],
+                            resolution=resolution)
+    scene.add(cone_actor)
+
+    if interactive:
+        window.show(scene, order_transparent=True)
+    arr = window.snapshot(scene)
+    report = window.analyze_snapshot(arr,
+                                     colors=[colors])
+    npt.assert_equal(report.objects, 3)
+
+    scene.clear()
+    vertices = np.array([[0, 0, 0], [0, 10, 0], [10, 0, 0], [0, 0, 10]])
+    faces = np.array([[0, 1, 3], [0, 1, 2]])
+    cone_actor = actor.cone(centers=xyzr[:, :3], directions=dirs,
+                            colors=colors[:], vertices=vertices,
+                            faces=faces)
+    scene.add(cone_actor)
+
+    if interactive:
+        window.show(scene, order_transparent=True)
+    arr = window.snapshot(scene)
+    report = window.analyze_snapshot(arr,
+                                     colors=[colors])
     npt.assert_equal(report.objects, 3)
 
 

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -822,6 +822,27 @@ def test_spheres(interactive=False):
 
 
 @xvfb_it
+def test_cones(interactive=False):
+
+    xyzr = np.array([[0, 0, 0, 10], [100, 0, 0, 25], [200, 0, 0, 50]])
+    dirs = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 1]])
+    colors = np.array([[1, 0, 0, 0.3], [0, 1, 0, 0.4], [0, 0, 1., 0.99]])
+
+    scene = window.Scene()
+    cone_actor = actor.cone(centers=xyzr[:, :3], directions=dirs,
+                            heights=10, colors=colors[:])
+    scene.add(cone_actor)
+
+    if interactive:
+        window.show(scene, order_transparent=True)
+
+    arr = window.snapshot(scene)
+    report = window.analyze_snapshot(arr,
+                                     colors=colors)
+    npt.assert_equal(report.objects, 3)
+
+
+@xvfb_it
 def test_grid(_interactive=False):
 
     vol1 = np.zeros((100, 100, 100))


### PR DESCRIPTION
As suggested by @agramfort this PR adds a function `cone()` that creates cone glyphs given `centers`, `resolutions` or `heights` with some basic testing in `fury/tests/test_actors.py::test_cones`.

![image](https://user-images.githubusercontent.com/18143289/59521976-ddac3080-8ecd-11e9-99f8-3c476d529bb6.png)