### PR TITLE
updated start function to allow saving

### DIFF
--- a/fury/window.py
+++ b/fury/window.py
@@ -496,7 +496,7 @@ class ShowManager(object):
         """Render only once."""
         self.window.Render()
 
-    def start(self,fname = None):
+    def start(self, fname=None):
         """Start interaction."""
         try:
             self.iren.Start()
@@ -515,21 +515,16 @@ class ShowManager(object):
             renderLarge = vtk.vtkRenderLargeImage()
             renderLarge.SetInput(self.scene)
             renderLarge.Update()
-            vtk_image = renderLarge.GetOutput()
-            h, w, _ = vtk_image.GetDimensions()
-            vtk_array = vtk_image.GetPointData().GetScalars()
-            components = vtk_array.GetNumberOfComponents()
-            arr = numpy_support.vtk_to_numpy(vtk_array).reshape(w, h, components)
-            
+
             writer = vtk.vtkPNGWriter()
             writer.SetFileName(fname)
             writer.SetInputConnection(renderLarge.GetOutputPort())
             writer.Write()
-        
+
         self.scene.SetRenderWindow(None)
         del self.iren
         del self.window
-    
+
     def record_events(self):
         """Record events during the interaction.
 


### PR DESCRIPTION
Fixes #113 
Changed `start(self)` to `start(self,fname = None)`  to save figure (using `vtkRenderLargeImage`)
only if fname is provided. 
