### PR TITLE
Add Superquadric primitives and actors

### DIFF
--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1699,8 +1699,8 @@ def cone(centers, directions, colors, heights=1., resolution=10,
     return actor
 
 
-def superquadrics(centers, roundness=(1, 1), directions=(1, 0, 0),
-                  colors=(255, 0, 0), scale=1):
+def superquadric(centers, roundness=(1, 1), directions=(1, 0, 0),
+                 colors=(255, 0, 0), scale=1):
     """Visualize one or many superquadrics with different features.
 
     Parameters
@@ -1728,9 +1728,9 @@ def superquadrics(centers, roundness=(1, 1), directions=(1, 0, 0),
     >>> directions = np.random.rand(3, 3)
     >>> scale = np.random.rand(5)
     >>> roundness = np.array([[1, 1], [1, 2], [2, 1]])
-    >>> sq_actor = actor.superquadrics(centers, roundness=roundness,
-    ...                                directions=directions,
-    ...                                colors=colors, scale=scale)
+    >>> sq_actor = actor.superquadric(centers, roundness=roundness,
+    ...                               directions=directions,
+    ...                               colors=colors, scale=scale)
     >>> scene.add(sq_actor)
     >>> # window.show(scene)
 

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1728,10 +1728,10 @@ def superquadrics(centers, roundness=(1, 1), directions=(1, 0, 0),
     >>> directions = np.random.rand(3, 3)
     >>> scale = np.random.rand(5)
     >>> roundness = np.array([[1, 1], [1, 2], [2, 1]])
-    >>> cone_actor = actor.superquadrics(centers, roundness=roundness,
-    ...                                  directions=directions,
-    ...                                  colors=colors, scale=scale)
-    >>> scene.add(cone_actor)
+    >>> sq_actor = actor.superquadrics(centers, roundness=roundness,
+    ...                                directions=directions,
+    ...                                colors=colors, scale=scale)
+    >>> scene.add(sq_actor)
     >>> # window.show(scene)
 
     """

--- a/fury/primitive.py
+++ b/fury/primitive.py
@@ -276,13 +276,22 @@ def prim_sphere(name='symmetric362', gen_faces=False):
     return verts, faces
 
 
-def prim_superquadric(roundness=(1, 1)):
+def prim_superquadric(roundness=(1, 1), sphere_name='symmetric362'):
     """Provide vertices and triangles of a superquadrics.
 
     Parameters
     ----------
     roundness : tuple, optional
         parameters (Phi and Theta) that control the shape of the superquadric
+
+    sphere_name : str, optional
+        which sphere - one of:
+        * 'symmetric362'
+        * 'symmetric642'
+        * 'symmetric724'
+        * 'repulsion724'
+        * 'repulsion100'
+        * 'repulsion200'
 
     Returns
     -------
@@ -306,7 +315,7 @@ def prim_superquadric(roundness=(1, 1)):
         """Return a different kind of exponentiation."""
         return np.sign(x) * (np.abs(x) ** p)
 
-    sphere_verts, sphere_triangles = prim_sphere('symmetric362')
+    sphere_verts, sphere_triangles = prim_sphere(sphere_name)
     _, sphere_phi, sphere_theta = cart2sphere(*sphere_verts.T)
 
     phi, theta = roundness

--- a/fury/primitive.py
+++ b/fury/primitive.py
@@ -1,8 +1,9 @@
 from os.path import join as pjoin
 import numpy as np
 from fury.data import DATA_DIR
-from fury.transform import cart2sphere
+from fury.transform import cart2sphere, euler_matrix
 from scipy.spatial import ConvexHull
+from scipy.spatial.transform import Rotation
 
 
 SPHERE_FILES = {
@@ -36,6 +37,144 @@ def faces_from_sphere_vertices(vertices):
         return np.asarray(faces, np.uint16)
     else:
         return faces
+
+
+def repeat_primitive_function(func, centers, func_args=[],
+                              directions=(1, 0, 0), colors=(255, 0, 0),
+                              scale=1):
+    """Repeat Vertices and triangles of a specific primitive function.
+
+    It could be seen as a glyph. The primitive function should generate and
+    return vertices and faces
+
+    Parameters
+    ----------
+    func : callable
+        primitive functions
+    centers : ndarray, shape (N, 3)
+        Superquadrics positions
+    func_args : args
+        primitive functions arguments/parameters
+    directions : ndarray, shape (N, 3) or tuple (3,), optional
+        The orientation vector of the cone.
+    colors : ndarray (N,3) or (N, 4) or tuple (3,) or tuple (4,)
+        RGB or RGBA (for opacity) R, G, B and A should be at the range [0, 1]
+    scale : ndarray, shape (N) or (N,3) or float or int, optional
+        The height of the cone.
+
+    Returns
+    -------
+    big_vertices: ndarray
+        Expanded vertices at the centers positions
+    big_triangles: ndarray
+        Expanded triangles that composed our shape to duplicate
+    big_colors : ndarray
+        Expanded colors applied to all vertices/faces
+
+    """
+    # Get faces
+    _, faces = func()
+    if len(func_args) == 1:
+        func_args = np.squeeze(np.array([func_args] * centers.shape[0]))
+    elif len(func_args) != centers.shape[0]:
+        raise IOError("sq_params should 1 or equal to the numbers \
+                        of centers")
+
+    vertices = np.concatenate([func(i)[0] for i in func_args])
+    return repeat_primitive(vertices=vertices, faces=faces, centers=centers,
+                            directions=directions, colors=colors, scale=scale,
+                            have_tiled_verts=True)
+
+
+def repeat_primitive(vertices, faces, centers, directions=(1, 0, 0),
+                     colors=(255, 0, 0), scale=1, have_tiled_verts=False):
+    """Repeat Vertices and triangles of a specific primitive shape.
+
+    It could be seen as a glyph.
+
+    Parameters
+    ----------
+    vertices: ndarray
+        vertices coords to duplicate at the centers positions
+    triangles: ndarray
+        triangles that composed our shape to duplicate
+    centers : ndarray, shape (N, 3)
+        Superquadrics positions
+    directions : ndarray, shape (N, 3) or tuple (3,), optional
+        The orientation vector of the cone.
+    colors : ndarray (N,3) or (N, 4) or tuple (3,) or tuple (4,)
+        RGB or RGBA (for opacity) R, G, B and A should be at the range [0, 1]
+    scale : ndarray, shape (N) or (N,3) or float or int, optional
+        The height of the cone.
+    have_tiled_verts : bool
+        option to control if we need to duplicate vertices of a shape or not
+
+    Returns
+    -------
+    big_vertices: ndarray
+        Expanded vertices at the centers positions
+    big_triangles: ndarray
+        Expanded triangles that composed our shape to duplicate
+    big_colors : ndarray
+        Expanded colors applied to all vertices/faces
+
+    """
+    # duplicated vertices if needed
+    if not have_tiled_verts:
+        vertices = np.tile(vertices, (centers.shape[0], 1))
+
+    # Get unit shape
+    unit_verts_size = vertices.shape[0] // centers.shape[0]
+    unit_triangles_size = faces.shape[0]
+
+    big_centers = np.repeat(centers, unit_verts_size, axis=0)
+    # apply centers position
+    big_vertices = vertices + big_centers
+    # scale them
+    if isinstance(scale, (list, tuple, np.ndarray)):
+        scale = np.repeat(scale, unit_verts_size, axis=0)
+        scale = scale.reshape((big_vertices.shape[0], 1))
+    big_vertices *= scale
+
+    # update triangles
+    big_triangles = np.array(np.tile(faces,
+                             (centers.shape[0], 1)),
+                             dtype=np.int32)
+    big_triangles += np.repeat(np.arange(0, centers.shape[0] *
+                               unit_verts_size, step=unit_verts_size),
+                               unit_triangles_size,
+                               axis=0).reshape((big_triangles.shape[0], 1))
+
+    def normalize_input(arr, arr_name=''):
+        if isinstance(arr, (tuple, list, np.ndarray)) and len(arr) == 3 and \
+          not all(isinstance(i, (list, tuple, np.ndarray)) for i in arr):
+            return np.array([arr] * centers.shape[0])
+        elif isinstance(arr, np.ndarray) and len(arr) == 1:
+            return np.repeat(arr, centers.shape[0], axis=0)
+        elif len(arr) != len(centers):
+            msg = "{} size should be 1 or ".format(arr_name)
+            msg += "equal to the numbers of centers"
+            raise IOError(msg)
+        else:
+            return np.array(arr)
+
+    # update colors
+    colors = normalize_input(colors, 'colors')
+    big_colors = np.repeat(colors, unit_verts_size, axis=0)
+
+    # update orientations
+    directions = normalize_input(directions, 'directions')
+    big_vertices -= big_centers
+    for pts, dirs in enumerate(directions):
+        ai, aj, ak = Rotation.from_rotvec(np.pi/2 * dirs).as_euler('zyx')
+        rotation_matrix = euler_matrix(ai, aj, ak)
+        big_vertices[pts * unit_verts_size: (pts+1) * unit_verts_size] = \
+            np.dot(rotation_matrix[:3, :3],
+                   big_vertices[pts * unit_verts_size:
+                                (pts+1) * unit_verts_size].T).T
+    big_vertices += big_centers
+
+    return big_vertices, big_triangles, big_colors
 
 
 def prim_square():

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -1185,5 +1185,28 @@ def test_matplotlib_figure():
     npt.assert_equal(res.colors_found, [True, True])
 
 
+def test_superquadrics_actor(interactive=False):
+    scene = window.Scene()
+    centers = np.random.rand(3, 3) * 8
+    colors = np.array([[255, 0, 0], [0, 255, 0], [0, 0, 255]])
+    directions = np.random.rand(3, 3)
+    scale = np.random.rand(3)
+    roundness = np.array([[1, 1], [1, 2], [2, 1]])
+
+    sq_actor = actor.superquadrics(centers, roundness=roundness,
+                                   directions=directions,
+                                   colors=colors.astype(np.uint8),
+                                   scale=scale)
+    scene.add(sq_actor)
+    if interactive:
+        window.show(scene)
+
+    arr = window.snapshot(scene, offscreen=True)
+    arr[arr > 0] = 255  # Normalization
+    res = window.analyze_snapshot(arr, colors=colors.astype(np.uint8),
+                                  find_objects=False)
+    npt.assert_equal(res.colors_found, [True, True, True])
+
+
 if __name__ == "__main__":
     npt.run_module_suite()

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -1185,7 +1185,7 @@ def test_matplotlib_figure():
     npt.assert_equal(res.colors_found, [True, True])
 
 
-def test_superquadrics_actor(interactive=False):
+def test_superquadric_actor(interactive=False):
     scene = window.Scene()
     centers = np.random.rand(3, 3) * 8
     colors = np.array([[255, 0, 0], [0, 255, 0], [0, 0, 255]])
@@ -1193,10 +1193,10 @@ def test_superquadrics_actor(interactive=False):
     scale = np.random.rand(3)
     roundness = np.array([[1, 1], [1, 2], [2, 1]])
 
-    sq_actor = actor.superquadrics(centers, roundness=roundness,
-                                   directions=directions,
-                                   colors=colors.astype(np.uint8),
-                                   scale=scale)
+    sq_actor = actor.superquadric(centers, roundness=roundness,
+                                  directions=directions,
+                                  colors=colors.astype(np.uint8),
+                                  scale=scale)
     scene.add(sq_actor)
     if interactive:
         window.show(scene)

--- a/fury/tests/test_primitive.py
+++ b/fury/tests/test_primitive.py
@@ -41,3 +41,22 @@ def test_spheres_primitives():
                          list(range(len(verts))))
 
     npt.assert_raises(ValueError, fp.prim_sphere, 'sym362')
+
+
+def test_superquadric_primitives():
+    # test default, should be like a sphere 362
+    sq_verts, sq_faces = fp.prim_superquadric()
+    s_verts, s_faces = fp.prim_sphere('symmetric362')
+
+    npt.assert_equal(sq_verts.shape, s_verts.shape)
+    npt.assert_equal(sq_faces.shape, s_faces.shape)
+
+    npt.assert_almost_equal(sq_verts, s_verts)
+
+    # Apply roundness
+    sq_verts, sq_faces = fp.prim_superquadric(roundness=(2, 3))
+    print(sq_verts.shape, sq_faces.shape)
+    npt.assert_equal(sq_verts.shape, s_verts.shape)
+    npt.assert_equal(sq_faces.shape, s_faces.shape)
+
+    # TODO: We need to check some superquadrics shape

--- a/fury/tests/test_primitive.py
+++ b/fury/tests/test_primitive.py
@@ -97,4 +97,3 @@ def test_repeat_primitive_function():
     big_verts, big_faces, big_colors = res
 
     # npt.assert_equal(big_verts.shape[0],  verts.shape[0] * centers.shape[0])
-

--- a/fury/tests/test_primitive.py
+++ b/fury/tests/test_primitive.py
@@ -55,8 +55,46 @@ def test_superquadric_primitives():
 
     # Apply roundness
     sq_verts, sq_faces = fp.prim_superquadric(roundness=(2, 3))
-    print(sq_verts.shape, sq_faces.shape)
     npt.assert_equal(sq_verts.shape, s_verts.shape)
     npt.assert_equal(sq_faces.shape, s_faces.shape)
 
     # TODO: We need to check some superquadrics shape
+
+
+def test_repeat_primitive():
+    # init variables
+    verts, faces = fp.prim_square()
+    centers = np.array([[0, 0, 0], [5, 0, 0], [10, 0, 0]])
+    dirs = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 1]])
+    colors = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1.]])
+
+    big_verts, big_faces, big_colors = fp.repeat_primitive(vertices=verts,
+                                                           faces=faces,
+                                                           centers=centers,
+                                                           directions=dirs,
+                                                           colors=colors)
+
+    npt.assert_equal(big_verts.shape[0],  verts.shape[0] * centers.shape[0])
+    npt.assert_equal(big_faces.shape[0],  faces.shape[0] * centers.shape[0])
+    npt.assert_equal(big_colors.shape[0],  verts.shape[0] * centers.shape[0])
+
+    # TODO: Check the array content
+
+
+def test_repeat_primitive_function():
+    # init variables
+    centers = np.array([[0, 0, 0], [5, 0, 0], [10, 0, 0]])
+    dirs = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 1]])
+    colors = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]) * 255
+    phi_theta = np.array([[1, 1], [1, 2], [2, 1]])
+
+    res = fp.repeat_primitive_function(func=fp.prim_superquadric,
+                                       centers=centers,
+                                       func_args=phi_theta,
+                                       directions=dirs,
+                                       colors=colors)
+
+    big_verts, big_faces, big_colors = res
+
+    # npt.assert_equal(big_verts.shape[0],  verts.shape[0] * centers.shape[0])
+

--- a/fury/tests/test_transform.py
+++ b/fury/tests/test_transform.py
@@ -1,0 +1,51 @@
+import numpy as np
+import numpy.testing as npt
+
+from fury.transform import sphere2cart, cart2sphere
+
+
+def _make_pts():
+    """ Make points around sphere quadrants """
+    thetas = np.arange(1, 4) * np.pi/4
+    phis = np.arange(8) * np.pi/4
+    north_pole = (0, 0, 1)
+    south_pole = (0, 0, -1)
+    points = [north_pole, south_pole]
+    for theta in thetas:
+        for phi in phis:
+            x = np.sin(theta) * np.cos(phi)
+            y = np.sin(theta) * np.sin(phi)
+            z = np.cos(theta)
+            points.append((x, y, z))
+    return np.array(points)
+
+
+def test_sphere_cart():
+    sphere_points = _make_pts()
+    # test arrays of points
+    rs, thetas, phis = cart2sphere(*(sphere_points.T))
+    xyz = sphere2cart(rs, thetas, phis)
+    npt.assert_array_almost_equal(xyz, sphere_points.T)
+    # test radius estimation
+    big_sph_pts = sphere_points * 10.4
+    rs, thetas, phis = cart2sphere(*big_sph_pts.T)
+    npt.assert_array_almost_equal(rs, 10.4)
+    xyz = sphere2cart(rs, thetas, phis)
+    npt.assert_array_almost_equal(xyz, big_sph_pts.T, decimal=6)
+    # test that result shapes match
+    x, y, z = big_sph_pts.T
+    r, theta, phi = cart2sphere(x[:1], y[:1], z)
+    npt.assert_equal(r.shape, theta.shape)
+    npt.assert_equal(r.shape, phi.shape)
+    x, y, z = sphere2cart(r[:1], theta[:1], phi)
+    npt.assert_equal(x.shape, y.shape)
+    npt.assert_equal(x.shape, z.shape)
+    # test a scalar point
+    pt = sphere_points[3]
+    r, theta, phi = cart2sphere(*pt)
+    xyz = sphere2cart(r, theta, phi)
+    npt.assert_array_almost_equal(xyz, pt)
+
+    # Test full circle on x=1, y=1, z=1
+    x, y, z = sphere2cart(*cart2sphere(1.0, 1.0, 1.0))
+    npt.assert_array_almost_equal((x, y, z), (1.0, 1.0, 1.0))

--- a/fury/tests/test_transform.py
+++ b/fury/tests/test_transform.py
@@ -1,7 +1,8 @@
 import numpy as np
 import numpy.testing as npt
 
-from fury.transform import sphere2cart, cart2sphere
+from fury.transform import (sphere2cart, cart2sphere, euler_matrix,
+                            _AXES2TUPLE, _TUPLE2AXES)
 
 
 def _make_pts():
@@ -49,3 +50,17 @@ def test_sphere_cart():
     # Test full circle on x=1, y=1, z=1
     x, y, z = sphere2cart(*cart2sphere(1.0, 1.0, 1.0))
     npt.assert_array_almost_equal((x, y, z), (1.0, 1.0, 1.0))
+
+
+def test_euler_matrix():
+    rotation = euler_matrix(1, 2, 3, 'syxz')
+    npt.assert_equal(np.allclose(np.sum(rotation[0]), -1.34786452), True)
+
+    rotation = euler_matrix(1, 2, 3, (0, 1, 0, 1))
+    npt.assert_equal(np.allclose(np.sum(rotation[0]), -0.383436184), True)
+
+    ai, aj, ak = (4.0 * np.pi) * (np.random.random(3) - 0.5)
+    for axes in _AXES2TUPLE.keys():
+        _ = euler_matrix(ai, aj, ak, axes)
+    for axes in _TUPLE2AXES.keys():
+        _ = euler_matrix(ai, aj, ak, axes)

--- a/fury/transform.py
+++ b/fury/transform.py
@@ -1,4 +1,99 @@
+import math
 import numpy as np
+
+
+# axis sequences for Euler angles
+_NEXT_AXIS = [1, 2, 0, 1]
+
+# map axes strings to/from tuples of inner axis, parity, repetition, frame
+_AXES2TUPLE = {
+    'sxyz': (0, 0, 0, 0), 'sxyx': (0, 0, 1, 0), 'sxzy': (0, 1, 0, 0),
+    'sxzx': (0, 1, 1, 0), 'syzx': (1, 0, 0, 0), 'syzy': (1, 0, 1, 0),
+    'syxz': (1, 1, 0, 0), 'syxy': (1, 1, 1, 0), 'szxy': (2, 0, 0, 0),
+    'szxz': (2, 0, 1, 0), 'szyx': (2, 1, 0, 0), 'szyz': (2, 1, 1, 0),
+    'rzyx': (0, 0, 0, 1), 'rxyx': (0, 0, 1, 1), 'ryzx': (0, 1, 0, 1),
+    'rxzx': (0, 1, 1, 1), 'rxzy': (1, 0, 0, 1), 'ryzy': (1, 0, 1, 1),
+    'rzxy': (1, 1, 0, 1), 'ryxy': (1, 1, 1, 1), 'ryxz': (2, 0, 0, 1),
+    'rzxz': (2, 0, 1, 1), 'rxyz': (2, 1, 0, 1), 'rzyz': (2, 1, 1, 1)}
+
+_TUPLE2AXES = dict((v, k) for k, v in _AXES2TUPLE.items())
+
+
+def euler_matrix(ai, aj, ak, axes='sxyz'):
+    """Return homogeneous rotation matrix from Euler angles and axis sequence.
+
+    Code modified from the work of Christoph Gohlke link provided here
+    http://www.lfd.uci.edu/~gohlke/code/transformations.py.html
+
+    Parameters
+    ------------
+    ai, aj, ak : Euler's roll, pitch and yaw angles
+    axes : One of 24 axis sequences as string or encoded tuple
+
+    Returns
+    ---------
+    matrix : ndarray (4, 4)
+
+    Code modified from the work of Christoph Gohlke link provided here
+    http://www.lfd.uci.edu/~gohlke/code/transformations.py.html
+
+    Examples
+    --------
+    >>> import numpy
+    >>> R = euler_matrix(1, 2, 3, 'syxz')
+    >>> numpy.allclose(numpy.sum(R[0]), -1.34786452)
+    True
+    >>> R = euler_matrix(1, 2, 3, (0, 1, 0, 1))
+    >>> numpy.allclose(numpy.sum(R[0]), -0.383436184)
+    True
+    >>> ai, aj, ak = (4.0*math.pi) * (numpy.random.random(3) - 0.5)
+    >>> for axes in _AXES2TUPLE.keys():
+    ...    _ = euler_matrix(ai, aj, ak, axes)
+    >>> for axes in _TUPLE2AXES.keys():
+    ...    _ = euler_matrix(ai, aj, ak, axes)
+
+    """
+    try:
+        firstaxis, parity, repetition, frame = _AXES2TUPLE[axes]
+    except (AttributeError, KeyError):
+        firstaxis, parity, repetition, frame = axes
+
+    i = firstaxis
+    j = _NEXT_AXIS[i + parity]
+    k = _NEXT_AXIS[i - parity + 1]
+
+    if frame:
+        ai, ak = ak, ai
+    if parity:
+        ai, aj, ak = -ai, -aj, -ak
+
+    si, sj, sk = math.sin(ai), math.sin(aj), math.sin(ak)
+    ci, cj, ck = math.cos(ai), math.cos(aj), math.cos(ak)
+    cc, cs = ci * ck, ci * sk
+    sc, ss = si * ck, si * sk
+
+    M = np.identity(4)
+    if repetition:
+        M[i, i] = cj
+        M[i, j] = sj * si
+        M[i, k] = sj * ci
+        M[j, i] = sj * sk
+        M[j, j] = -cj * ss + cc
+        M[j, k] = -cj * cs - sc
+        M[k, i] = -sj * ck
+        M[k, j] = cj * sc + cs
+        M[k, k] = cj * cc - ss
+    else:
+        M[i, i] = cj * ck
+        M[i, j] = sj * sc - cs
+        M[i, k] = sj * cc + ss
+        M[j, i] = cj * sk
+        M[j, j] = sj * ss + cc
+        M[j, k] = sj * cs - sc
+        M[k, i] = -sj
+        M[k, j] = cj * si
+        M[k, k] = cj * ci
+    return M
 
 
 def sphere2cart(r, theta, phi):

--- a/fury/transform.py
+++ b/fury/transform.py
@@ -1,0 +1,110 @@
+import numpy as np
+
+
+def sphere2cart(r, theta, phi):
+    """Spherical to Cartesian coordinates.
+
+    This is the standard physics convention where `theta` is the
+    inclination (polar) angle, and `phi` is the azimuth angle.
+
+    Imagine a sphere with center (0,0,0).  Orient it with the z axis
+    running south-north, the y axis running west-east and the x axis
+    from posterior to anterior.  `theta` (the inclination angle) is the
+    angle to rotate from the z-axis (the zenith) around the y-axis,
+    towards the x axis.  Thus the rotation is counter-clockwise from the
+    point of view of positive y.  `phi` (azimuth) gives the angle of
+    rotation around the z-axis towards the y axis.  The rotation is
+    counter-clockwise from the point of view of positive z.
+
+    Equivalently, given a point P on the sphere, with coordinates x, y,
+    z, `theta` is the angle between P and the z-axis, and `phi` is
+    the angle between the projection of P onto the XY plane, and the X
+    axis.
+
+    Geographical nomenclature designates theta as 'co-latitude', and phi
+    as 'longitude'
+
+    Parameters
+    ------------
+    r : array_like
+       radius
+    theta : array_like
+       inclination or polar angle
+    phi : array_like
+       azimuth angle
+
+    Returns
+    ---------
+    x : array
+       x coordinate(s) in Cartesion space
+    y : array
+       y coordinate(s) in Cartesian space
+    z : array
+       z coordinate
+
+    Notes
+    --------
+    See these pages:
+
+    * http://en.wikipedia.org/wiki/Spherical_coordinate_system
+    * http://mathworld.wolfram.com/SphericalCoordinates.html
+
+    for excellent discussion of the many different conventions
+    possible.  Here we use the physics conventions, used in the
+    wikipedia page.
+
+    Derivations of the formulae are simple. Consider a vector x, y, z of
+    length r (norm of x, y, z).  The inclination angle (theta) can be
+    found from: cos(theta) == z / r -> z == r * cos(theta).  This gives
+    the hypotenuse of the projection onto the XY plane, which we will
+    call Q. Q == r*sin(theta). Now x / Q == cos(phi) -> x == r *
+    sin(theta) * cos(phi) and so on.
+
+    We have deliberately named this function ``sphere2cart`` rather than
+    ``sph2cart`` to distinguish it from the Matlab function of that
+    name, because the Matlab function uses an unusual convention for the
+    angles that we did not want to replicate.  The Matlab function is
+    trivial to implement with the formulae given in the Matlab help.
+
+    """
+    sin_theta = np.sin(theta)
+    x = r * np.cos(phi) * sin_theta
+    y = r * np.sin(phi) * sin_theta
+    z = r * np.cos(theta)
+    x, y, z = np.broadcast_arrays(x, y, z)
+    return x, y, z
+
+
+def cart2sphere(x, y, z):
+    r"""Return angles for Cartesian 3D coordinates `x`, `y`, and `z`.
+
+    See doc for ``sphere2cart`` for angle conventions and derivation
+    of the formulae.
+
+    $0\le\theta\mathrm{(theta)}\le\pi$ and $-\pi\le\phi\mathrm{(phi)}\le\pi$
+
+    Parameters
+    ------------
+    x : array_like
+       x coordinate in Cartesian space
+    y : array_like
+       y coordinate in Cartesian space
+    z : array_like
+       z coordinate
+
+    Returns
+    ---------
+    r : array
+       radius
+    theta : array
+       inclination (polar) angle
+    phi : array
+       azimuth angle
+
+    """
+    r = np.sqrt(x * x + y * y + z * z)
+    theta = np.arccos(np.divide(z, r, where=r > 0))
+    theta = np.where(r > 0, theta, 0.)
+    phi = np.arctan2(y, x)
+    r, theta, phi = np.broadcast_arrays(r, theta, phi)
+    return r, theta, phi

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -482,6 +482,46 @@ def get_actor_from_polydata(polydata):
     return get_actor_from_polymapper(poly_mapper)
 
 
+def get_actor_from_primitive(vertices, triangles, colors=None,
+                             normals=None, backface_culling=True):
+    """Get vtkActor from a vtkPolyData.
+
+    Parameters
+    ----------
+    vertices : (Mx3) ndarray
+        XYZ coordinates of the object
+    triangles: (Nx3) ndarray
+        Indices into vertices; forms triangular faces.
+    colors: (Nx3) ndarray
+        N is equal to the number of lines. Every line is coloured with a
+        different RGB color.
+    normals: (Nx3) ndarray
+        normals, represented as 2D ndarrays (Nx3) (one per vertex)
+    backface_culling: bool
+        culling of polygons based on orientation of normal with respect to
+        camera. If backface culling is True, polygons facing away from camera
+        are not drawn. Default: True
+
+
+    Returns
+    -------
+    actor : vtkActor
+
+    """
+    # Create a Polydata
+    pd = vtk.vtkPolyData()
+    set_polydata_vertices(pd, vertices)
+    set_polydata_triangles(pd, triangles)
+    if isinstance(colors, np.ndarray):
+        set_polydata_colors(pd, colors)
+    if isinstance(normals, np.ndarray):
+        set_polydata_normals(pd, normals)
+
+    current_actor = get_actor_from_polydata(pd)
+    current_actor.GetProperty().SetBackfaceCulling(backface_culling)
+    return current_actor
+
+
 def repeat_sources(centers, colors, active_scalars=1., directions=None,
                    source=None, vertices=None, faces=None):
     """Transform a vtksource to glyph.


### PR DESCRIPTION
Adding the superquadrics actor and primitive. Below a small example to use it

```
from fury import window, actor
scene = window.Scene()
centers = np.random.rand(3, 3) * 10
directions = np.random.rand(3, 3)
colors = np.array([[255, 0, 0], [0, 255, 0], [0, 0, 255]])
scale = np.random.rand(5)
roundness = np.array([[1, 1], [1, 2], [2, 1]])

sq_actor = actor.superquadric(centers, roundness=roundness,
                              directions=directions,
                              colors=colors, scale=scale)
scene.add(sq_actor)
window.show(scene)
```

<img width="684" alt="Capture d’écran 2019-12-06 à 06 47 32" src="https://user-images.githubusercontent.com/23106443/70299129-52fd1c00-17f4-11ea-82b5-136e93c52497.png">
