### PR TITLE
Vertical Layout for RangeSlider

### DIFF
--- a/docs/tutorials/02_advanced_ui/viz_ui.py
+++ b/docs/tutorials/02_advanced_ui/viz_ui.py
@@ -187,13 +187,17 @@ line_slider_y.on_change = translate_cube_y
 # Finally, we can add a range slider. This element is composed of two sliders.
 # The first slider has two handles which let you set the range of the second.
 
-range_slider = ui.RangeSlider(
-    line_width=8, handle_side=25, range_slider_center=(550, 450),
-    value_slider_center=(550, 350), length=250, min_value=0,
+range_slider_x = ui.RangeSlider(
+    line_width=8, handle_side=25, range_slider_center=(450, 450),
+    value_slider_center=(450, 350), length=150, min_value=0,
     max_value=10, font_size=18, range_precision=2, value_precision=4,
     shape="square")
 
-
+range_slider_y = ui.RangeSlider(
+    line_width=8, handle_side=25, range_slider_center=(750, 400),
+    value_slider_center=(650, 400), length=150, min_value=0,
+    max_value=10, font_size=18, range_precision=2, value_precision=4,
+    orientation="vertical", shape="square")
 ###############################################################################
 # Select menu
 # ============
@@ -204,7 +208,7 @@ range_slider = ui.RangeSlider(
 # We'll first make a list of the examples.
 
 examples = [[rect], [disk, ring], [img], [panel],
-            [ring_slider, line_slider_x, line_slider_y], [range_slider]]
+            [ring_slider, line_slider_x, line_slider_y], [range_slider_x, range_slider_y]]
 
 ###############################################################################
 # Now we'll make a function to hide all the examples. Then we'll call it so
@@ -225,7 +229,7 @@ hide_all_examples()
 # correspond with the examples.
 
 values = ['Rectangle', 'Disks', 'Image', "Button Panel",
-          "Line and Ring Slider", "Range Slider"]
+          "Line & Ring Slider", "Range Slider"]
 
 ###############################################################################
 # Now we can create the menu.

--- a/docs/tutorials/02_advanced_ui/viz_ui.py
+++ b/docs/tutorials/02_advanced_ui/viz_ui.py
@@ -208,7 +208,8 @@ range_slider_y = ui.RangeSlider(
 # We'll first make a list of the examples.
 
 examples = [[rect], [disk, ring], [img], [panel],
-            [ring_slider, line_slider_x, line_slider_y], [range_slider_x, range_slider_y]]
+            [ring_slider, line_slider_x, line_slider_y],
+            [range_slider_x, range_slider_y]]
 
 ###############################################################################
 # Now we'll make a function to hide all the examples. Then we'll call it so

--- a/fury/tests/test_ui.py
+++ b/fury/tests/test_ui.py
@@ -639,12 +639,15 @@ def test_ui_ring_slider_2d(recording=False):
 
 
 def test_ui_range_slider(interactive=False):
-    range_slider_test = ui.RangeSlider(shape="square")
+    range_slider_test_horizontal = ui.RangeSlider(shape="square")
+    range_slider_test_vertical = ui.RangeSlider(shape="square",
+                                                orientation="vertical")
 
     if interactive:
         show_manager = window.ShowManager(size=(600, 600),
                                           title="FURY Line Double Slider")
-        show_manager.scene.add(range_slider_test)
+        show_manager.scene.add(range_slider_test_horizontal)
+        show_manager.scene.add(range_slider_test_vertical)
         show_manager.start()
 
 

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -2932,7 +2932,7 @@ class RangeSlider(UI):
                  handle_side=20, range_slider_center=(450, 400),
                  value_slider_center=(450, 300), length=200, min_value=0,
                  max_value=100, font_size=16, range_precision=1,
-                 value_precision=2, shape="disk"):
+                 orientation="horizontal", value_precision=2, shape="disk"):
         """
         Parameters
         ----------
@@ -2958,6 +2958,8 @@ class RangeSlider(UI):
             Size of the text to display alongside the sliders (pt).
         range_precision : int
             Number of decimal places to show the min and max values set.
+        orientation : str
+            horizontal or vertical
         value_precision : int
             Number of decimal places to show the value set on slider.
         shape : string
@@ -2973,6 +2975,7 @@ class RangeSlider(UI):
         self.line_width = line_width
         self.font_size = font_size
         self.shape = shape
+        self.orientation = orientation.lower()
 
         self.range_slider_text_template = \
             "{value:." + str(range_precision) + "f}"
@@ -2997,6 +3000,7 @@ class RangeSlider(UI):
                                initial_values=(self.min_value,
                                                self.max_value),
                                font_size=self.font_size, shape=self.shape,
+                               orientation = self.orientation,
                                text_template=self.range_slider_text_template)
 
         self.value_slider = \
@@ -3008,6 +3012,7 @@ class RangeSlider(UI):
                          min_value=self.min_value, max_value=self.max_value,
                          initial_value=(self.min_value + self.max_value) / 2,
                          font_size=self.font_size, shape=self.shape,
+                         orientation = self.orientation,
                          text_template=self.value_slider_text_template)
 
         # Add default events listener for this UI component.

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -3000,7 +3000,7 @@ class RangeSlider(UI):
                                initial_values=(self.min_value,
                                                self.max_value),
                                font_size=self.font_size, shape=self.shape,
-                               orientation = self.orientation,
+                               orientation=self.orientation,
                                text_template=self.range_slider_text_template)
 
         self.value_slider = \
@@ -3012,7 +3012,7 @@ class RangeSlider(UI):
                          min_value=self.min_value, max_value=self.max_value,
                          initial_value=(self.min_value + self.max_value) / 2,
                          font_size=self.font_size, shape=self.shape,
-                         orientation = self.orientation,
+                         orientation=self.orientation,
                          text_template=self.value_slider_text_template)
 
         # Add default events listener for this UI component.


### PR DESCRIPTION
# Overview
* Adding a vertical layout for `RangeSlider`.

## Example:
![range-slider-2020-03-14-194607](https://user-images.githubusercontent.com/29832615/76684031-8d195d80-662e-11ea-902e-43b1f030ef99.gif)

## Code Snippet for the above viz:
```python
from fury import ui, window

range_slider_hor = ui.RangeSlider(
    line_width=8, handle_side=25, range_slider_center=(200, 500),
    value_slider_center=(200, 400), length=250, min_value=0,
    max_value=10, font_size=18, range_precision=2, value_precision=4,
    shape="square")
    
range_slider_ver = ui.RangeSlider(
    line_width=8, handle_side=25, range_slider_center=(475, 450),
    value_slider_center=(375, 450), length=250, min_value=0,
    max_value=10, font_size=18, range_precision=2, value_precision=4,
    orientation="vertical", shape="square")
    
current_size = (800, 800)
show_manager = window.ShowManager(size=current_size, title="Range Sliders Example")
show_manager.scene.add(range_slider_hor)
show_manager.scene.add(range_slider_ver)
show_manager.start()
```

