### PR TITLE
[Fix] layout with small cells

### DIFF
--- a/fury/tests/test_utils.py
+++ b/fury/tests/test_utils.py
@@ -48,6 +48,8 @@ def test_polydata_lines():
     res_colors = np.unique(res_colors, axis=0) / 255
     npt.assert_array_equal(colors, np.flipud(res_colors))
 
+    npt.assert_equal(utils.get_polydata_colors(vtk.vtkPolyData()), None)
+
 
 @xvfb_it
 def test_polydata_polygon(interactive=False):

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -640,14 +640,12 @@ def get_grid_cells_position(shapes, aspect_ratio=16/9., dim=None):
         # Compute the number of rows and columns.
         n_cols = np.ceil(np.sqrt(count*aspect_ratio / cell_aspect_ratio))
         n_rows = np.ceil(count / n_cols)
-        if n_cols * n_rows <= count:
-            raise ValueError("Too small")
     else:
         n_rows, n_cols = dim
 
-        if n_cols * n_rows < count:
-            msg = "Size is too small, it cannot contain at least {} elements."
-            raise ValueError(msg.format(count))
+    if n_cols * n_rows < count:
+        msg = "Size is too small, it cannot contain at least {} elements."
+        raise ValueError(msg.format(count))
 
     # Use indexing="xy" so the cells are in row-major (C-order). Also,
     # the Y coordinates are negative so the cells are order from top to bottom.

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -351,8 +351,9 @@ def set_polydata_triangles(polydata, triangles):
     """
     isize = vtk.vtkIdTypeArray().GetDataTypeSize()
     req_dtype = np.int32 if isize == 4 else np.int64
-    vtk_triangles = np.hstack(np.c_[np.ones(len(triangles), dtype=req_dtype) * 3,
-                                    triangles.astype(req_dtype)])
+    vtk_triangles = np.hstack(
+        np.c_[np.ones(len(triangles), dtype=req_dtype) * 3,
+              triangles.astype(req_dtype)])
     vtk_triangles = numpy_support.numpy_to_vtkIdTypeArray(vtk_triangles,
                                                           deep=True)
     vtk_cells = vtk.vtkCellArray()


### PR DESCRIPTION
This should fix a small issue with the code below:
```
from fury import actor, window, layout
c = actor.Container(layout=layout.GridLayout())
c.add(actor.axes(), actor.axes())
s=window.Scene()
s.add(c)
window.show(s)
```

I use the opportunity to fix some pep8 and add a test