### PR TITLE
bumping scipy version to 1.2.0

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,5 @@
 # List required packages in this file, one per line.
 numpy>=1.7.1
 vtk>=8.1.2
-scipy>=0.9
+scipy>=1.2.0
 pillow>=5.4.1


### PR DESCRIPTION
Referencing #219 , bumping minimum scipy version requirement from `0.9` to `1.2.0` for fixing `scipy.spatial.transform` module not found error.