### PR TITLE
Added contour_from_label method

### DIFF
--- a/fury/actor.py
+++ b/fury/actor.py
@@ -444,9 +444,8 @@ def contour_from_roi(data, affine=None,
     return skin_actor
 
 
-def contour_from_label(data, affine=None,
-                       color=None, opacity=None):
-    """Generate surface actor from a binary labeled Array.
+def contour_from_label(data, affine=None, color=None):
+    """Generate surface actor from a labeled Array.
 
     The color and opacity of individual surfaces can be customized.
 
@@ -457,13 +456,9 @@ def contour_from_label(data, affine=None,
     affine : array, shape (4, 4)
         Grid to space (usually RAS 1mm) transformation matrix. Default is None.
         If None then the identity matrix is used.
-    color : (N, 3) ndarray
-        RGB values in [0,1]. Default is None.
+    color : (N, 3) or (N, 4) ndarray
+        RGB/RGBA values in [0,1]. Default is None.
         If None then random colors are used.
-    opacity : float or (N,) ndarray
-        Opacity of surface between 0 and 1. Default is None
-        if opacity is numeric, same value is applied to all surfaces.
-        if opacity is None, then 1.0 is used by default for all surfaces.
 
     Returns
     -------
@@ -479,17 +474,16 @@ def contour_from_label(data, affine=None,
 
     unique_roi_surfaces = vtk.vtkAssembly()
 
-    if opacity is None:
-        opacity = np.ones((nb_surfaces, 1)).astype(np.float)
-    elif isinstance(opacity, (float, int)):
-        opacity = np.full((nb_surfaces), opacity)
-    elif opacity.shape != (nb_surfaces,):
-        raise ValueError("Incorrect opacity array shape")
-
     if color is None:
         color = np.random.rand(nb_surfaces, 3)
-    elif color.shape != (nb_surfaces, 3):
+    elif color.shape[0] != nb_surfaces or color.shape[1] < 3:
         raise ValueError("Incorrect color array shape")
+
+    if color.shape[1] == 4:
+        opacity = color[:, -1]
+        color = color[:, :-1]
+    else:
+        opacity = np.ones((nb_surfaces, 1)).astype(np.float)
 
     for roi_id in unique_roi_id:
         roi_data = np.isin(data, roi_id).astype(np.int)

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -445,7 +445,7 @@ def contour_from_roi(data, affine=None,
 
 
 def contour_from_label(data, affine=None,
-                       color=None, opacity=1):
+                       color=None, opacity=None):
     """Generate surface actor from a binary labeled Array.
 
     The color and opacity of the individual surfaces can be customized.
@@ -473,16 +473,25 @@ def contour_from_label(data, affine=None,
 
     unique_roi_id = np.delete(np.unique(data), 0)
 
+    nb_surfaces = len(unique_roi_id)
+
     unique_roi_surfaces = vtk.vtkAssembly()
 
+    if opacity is None:
+        opacity = np.ones((nb_surfaces, 1))
+    elif isinstance(opacity, (float, int)):
+        opacity = np.full((nb_surfaces, 1), opacity).flatten()
+    elif opacity.shape != (nb_surfaces, 1):
+        raise ValueError("Incorrect opacity array shape")
+
     if color is None:
-        color = np.random.rand(len(unique_roi_id), 3)
-    elif color.shape != (len(unique_roi_id), 3):
+        color = np.random.rand(nb_surfaces, 3)
+    elif color.shape != (nb_surfaces, 3):
         raise ValueError("Incorrect color array shape")
 
-    for i, roi_id in enumerate(unique_roi_id):
+    for roi_id in unique_roi_id:
         roi_data = np.isin(data, roi_id).astype(np.int)
-        roi_surface = contour_from_roi(roi_data, affine, color=color[i], opacity=opacity)
+        roi_surface = contour_from_roi(roi_data, affine, color=color[int(roi_id)-1], opacity=opacity[int(roi_id)-1])
         unique_roi_surfaces.AddPart(roi_surface)
 
     return unique_roi_surfaces

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -445,7 +445,7 @@ def contour_from_roi(data, affine=None,
 
 
 def contour_from_label(data, affine=None,
-                       color=np.array([1, 0, 0]), opacity=1):
+                       color=None, opacity=1):
     """Generate surface actor from a binary labeled Array.
 
     The color and opacity of the surface can be customized.
@@ -457,8 +457,9 @@ def contour_from_label(data, affine=None,
     affine : array, shape (4, 4)
         Grid to space (usually RAS 1mm) transformation matrix. Default is None.
         If None then the identity matrix is used.
-    color : (1, 3) ndarray
-        RGB values in [0,1].
+    color : (N, 3) ndarray
+        RGB values in [0,1]. Default is None.
+        If None then random colors are used.
     opacity : float
         Opacity of surface between 0 and 1.
 
@@ -476,6 +477,11 @@ def contour_from_label(data, affine=None,
 
     unique_roi_id = np.unique(data)
 
+    if color is None:
+        color = np.random.rand(len(unique_roi_id), 3)
+    elif color.shape != (len(unique_roi_id), 3):
+        raise ValueError("Incorrect color array shape")
+    
     if affine is None:
         affine = np.eye(4)
 

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -493,7 +493,9 @@ def contour_from_label(data, affine=None,
 
     for roi_id in unique_roi_id:
         roi_data = np.isin(data, roi_id).astype(np.int)
-        roi_surface = contour_from_roi(roi_data, affine, color=color[int(roi_id)-1], opacity=opacity[int(roi_id)-1])
+        roi_surface = contour_from_roi(roi_data, affine,
+                                       color=color[int(roi_id)-1],
+                                       opacity=opacity[int(roi_id)-1])
         unique_roi_surfaces.AddPart(roi_surface)
 
     return unique_roi_surfaces

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -443,6 +443,7 @@ def contour_from_roi(data, affine=None,
 
     return skin_actor
 
+
 def contour_from_label(data, affine=None,
                        color=np.array([1, 0, 0]), opacity=1):
     """Generate surface actor from a binary labeled Array.
@@ -476,10 +477,11 @@ def contour_from_label(data, affine=None,
         if roi_id != 0:
             roi_surface = np.isin(data, roi_id)
             roi_surface = roi_surface * 1
-            roi_surface = contour_from_roi(roi_surface, affine, color=color, opacity=opacity)
+            roi_surface = contour_from_roi(roi_surface, affine, color, opacity)
             unique_roi_surfaces.append(roi_surface)
 
     return tuple(unique_roi_surfaces)
+
 
 def streamtube(lines, colors="RGB", opacity=1, linewidth=0.1, tube_sides=9,
                lod=True, lod_points=10 ** 4, lod_points_size=3,

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -459,6 +459,7 @@ def contour_from_label(data, affine=None, color=None):
     color : (N, 3) or (N, 4) ndarray
         RGB/RGBA values in [0,1]. Default is None.
         If None then random colors are used.
+        Alpha channel is set to 1 by default.
 
     Returns
     -------
@@ -476,10 +477,10 @@ def contour_from_label(data, affine=None, color=None):
 
     if color is None:
         color = np.random.rand(nb_surfaces, 3)
-    elif color.shape[0] != nb_surfaces or color.shape[1] < 3:
+    elif color.shape != (nb_surfaces, 3) and color.shape != (nb_surfaces, 4):
         raise ValueError("Incorrect color array shape")
 
-    if color.shape[1] == 4:
+    if color.shape == (nb_surfaces, 4):
         opacity = color[:, -1]
         color = color[:, :-1]
     else:

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -448,7 +448,7 @@ def contour_from_label(data, affine=None,
                        color=None, opacity=1):
     """Generate surface actor from a binary labeled Array.
 
-    The color and opacity of the surface can be customized.
+    The color and opacity of the individual surfaces can be customized.
 
     Parameters
     ----------
@@ -470,90 +470,22 @@ def contour_from_label(data, affine=None,
         coordinates as calculated by the affine parameter
         in the order of their roi ids.
     """
-    if data.ndim != 3:
-        raise ValueError('Only 3D arrays are currently supported.')
-    else:
-        nb_components = 1
 
-    unique_roi_id = np.unique(data)
+    unique_roi_id = np.delete(np.unique(data), 0)
+
+    unique_roi_surfaces = vtk.vtkAssembly()
 
     if color is None:
         color = np.random.rand(len(unique_roi_id), 3)
     elif color.shape != (len(unique_roi_id), 3):
         raise ValueError("Incorrect color array shape")
 
-    if affine is None:
-        affine = np.eye(4)
-
-    # Set the transform (identity if none given)
-    transform = vtk.vtkTransform()
-    transform_matrix = vtk.vtkMatrix4x4()
-    transform_matrix.DeepCopy((
-        affine[0][0], affine[0][1], affine[0][2], affine[0][3],
-        affine[1][0], affine[1][1], affine[1][2], affine[1][3],
-        affine[2][0], affine[2][1], affine[2][2], affine[2][3],
-        affine[3][0], affine[3][1], affine[3][2], affine[3][3]))
-    transform.SetMatrix(transform_matrix)
-    transform.Inverse()
-
-    skin_extractor = vtk.vtkContourFilter()
-
     for i, roi_id in enumerate(unique_roi_id):
-        if roi_id == 0:
-            continue
         roi_data = np.isin(data, roi_id).astype(np.int)
+        roi_surface = contour_from_roi(roi_data, affine, color=color[i], opacity=opacity)
+        unique_roi_surfaces.AddPart(roi_surface)
 
-        vol = np.interp(roi_data,
-                        xp=[roi_data.min(), roi_data.max()], fp=[0, 255])
-        vol = vol.astype('uint8')
-
-        im = vtk.vtkImageData()
-        di, dj, dk = vol.shape[:3]
-        im.SetDimensions(di, dj, dk)
-        voxsz = (1., 1., 1.)
-        # im.SetOrigin(0,0,0)
-        im.SetSpacing(voxsz[2], voxsz[0], voxsz[1])
-        im.AllocateScalars(vtk.VTK_UNSIGNED_CHAR, nb_components)
-
-        vol = np.swapaxes(vol, 0, 2)
-        vol = np.ascontiguousarray(vol)
-
-        vol = vol.ravel()
-
-        uchar_array = numpy_support.numpy_to_vtk(vol, deep=0)
-        im.GetPointData().SetScalars(uchar_array)
-
-        image_resliced = vtk.vtkImageReslice()
-        set_input(image_resliced, im)
-        image_resliced.SetResliceTransform(transform)
-        image_resliced.AutoCropOutputOn()
-
-        rzs = affine[:3, :3]
-        zooms = np.sqrt(np.sum(rzs * rzs, axis=0))
-        image_resliced.SetOutputSpacing(*zooms)
-
-        image_resliced.SetInterpolationModeToLinear()
-        image_resliced.Update()
-
-        skin_extractor.SetInputData(image_resliced.GetOutput())
-        skin_extractor.SetValue(i, roi_id)
-
-    skin_normals = vtk.vtkPolyDataNormals()
-    skin_normals.SetInputConnection(skin_extractor.GetOutputPort())
-    skin_normals.SetFeatureAngle(60.0)
-
-    skin_mapper = vtk.vtkPolyDataMapper()
-    skin_mapper.SetInputConnection(skin_normals.GetOutputPort())
-    skin_mapper.ScalarVisibilityOff()
-
-    skin_actor = vtk.vtkActor()
-
-    skin_actor.SetMapper(skin_mapper)
-    skin_actor.GetProperty().SetOpacity(opacity)
-
-    skin_actor.GetProperty().SetColor(color[0], color[1], color[2])
-
-    return skin_actor
+    return unique_roi_surfaces
 
 
 def streamtube(lines, colors="RGB", opacity=1, linewidth=0.1, tube_sides=9,

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -495,9 +495,10 @@ def contour_from_label(data, affine=None,
     for i, roi_id in enumerate(unique_roi_id):
         if roi_id != 0:
             roi_data = np.isin(data, roi_id)
-            
+
             roi_data = roi_data * 1
-            vol = np.interp(roi_data, xp=[roi_data.min(), roi_data.max()], fp=[0, 255])
+            vol = np.interp(roi_data,
+                            xp=[roi_data.min(), roi_data.max()], fp=[0, 255])
             vol = vol.astype('uint8')
 
             vol = vol.ravel()
@@ -523,7 +524,7 @@ def contour_from_label(data, affine=None,
             image_resliced.SetOutputSpacing(*zooms)
 
             image_resliced.SetInterpolationModeToLinear()
-            image_resliced.Update()            
+            image_resliced.Update()
 
             skin_extractor.SetInputData(image_resliced.GetOutput())
             skin_extractor.SetValue(i, roi_id)

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -448,7 +448,7 @@ def contour_from_label(data, affine=None,
                        color=None, opacity=None):
     """Generate surface actor from a binary labeled Array.
 
-    The color and opacity of the individual surfaces can be customized.
+    The color and opacity of individual surfaces can be customized.
 
     Parameters
     ----------
@@ -460,13 +460,15 @@ def contour_from_label(data, affine=None,
     color : (N, 3) ndarray
         RGB values in [0,1]. Default is None.
         If None then random colors are used.
-    opacity : float
-        Opacity of surface between 0 and 1.
+    opacity : float or (N, 1) ndarray
+        Opacity of surface between 0 and 1. Default is None
+        if opacity is numeric, same value is applied to all surfaces.
+        if opacity is None, then 1.0 is used by default for all surfaces.
 
     Returns
     -------
     contour_assembly : vtkAssembly
-        Tuple of Array surface object displayed in space
+        Array surface object displayed in space
         coordinates as calculated by the affine parameter
         in the order of their roi ids.
     """
@@ -478,7 +480,7 @@ def contour_from_label(data, affine=None,
     unique_roi_surfaces = vtk.vtkAssembly()
 
     if opacity is None:
-        opacity = np.ones((nb_surfaces, 1))
+        opacity = np.ones((nb_surfaces, 1)).astype(np.float)
     elif isinstance(opacity, (float, int)):
         opacity = np.full((nb_surfaces, 1), opacity).flatten()
     elif opacity.shape != (nb_surfaces, 1):

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -460,7 +460,7 @@ def contour_from_label(data, affine=None,
     color : (N, 3) ndarray
         RGB values in [0,1]. Default is None.
         If None then random colors are used.
-    opacity : float or (N, 1) ndarray
+    opacity : float or (N,) ndarray
         Opacity of surface between 0 and 1. Default is None
         if opacity is numeric, same value is applied to all surfaces.
         if opacity is None, then 1.0 is used by default for all surfaces.
@@ -482,8 +482,8 @@ def contour_from_label(data, affine=None,
     if opacity is None:
         opacity = np.ones((nb_surfaces, 1)).astype(np.float)
     elif isinstance(opacity, (float, int)):
-        opacity = np.full((nb_surfaces, 1), opacity).flatten()
-    elif opacity.shape != (nb_surfaces, 1):
+        opacity = np.full((nb_surfaces), opacity)
+    elif opacity.shape != (nb_surfaces,):
         raise ValueError("Incorrect opacity array shape")
 
     if color is None:

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -443,6 +443,43 @@ def contour_from_roi(data, affine=None,
 
     return skin_actor
 
+def contour_from_label(data, affine=None,
+                       color=np.array([1, 0, 0]), opacity=1):
+    """Generate surface actor from a binary labeled Array.
+
+    The color and opacity of the surface can be customized.
+
+    Parameters
+    ----------
+    data : array, shape (X, Y, Z)
+        A labeled array file that will be binarized and displayed.
+    affine : array, shape (4, 4)
+        Grid to space (usually RAS 1mm) transformation matrix. Default is None.
+        If None then the identity matrix is used.
+    color : (1, 3) ndarray
+        RGB values in [0,1].
+    opacity : float
+        Opacity of surface between 0 and 1.
+
+    Returns
+    -------
+    tuple of contour_assembly : vtkAssembly
+        Tuple of Array surface object displayed in space
+        coordinates as calculated by the affine parameter
+        in the order of their roi ids.
+    """
+    unique_roi_surfaces = []
+
+    unique_roi_id = np.unique(data)
+
+    for roi_id in unique_roi_id:
+        if roi_id != 0:
+            roi_surface = np.isin(data, roi_id)
+            roi_surface = roi_surface * 1
+            roi_surface = contour_from_roi(roi_surface, affine, color=color, opacity=opacity)
+            unique_roi_surfaces.append(roi_surface)
+
+    return tuple(unique_roi_surfaces)
 
 def streamtube(lines, colors="RGB", opacity=1, linewidth=0.1, tube_sides=9,
                lod=True, lod_points=10 ** 4, lod_points_size=3,

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -481,7 +481,7 @@ def contour_from_label(data, affine=None,
         color = np.random.rand(len(unique_roi_id), 3)
     elif color.shape != (len(unique_roi_id), 3):
         raise ValueError("Incorrect color array shape")
-    
+
     if affine is None:
         affine = np.eye(4)
 

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -501,8 +501,6 @@ def contour_from_label(data, affine=None,
                         xp=[roi_data.min(), roi_data.max()], fp=[0, 255])
         vol = vol.astype('uint8')
 
-        vol = vol.ravel()
-
         im = vtk.vtkImageData()
         di, dj, dk = vol.shape[:3]
         im.SetDimensions(di, dj, dk)
@@ -510,6 +508,11 @@ def contour_from_label(data, affine=None,
         # im.SetOrigin(0,0,0)
         im.SetSpacing(voxsz[2], voxsz[0], voxsz[1])
         im.AllocateScalars(vtk.VTK_UNSIGNED_CHAR, nb_components)
+
+        vol = np.swapaxes(vol, 0, 2)
+        vol = np.ascontiguousarray(vol)
+
+        vol = vol.ravel()
 
         uchar_array = numpy_support.numpy_to_vtk(vol, deep=0)
         im.GetPointData().SetScalars(uchar_array)

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -464,23 +464,86 @@ def contour_from_label(data, affine=None,
 
     Returns
     -------
-    tuple of contour_assembly : vtkAssembly
+    contour_assembly : vtkAssembly
         Tuple of Array surface object displayed in space
         coordinates as calculated by the affine parameter
         in the order of their roi ids.
     """
-    unique_roi_surfaces = []
+    if data.ndim != 3:
+        raise ValueError('Only 3D arrays are currently supported.')
+    else:
+        nb_components = 1
 
     unique_roi_id = np.unique(data)
 
-    for roi_id in unique_roi_id:
-        if roi_id != 0:
-            roi_surface = np.isin(data, roi_id)
-            roi_surface = roi_surface * 1
-            roi_surface = contour_from_roi(roi_surface, affine, color, opacity)
-            unique_roi_surfaces.append(roi_surface)
+    if affine is None:
+        affine = np.eye(4)
 
-    return tuple(unique_roi_surfaces)
+    # Set the transform (identity if none given)
+    transform = vtk.vtkTransform()
+    transform_matrix = vtk.vtkMatrix4x4()
+    transform_matrix.DeepCopy((
+        affine[0][0], affine[0][1], affine[0][2], affine[0][3],
+        affine[1][0], affine[1][1], affine[1][2], affine[1][3],
+        affine[2][0], affine[2][1], affine[2][2], affine[2][3],
+        affine[3][0], affine[3][1], affine[3][2], affine[3][3]))
+    transform.SetMatrix(transform_matrix)
+    transform.Inverse()
+
+    skin_extractor = vtk.vtkContourFilter()
+
+    for i, roi_id in enumerate(unique_roi_id):
+        if roi_id != 0:
+            roi_data = np.isin(data, roi_id)
+            
+            roi_data = roi_data * 1
+            vol = np.interp(roi_data, xp=[roi_data.min(), roi_data.max()], fp=[0, 255])
+            vol = vol.astype('uint8')
+
+            vol = vol.ravel()
+
+            im = vtk.vtkImageData()
+            di, dj, dk = vol.shape[:3]
+            im.SetDimensions(di, dj, dk)
+            voxsz = (1., 1., 1.)
+            # im.SetOrigin(0,0,0)
+            im.SetSpacing(voxsz[2], voxsz[0], voxsz[1])
+            im.AllocateScalars(vtk.VTK_UNSIGNED_CHAR, nb_components)
+
+            uchar_array = numpy_support.numpy_to_vtk(vol, deep=0)
+            im.GetPointData().SetScalars(uchar_array)
+
+            image_resliced = vtk.vtkImageReslice()
+            set_input(image_resliced, im)
+            image_resliced.SetResliceTransform(transform)
+            image_resliced.AutoCropOutputOn()
+
+            rzs = affine[:3, :3]
+            zooms = np.sqrt(np.sum(rzs * rzs, axis=0))
+            image_resliced.SetOutputSpacing(*zooms)
+
+            image_resliced.SetInterpolationModeToLinear()
+            image_resliced.Update()            
+
+            skin_extractor.SetInputData(image_resliced.GetOutput())
+            skin_extractor.SetValue(i, roi_id)
+
+    skin_normals = vtk.vtkPolyDataNormals()
+    skin_normals.SetInputConnection(skin_extractor.GetOutputPort())
+    skin_normals.SetFeatureAngle(60.0)
+
+    skin_mapper = vtk.vtkPolyDataMapper()
+    skin_mapper.SetInputConnection(skin_normals.GetOutputPort())
+    skin_mapper.ScalarVisibilityOff()
+
+    skin_actor = vtk.vtkActor()
+
+    skin_actor.SetMapper(skin_mapper)
+    skin_actor.GetProperty().SetOpacity(opacity)
+
+    skin_actor.GetProperty().SetColor(color[0], color[1], color[2])
+
+    return skin_actor
 
 
 def streamtube(lines, colors="RGB", opacity=1, linewidth=0.1, tube_sides=9,

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -353,8 +353,10 @@ def test_contour_from_label():
     scene2.reset_clipping_range()
     # window.show(scene2)
 
-    arr = window.snapshot(scene, 'test_surface.png', offscreen=True)
-    arr2 = window.snapshot(scene2, 'test_surface2.png', offscreen=True)
+    arr = window.snapshot(scene, 'test_surface.png', offscreen=True,
+                          order_transparent=True)
+    arr2 = window.snapshot(scene2, 'test_surface2.png', offscreen=True,
+                           order_transparent=True)
 
     report = window.analyze_snapshot(arr, find_objects=True)
     report2 = window.analyze_snapshot(arr2, find_objects=True)

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -309,6 +309,64 @@ def test_contour_from_roi():
         # window.show(r)
         # window.show(r2)
 
+def test_contour_from_label():
+    
+    # Render volumne
+    scene = window.Scene()
+    data = np.zeros((50, 50, 50))
+    data[15:20, 25, 25] = 1.
+    data[25, 20:30, 25] = 2.
+    data[25, 40:50, 30:50] = 3.
+
+    color = np.array(
+        [[1, 0, 0],
+         [0, 1, 0],
+         [0, 0, 1]])
+
+    opacity = 0.6
+
+    surface = actor.contour_from_label(data, color=color, opacity=opacity)
+
+    scene.add(surface)
+    scene.reset_camera()
+    scene.reset_clipping_range()
+    # window.show(scene)
+
+    # Test Errors
+    with npt.assert_raises(ValueError):
+        actor.contour_from_label(data, opacity=np.array([1, 2, 3, 4]))
+        actor.contour_from_label(data, color=np.array([1, 2, 3]))
+        actor.contour_from_label(np.ones(50))
+
+    # Test binarization
+    scene2 = window.Scene()
+    data2 = np.zeros((50, 50, 50))
+    data2[25, 25, 15:20] = 1.
+    data2[25, 30:50, 20] = 2.
+    data2[30:50, 25, 30] = 3.
+
+    color2 = np.array(
+        [[1, 0, 1],
+         [1, 1, 0],
+         [0, 1, 1]])
+
+    opacity2 = np.array([1, 0.5, 0.3])
+
+    surface2 = actor.contour_from_label(data2, color=color2, opacity=opacity2)
+
+    scene2.add(surface2)
+    scene2.reset_camera()
+    scene2.reset_clipping_range()
+    # window.show(scene2)
+
+    arr = window.snapshot(scene, 'test_surface.png', offscreen=True)
+    arr2 = window.snapshot(scene2, 'test_surface2.png', offscreen=True)
+
+    report = window.analyze_snapshot(arr, find_objects=True)
+    report2 = window.analyze_snapshot(arr2, find_objects=True)
+
+    npt.assert_equal(report.objects, 3)
+    npt.assert_equal(report2.objects, 3)
 
 def test_streamtube_and_line_actors():
     scene = window.Scene()

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -309,8 +309,9 @@ def test_contour_from_roi():
         # window.show(r)
         # window.show(r2)
 
+
 def test_contour_from_label():
-    
+
     # Render volumne
     scene = window.Scene()
     data = np.zeros((50, 50, 50))
@@ -367,6 +368,7 @@ def test_contour_from_label():
 
     npt.assert_equal(report.objects, 3)
     npt.assert_equal(report2.objects, 3)
+
 
 def test_streamtube_and_line_actors():
     scene = window.Scene()

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -364,6 +364,8 @@ def test_contour_from_label():
     npt.assert_equal(report.objects, 3)
     npt.assert_equal(report2.objects, 1)
 
+    actor.test_contour_from_label(data)
+
 
 def test_streamtube_and_line_actors():
     scene = window.Scene()

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -320,13 +320,11 @@ def test_contour_from_label():
     data[25, 40:50, 30:50] = 3.
 
     color = np.array(
-        [[1, 0, 0],
-         [0, 1, 0],
-         [0, 0, 1]])
+        [[1, 0, 0, 0.6],
+         [0, 1, 0, 0.5],
+         [0, 0, 1, 1.0]])
 
-    opacity = 0.6
-
-    surface = actor.contour_from_label(data, color=color, opacity=opacity)
+    surface = actor.contour_from_label(data, color=color)
 
     scene.add(surface)
     scene.reset_camera()
@@ -335,25 +333,20 @@ def test_contour_from_label():
 
     # Test Errors
     with npt.assert_raises(ValueError):
-        actor.contour_from_label(data, opacity=np.array([1, 2, 3, 4]))
         actor.contour_from_label(data, color=np.array([1, 2, 3]))
         actor.contour_from_label(np.ones(50))
 
     # Test binarization
     scene2 = window.Scene()
     data2 = np.zeros((50, 50, 50))
-    data2[25, 25, 15:20] = 1.
-    data2[25, 30:50, 20] = 2.
-    data2[30:50, 25, 30] = 3.
+    data2[20:30, 25, 25] = 1.
+    data2[25, 20:30, 25] = 2.
 
     color2 = np.array(
         [[1, 0, 1],
-         [1, 1, 0],
-         [0, 1, 1]])
+         [1, 1, 0]])
 
-    opacity2 = np.array([1, 0.5, 0.3])
-
-    surface2 = actor.contour_from_label(data2, color=color2, opacity=opacity2)
+    surface2 = actor.contour_from_label(data2, color=color2)
 
     scene2.add(surface2)
     scene2.reset_camera()
@@ -367,7 +360,7 @@ def test_contour_from_label():
     report2 = window.analyze_snapshot(arr2, find_objects=True)
 
     npt.assert_equal(report.objects, 3)
-    npt.assert_equal(report2.objects, 3)
+    npt.assert_equal(report2.objects, 1)
 
 
 def test_streamtube_and_line_actors():

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -364,7 +364,7 @@ def test_contour_from_label():
     npt.assert_equal(report.objects, 3)
     npt.assert_equal(report2.objects, 1)
 
-    actor.test_contour_from_label(data)
+    actor.contour_from_label(data)
 
 
 def test_streamtube_and_line_actors():


### PR DESCRIPTION
# Overview
In reference to issue #77 
* Takes `Labeled Array`, `affine`, `colors` and `opacity` as arguments for individual surfaces.
* Extracts unique _Regions of Interest_ from the labeled array.
* Generates unique **ROI** surfaces and returns them in a vtkAssembly instance in order of their label IDs.