### PR TITLE
Remove nose dependency

### DIFF
--- a/docs/examples/viz_advanced.py
+++ b/docs/examples/viz_advanced.py
@@ -243,7 +243,6 @@ show_m.scene.add(panel)
 # the panel using its ``re_align`` method every time the window size changes.
 
 
-global size
 size = scene.GetSize()
 
 

--- a/docs/examples/viz_roi_contour.py
+++ b/docs/examples/viz_roi_contour.py
@@ -14,7 +14,8 @@ from dipy.reconst.shm import CsaOdfModel
 from dipy.data import default_sphere
 from dipy.direction import peaks_from_model
 try:
-    from dipy.tracking.local import ThresholdTissueClassifier as ThresholdStoppingCriterion
+    from dipy.tracking.local import ThresholdTissueClassifier as \
+        ThresholdStoppingCriterion
     from dipy.tracking.local import LocalTracking
 except ImportError:
     from dipy.tracking.stopping_criterion import ThresholdStoppingCriterion

--- a/docs/source/ext/apigen.py
+++ b/docs/source/ext/apigen.py
@@ -87,6 +87,7 @@ class ApiDocWriter(object):
 
         self.root_path = ''
         self.written_modules = None
+        self._package_name = None
         self.package_name = package_name
         self.rst_extension = rst_extension
         self.package_skip_patterns = package_skip_patterns

--- a/docs/source/ext/build_modref_templates.py
+++ b/docs/source/ext/build_modref_templates.py
@@ -25,7 +25,7 @@ def generate_api_reference_rst(app=None, package='fury', outdir='reference',
                                defines=True):
     try:
         __import__(package)
-    except ImportError as e:
+    except ImportError:
         abort("Can not import " + package)
 
     module = sys.modules[package]

--- a/fury/data/fetcher.py
+++ b/fury/data/fetcher.py
@@ -40,7 +40,7 @@ def update_progressbar(progress, total_length):
     try:
         columns = os.popen('tput cols', 'r').read()
         bar_length = int(columns) - 46
-        if(not (bar_length > 1)):
+        if not (bar_length > 1):
             bar_length = 20
     except Exception:
         # Default value if determination of console size fails
@@ -66,14 +66,14 @@ def copyfileobj_withprogress(fsrc, fdst, total_length, length=16 * 1024):
 
 
 def _already_there_msg(folder):
-    """Print a message indicating that a certain data-set is already in place."""
+    """Print a message indicating that dataset is already in place."""
     msg = 'Dataset is already in place. If you want to fetch it again '
     msg += 'please first remove the folder %s ' % folder
     print(msg)
 
 
 def _get_file_md5(filename):
-    """Compute the md5 checksum of a file"""
+    """Compute the md5 checksum of a file."""
     md5_data = md5()
     with open(filename, 'rb') as f:
         for chunk in iter(lambda: f.read(128 * md5_data.block_size), b''):
@@ -115,7 +115,7 @@ def _get_file_data(fname, url):
             response_size = None
 
         with open(fname, 'wb') as data:
-            if(response_size is None):
+            if response_size is None:
                 copyfileobj(opener, data)
             else:
                 copyfileobj_withprogress(opener, data, response_size)

--- a/fury/io.py
+++ b/fury/io.py
@@ -1,5 +1,4 @@
 import os
-import numpy as np
 import vtk
 from vtk.util import numpy_support
 from fury.utils import set_input

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -8,6 +8,7 @@ from fury.utils import shallow_copy
 import itertools
 
 import numpy.testing as npt
+import pytest
 from fury.tmpdirs import InTemporaryDirectory
 from tempfile import mkstemp
 
@@ -346,8 +347,7 @@ def test_streamtube_and_line_actors():
 
     npt.assert_equal(c3.GetProperty().GetRenderLinesAsTubes(), True)
 
-
-@npt.dec.skipif(not have_dipy)
+@pytest.mark.skipif(not have_dipy, reason="Requires DIPY")
 def test_bundle_maps():
     scene = window.Scene()
     bundle = fornix_streamlines()
@@ -420,7 +420,7 @@ def test_bundle_maps():
     actor.line(bundle, colors=colors)
 
 
-@npt.dec.skipif(not have_dipy)
+@pytest.mark.skipif(not have_dipy, reason="Requires DIPY")
 def test_odf_slicer(interactive=False):
 
     sphere = get_sphere('symmetric362')
@@ -610,7 +610,7 @@ def test_peak_slicer(interactive=False):
     npt.assert_equal(report.actors_classnames, ex)
 
 
-@npt.dec.skipif(not have_dipy)
+@pytest.mark.skipif(not have_dipy, reason="Requires DIPY")
 def test_tensor_slicer(interactive=False):
 
     evals = np.array([1.4, .35, .35]) * 10 ** (-3)

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -661,7 +661,7 @@ def test_tensor_slicer(interactive=False):
     # Test empty mask
     empty_actor = actor.tensor_slicer(mevals, mevecs, affine=affine,
                                       mask=np.zeros(mevals.shape[:3]),
-                                      sphere=sphere,  scale=.3)
+                                      sphere=sphere, scale=.3)
     npt.assert_equal(empty_actor.GetMapper(), None)
 
     # Test mask

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -347,6 +347,7 @@ def test_streamtube_and_line_actors():
 
     npt.assert_equal(c3.GetProperty().GetRenderLinesAsTubes(), True)
 
+
 @pytest.mark.skipif(not have_dipy, reason="Requires DIPY")
 def test_bundle_maps():
     scene = window.Scene()

--- a/fury/tests/test_interactor.py
+++ b/fury/tests/test_interactor.py
@@ -9,12 +9,15 @@ from fury import actor, window, interactor
 from fury import utils as vtk_utils
 from fury.data import DATA_DIR
 import numpy.testing as npt
+import pytest
 
 skip_osx = platform.system().lower() == "darwin"
 skip_win = platform.system().lower() == "windows"
 
 
-@npt.dec.skipif(skip_osx or skip_win)
+@pytest.mark.skipif(skip_osx or skip_win, reason="This test does not work on"
+                                                 " Windows and OSX. Need to "
+                                                 " be introspected")
 def test_custom_interactor_style_events(recording=False):
     print("Using VTK {}".format(vtk.vtkVersion.GetVTKVersion()))
     filename = "test_custom_interactor_style_events.log.gz"

--- a/fury/tests/test_ui.py
+++ b/fury/tests/test_ui.py
@@ -6,6 +6,7 @@ import vtk
 
 from os.path import join as pjoin
 import numpy.testing as npt
+import pytest
 
 from fury.data import read_viz_icons, fetch_viz_icons
 from fury import window, actor, ui
@@ -760,7 +761,7 @@ def test_ui_image_container_2d(interactive=False):
         show_manager.start()
 
 
-@npt.dec.skipif(not have_dipy)
+@pytest.mark.skipif(not have_dipy, reason="Requires DIPY")
 def test_timer():
     """Testing add a timer and exit window and app from inside timer."""
     xyzr = np.array([[0, 0, 0, 10], [100, 0, 0, 50], [300, 0, 0, 100]])

--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -4,6 +4,7 @@ import warnings
 import numpy as np
 from fury import actor, window, io
 import numpy.testing as npt
+import pytest
 from fury.testing import captured_output, assert_less_equal
 from fury.tmpdirs import InTemporaryDirectory
 
@@ -234,7 +235,9 @@ def test_parallel_projection():
     npt.assert_equal(np.sum(arr2 > 0), np.sum(arr > 0))
 
 
-@npt.dec.skipif(skip_osx or skip_win)
+@pytest.mark.skipif(skip_osx or skip_win, reason="This test does not work on"
+                                                 " Windows and OSX. Need to "
+                                                 " be introspected")
 def test_order_transparent():
 
     scene = window.Scene()
@@ -296,7 +299,9 @@ def test_stereo():
     npt.assert_array_equal(stereo[150, 150], [0, 0, 0])
 
 
-@npt.dec.skipif(skip_osx)
+@pytest.mark.skipif(skip_osx or skip_win, reason="This test does not work on"
+                                                 " Windows and OSX. Need to "
+                                                 " be introspected")
 def test_record():
     xyzr = np.array([[0, 0, 0, 10], [100, 0, 0, 25], [200, 0, 0, 50]])
     colors = np.array([[1, 0, 0, 1], [0, 1, 0, 1], [0, 0, 1., 1]])

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,8 +3,6 @@
 codecov
 coverage
 flake8
-# nosetests for numpy.testing<=1.15
-nose
 pytest
 # temporary Dependency for the tests
 dipy


### PR DESCRIPTION
This PR removes `nose` package dependency by replacing `skipif` function.

I use the opportunity to solve some pep8 issue