### PR TITLE
 fix snapshot when size is not square

### DIFF
--- a/fury/window.py
+++ b/fury/window.py
@@ -932,7 +932,7 @@ def snapshot(scene, fname=None, size=(300, 300), offscreen=True,
     h, w, _ = vtk_image.GetDimensions()
     vtk_array = vtk_image.GetPointData().GetScalars()
     components = vtk_array.GetNumberOfComponents()
-    arr = numpy_support.vtk_to_numpy(vtk_array).reshape(h, w, components)
+    arr = numpy_support.vtk_to_numpy(vtk_array).reshape(w, h, components)
 
     if fname is None:
         return arr


### PR DESCRIPTION
When the image / screen view was not square, the reshape was not right,
x and y axis needed to be swap :

before
![test](https://user-images.githubusercontent.com/5375393/63808353-be7a4800-c8ed-11e9-83b4-eb6c4ae6c470.gif)

after
![test2](https://user-images.githubusercontent.com/5375393/63808358-c33efc00-c8ed-11e9-9027-d27998095110.gif)
