### PR TITLE
Fixes a typo in the viz_ui tutorial.

### DIFF
--- a/docs/tutorials/viz_ui.py
+++ b/docs/tutorials/viz_ui.py
@@ -98,7 +98,7 @@ def change_text_callback(i_ren, _obj, _button):
 
 
 def change_icon_callback(i_ren, _obj, _button):
-    button.next_icon()
+    _button.next_icon()
     i_ren.force_render()
 
 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -2,3 +2,4 @@
 numpy>=1.7.1
 vtk>=8.1.0
 scipy>=0.9
+six


### PR DESCRIPTION
Also, adds six as a requirement.

See: https://github.com/fury-gl/fury/blob/master/fury/ui.py#L8