### PR TITLE
nose is missing

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -3,3 +3,4 @@ numpy>=1.7.1
 vtk>=8.1.2
 scipy>=0.9
 pillow>=5.4.1
+nose>=1.0.0


### PR DESCRIPTION
ImportError: Need nose >= 1.0.0 for tests - see https://nose.readthedocs.io
can be fixed by adding nose>=1.0.0 to the default.txt ,please accept my commit for smooth testing!
tested on my pc, by adding the above change, showing no error , working fine