### PR TITLE
[Fix] doc generation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,14 @@
 .. image:: https://travis-ci.org/fury-gl/fury.svg?branch=master
         :target: https://travis-ci.org/fury-gl/fury
 
-.. image:: https://ci.appveyor.com/api/projects/status/9asvp22cf5pkl45l?svg=true
-        :target: https://ci.appveyor.com/project/skoudoro/fury-o608g
+.. image:: https://https://dev.azure.com/fury-gl/fury/_apis/build/status/fury-gl.fury?branchName=master
+        :target: https://dev.azure.com/fury-gl/fury/_build/latest?definitionId=1&branchName=master
 
 .. image:: https://img.shields.io/pypi/v/fury.svg
         :target: https://pypi.python.org/pypi/fury
+
+.. image:: https://anaconda.org/conda-forge/fury/badges/version.svg
+        :target: https://anaconda.org/conda-forge/fury
 
 .. image:: https://codecov.io/gh/fury-gl/fury/branch/master/graph/badge.svg
         :target: https://codecov.io/gh/fury-gl/fury

--- a/docs/examples/viz_advanced.py
+++ b/docs/examples/viz_advanced.py
@@ -35,7 +35,7 @@ from fury import actor, window, ui
 # a ``LineSlider2D`` widget.
 #
 # First we need to fetch and load some datasets.
-
+from dipy.tracking.streamline import Streamlines
 from dipy.data.fetcher import fetch_bundles_2_subjects, read_bundles_2_subjects
 
 fetch_bundles_2_subjects()
@@ -52,7 +52,10 @@ res = read_bundles_2_subjects('subj_1', ['t1', 'fa'],
 # We will use 3 bundles, FA and the affine transformation that brings the voxel
 # coordinates to world coordinates (RAS 1mm).
 
-streamlines = res['af.left'] + res['cst.right'] + res['cc_1']
+streamlines = Streamlines(res['af.left'])
+streamlines.extend(res['cst.right'])
+streamlines.extend(res['cc_1'])
+
 data = res['fa']
 shape = data.shape
 affine = res['affine']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,7 +61,7 @@ plot_html_show_source_link = False
 plot_html_show_formats = False
 
 # Generate the API documentation when building
-autosummary_generate = False
+autosummary_generate = []
 numpydoc_show_class_members = False
 
 # Add any paths that contain templates here, relative to this directory.
@@ -233,4 +233,6 @@ intersphinx_mapping = {
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable', None),
     'matplotlib': ('https://matplotlib.org', None),
+    'dipy': ('https://dipy.org/documentation/latest',
+             'https://dipy.org/documentation/1.0.0./objects.inv/'),
 }


### PR DESCRIPTION
Quick PR to fix doc generation and specifically: 

this error via [this workaround](https://github.com/sphinx-doc/sphinx/issues/6695#issuecomment-530009784): 
```
Exception occurred:
  File "/home/travis/envs/miniconda/envs/testenv/lib/python3.6/site-packages/sphinx/ext/autosummary/__init__.py", line 726, in process_generate_options
    for genfile in genfiles]
```
and this error:
```
Warning, treated as error:
/Users/koudoro/Software/fury/docs/examples/viz_advanced.py failed to execute correctly: Traceback (most recent call last):
  File "/Users/koudoro/miniconda3/envs/fury-env-37/lib/python3.7/site-packages/sphinx_gallery/gen_rst.py", line 430, in _memory_usage
    out = func()
  File "/Users/koudoro/miniconda3/envs/fury-env-37/lib/python3.7/site-packages/sphinx_gallery/gen_rst.py", line 415, in __call__
    exec(self.code, self.globals)
  File "/Users/koudoro/Software/fury/docs/examples/viz_advanced.py", line 55, in <module>
    streamlines = res['af.left'] + res['cst.right'] + res['cc_1']
TypeError: unsupported operand type(s) for +: 'ArraySequence' and 'ArraySequence'

make: *** [html] Error 2
```