### PR TITLE
bug-in-image 0.1

### DIFF
--- a/fury/io.py
+++ b/fury/io.py
@@ -2,6 +2,7 @@ import os
 import vtk
 import numpy as np
 from PIL import Image
+import PIL.ImageOps
 from vtk.util import numpy_support
 from fury.utils import set_input
 
@@ -130,6 +131,7 @@ def save_image(arr, filename, compression_quality=75,
 
     if use_pillow:
         im = Image.fromarray(arr)
+        im = im.transpose(Image.FLIP_TOP_BOTTOM)
         im.save(filename, quality=compression_quality)
         return
 


### PR DESCRIPTION
**Title** 
Image saved vertivally solved 

**Code** 
Changed in io.py file
im = im.transpose(Image.FLIP_TOP_BOTTOM)

Decription 
There might me error in arr.reshape so i don't know how to correct it. But i than change the code in pillow where the image is being saved and tranposed the image. I thinki can do the same with the arr but it giving me lot's of error so i have gone with the pillow code. Know it is givign right answer but the test case are failing. I might solved the  **issue** but not sure about it (https://github.com/fury-gl/fury/issues/160)

Output 
![result1](https://user-images.githubusercontent.com/35897183/75607966-7ac4fd00-5b21-11ea-8c71-7b6538cf54fa.PNG)
![failing](https://user-images.githubusercontent.com/35897183/75607978-95977180-5b21-11ea-8e7d-f95369bf0206.PNG)

O.S information :
{'fury_version': '0.4.0.post198+g10c977e', 'pkg_path': '/home/jasims/fury/fury', 'commit_hash': '10c977e343aa23141dda26fce5dd08257197216d', 'sys_version': '3.7.4 (default, Aug 13 2019, 20:35:49) \n[GCC 7.3.0]', 'sys_executable': '/home/jasims/miniconda3/bin/python', 'sys_platform': 'linux', 'numpy_version': '1.18.1', 'scipy_version': '1.4.1', 'vtk_version': '8.1.2', 'matplotlib_version': '3.1.3', 'dipy_version': '1.1.1'}