### PR TITLE
Fixing Text Overflow of ListBox2D

### DIFF
--- a/fury/tests/test_ui.py
+++ b/fury/tests/test_ui.py
@@ -725,7 +725,8 @@ def test_ui_listbox_2d(interactive=False):
     event_counter.check_counts(expected)
 
     # Check if the right values were selected.
-    expected = [[1], [1, 2], [1], ["A Very Very Long Item To Test Text Overflow of List Box 2D"], [1], values]
+    expected = [[1], [1, 2], [1], ["A Very Very Long Item To Test Text Overflow \
+of List Box 2D"], [1], values]
     npt.assert_equal(len(selected_values), len(expected))
     assert_arrays_equal(selected_values, expected)
 
@@ -735,7 +736,9 @@ def test_ui_listbox_2d(interactive=False):
     show_manager.play_events_from_file(recording_filename)
 
     # Check if the right values were selected.
-    expected = [[1], [2], [2], ["A Very Very Long Item To Test Text Overflow of List Box 2D"], [1], ["A Very Very Long Item To Test Text Overflow of List Box 2D"]]
+    expected = [[1], [2], [2], ["A Very Very Long Item To Test \
+Text Overflow of List Box 2D"], [1], ["A Very Very Long Item To Test \
+Text Overflow of List Box 2D"]]
     npt.assert_equal(len(selected_values), len(expected))
     assert_arrays_equal(selected_values, expected)
 

--- a/fury/tests/test_ui.py
+++ b/fury/tests/test_ui.py
@@ -736,8 +736,8 @@ of List Box 2D"], [1], values]
     show_manager.play_events_from_file(recording_filename)
 
     # Check if the right values were selected.
-    expected = [[1], [2], [2], ["A Very Very Long Item To Test \
-Text Overflow of List Box 2D"], [1], ["A Very Very Long Item To Test \
+    expected = [[1], [2], [2], ["A Very Very Long Item \
+To Test Text Overflow of List Box 2D"], [1], ["A Very Very Long Item To Test \
 Text Overflow of List Box 2D"]]
     npt.assert_equal(len(selected_values), len(expected))
     assert_arrays_equal(selected_values, expected)

--- a/fury/tests/test_ui.py
+++ b/fury/tests/test_ui.py
@@ -725,8 +725,8 @@ def test_ui_listbox_2d(interactive=False):
     event_counter.check_counts(expected)
 
     # Check if the right values were selected.
-    expected = [[1], [1, 2], [1], ["A Very Very Long Item To Test Text Overflow \
-of List Box 2D"], [1], values]
+    expected = [[1], [1, 2], [1], ["A Very Very Long Item To \
+Test Text Overflow of List Box 2D"], [1], values]
     npt.assert_equal(len(selected_values), len(expected))
     assert_arrays_equal(selected_values, expected)
 
@@ -736,8 +736,8 @@ of List Box 2D"], [1], values]
     show_manager.play_events_from_file(recording_filename)
 
     # Check if the right values were selected.
-    expected = [[1], [2], [2], ["A Very Very Long Item \
-To Test Text Overflow of List Box 2D"], [1], ["A Very Very Long Item To Test \
+    expected = [[1], [2], [2], ["A Very Very Long Item To \
+Test Text Overflow of List Box 2D"], [1], ["A Very Very Long Item To Test \
 Text Overflow of List Box 2D"]]
     npt.assert_equal(len(selected_values), len(expected))
     assert_arrays_equal(selected_values, expected)

--- a/fury/tests/test_ui.py
+++ b/fury/tests/test_ui.py
@@ -669,6 +669,7 @@ def test_ui_listbox_2d(interactive=False):
 
     # Values that will be displayed by the listbox.
     values = list(range(1, 42 + 1))
+    values.append("A Very Very Long Item To Test Text Overflow of List Box 2D")
 
     if interactive:
         listbox = ui.ListBox2D(values=values,
@@ -690,11 +691,11 @@ def test_ui_listbox_2d(interactive=False):
     #  2. Ctrl + click on 2,
     #  3. Ctrl + click on 2.
     #  4. Use scroll bar to scroll to the bottom.
-    #  5. Click on 42.
+    #  5. Click on "A Very Very Long Item...".
     #  6. Use scroll bar to scroll to the top.
     #  7. Click on 1
     #  8. Use mouse wheel to scroll down.
-    #  9. Shift + click on 42.
+    #  9. Shift + click on "A Very Very Long Item...".
     # 10. Use mouse wheel to scroll back up.
 
     listbox = ui.ListBox2D(values=values,
@@ -724,7 +725,7 @@ def test_ui_listbox_2d(interactive=False):
     event_counter.check_counts(expected)
 
     # Check if the right values were selected.
-    expected = [[1], [1, 2], [1], [42], [1], values]
+    expected = [[1], [1, 2], [1], ["A Very Very Long Item To Test Text Overflow of List Box 2D"], [1], values]
     npt.assert_equal(len(selected_values), len(expected))
     assert_arrays_equal(selected_values, expected)
 
@@ -734,7 +735,7 @@ def test_ui_listbox_2d(interactive=False):
     show_manager.play_events_from_file(recording_filename)
 
     # Check if the right values were selected.
-    expected = [[1], [2], [2], [42], [1], [42]]
+    expected = [[1], [2], [2], ["A Very Very Long Item To Test Text Overflow of List Box 2D"], [1], ["A Very Very Long Item To Test Text Overflow of List Box 2D"]]
     npt.assert_equal(len(selected_values), len(expected))
     assert_arrays_equal(selected_values, expected)
 

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -3393,14 +3393,14 @@ class ListBox2D(UI):
             self.scroll_bar, size - self.scroll_bar.size - self.margin)
 
         # Initialisation of empty text actors
-        slot_width = size[0] - self.scroll_bar.size[0] - \
+        self.slot_width = size[0] - self.scroll_bar.size[0] - \
             2 * self.margin - self.margin
         x = self.margin
         y = size[1] - self.margin
         for _ in range(self.nb_slots):
             y -= self.slot_height
             item = ListBoxItem2D(list_box=self,
-                                 size=(slot_width, self.slot_height),
+                                 size=(self.slot_width, self.slot_height),
                                  text_color=self.text_color,
                                  selected_color=self.selected_color,
                                  unselected_color=self.unselected_color,
@@ -3598,7 +3598,15 @@ class ListBox2D(UI):
         # Populate slots according to the view.
         for i, choice in enumerate(values_to_show):
             slot = self.slots[i]
-            slot.element = choice
+            char_width = slot.textblock.size[0] - self.margin
+            text_width = char_width * len(choice) * 0.783
+            if text_width > self.slot_width:
+                excess_width = text_width - self.slot_width
+                excess_chars = excess_width//char_width
+                wrapped_choice = choice[:int(-excess_chars) - 3] + "..."
+                slot.element = wrapped_choice
+            else:
+                slot.element = choice
             slot.set_visibility(True)
             if slot.element in self.selected:
                 slot.select()

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -3599,7 +3599,7 @@ class ListBox2D(UI):
         for i, choice in enumerate(values_to_show):
             slot = self.slots[i]
             char_width = slot.textblock.size[0] - self.margin
-            text_width = char_width * len(choice) * 0.783
+            text_width = char_width * len(str(choice)) * 0.783
             if text_width > self.slot_width:
                 excess_width = text_width - self.slot_width
                 excess_chars = excess_width//char_width

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -3599,11 +3599,11 @@ class ListBox2D(UI):
         for i, choice in enumerate(values_to_show):
             slot = self.slots[i]
             char_width = slot.textblock.size[0] - self.margin
-            text_width = char_width * len(str(choice)) * 0.783
-            if text_width > self.slot_width:
-                excess_width = text_width - self.slot_width
-                excess_chars = excess_width//char_width
-                wrapped_choice = choice[:int(-excess_chars) - 3] + "..."
+            permissible_chars = int(self.slot_width)//char_width
+            total_chars = len(str(choice))
+            if total_chars > permissible_chars:
+                excess_chars = total_chars - permissible_chars
+                wrapped_choice = choice[:(-excess_chars) + 3] + "..."
                 slot.element = choice
                 slot.textblock.message = wrapped_choice
             else:

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -3604,7 +3604,8 @@ class ListBox2D(UI):
                 excess_width = text_width - self.slot_width
                 excess_chars = excess_width//char_width
                 wrapped_choice = choice[:int(-excess_chars) - 3] + "..."
-                slot.element = wrapped_choice
+                slot.element = choice
+                slot.textblock.message = wrapped_choice
             else:
                 slot.element = choice
             slot.set_visibility(True)


### PR DESCRIPTION
Referencing #15 and #166 , my objective is to prevent text overflow in ListBox2D. As issue #15 is similar to #166 I am referencing both the issues within this Pull Request.

## Overview:
* Added Fix to prevent text-overflow in ListBox2D by replacing the **end of the string** exceeding the width of the item slot with `...`

## Code Snippet to reproduce UI
```python
import fury.ui as ui
import fury.window as window
values = ['abcdefghijklmnopqrstuvwxyz', 'ahdfjkhkashdfjkhdskfhiweuroqweqr', 'akdiuhdaiufhasdfusdffsdfusdyf', 'Soham']
listbox = ui.ListBox2D(values=values, size=(300, 300))
sm=window.ShowManager(size=(600,600))
sm.scene.add(listbox)
sm.start()
```

## Current Implementation
![Previous Implementation](https://ibin.co/5E8d6AU7f0ow.png)

## Fixed Implementation 
![Fixed Implementation](https://ibin.co/5E8dZpRuNI1G.png)

Thank You. :heart: