### PR TITLE
[Fix] update streamlines default color

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-.. image:: https://travis-ci.org/fury-gl/fury.svg?branch=master
-        :target: https://travis-ci.org/fury-gl/fury
+.. image:: https://travis-ci.com/fury-gl/fury.svg?branch=master
+        :target: https://travis-ci.com/fury-gl/fury
 
 .. image:: https://dev.azure.com/fury-gl/fury/_apis/build/status/fury-gl.fury?branchName=master
         :target: https://dev.azure.com/fury-gl/fury/_build/latest?definitionId=1&branchName=master

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -496,7 +496,7 @@ def contour_from_label(data, affine=None, color=None):
     return unique_roi_surfaces
 
 
-def streamtube(lines, colors="RGB", opacity=1, linewidth=0.1, tube_sides=9,
+def streamtube(lines, colors=None, opacity=1, linewidth=0.1, tube_sides=9,
                lod=True, lod_points=10 ** 4, lod_points_size=3,
                spline_subdiv=None, lookup_colormap=None):
     """Use streamtubes to visualize polylines
@@ -506,9 +506,9 @@ def streamtube(lines, colors="RGB", opacity=1, linewidth=0.1, tube_sides=9,
     lines : list
         list of N curves represented as 2D ndarrays
 
-    colors : array (N, 3), list of arrays, tuple (3,), array (K,), "RGB"
-        If None or False, no coloring is done
-        If "RGB" then a standard orientation colormap is used for every line.
+    colors : array (N, 3), list of arrays, tuple (3,), array (K,)
+        If None or False, a standard orientation colormap is used for every
+        line.
         If one tuple of color is used. Then all streamlines will have the same
         colour.
         If an array (N, 3) is given, where N is equal to the number of lines.
@@ -641,7 +641,7 @@ def streamtube(lines, colors="RGB", opacity=1, linewidth=0.1, tube_sides=9,
     return actor
 
 
-def line(lines, colors="RGB", opacity=1, linewidth=1,
+def line(lines, colors=None, opacity=1, linewidth=1,
          spline_subdiv=None, lod=True, lod_points=10 ** 4, lod_points_size=3,
          lookup_colormap=None, depth_cue=False, fake_tube=False):
     """ Create an actor for one or more lines.
@@ -650,9 +650,9 @@ def line(lines, colors="RGB", opacity=1, linewidth=1,
     ------------
     lines :  list of arrays
 
-    colors : array (N, 3), list of arrays, tuple (3,), array (K,), "RGB"
-        If None or False, no coloring is done
-        If "RGB" then a standard orientation colormap is used for every line.
+    colors : array (N, 3), list of arrays, tuple (3,), array (K,)
+        If None or False, a standard orientation colormap is used for every
+        line.
         If one tuple of color is used. Then all streamlines will have the same
         colour.
         If an array (N, 3) is given, where N is equal to the number of lines.

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -110,16 +110,16 @@ def map_coordinates_3d_4d(input_array, indices):
         return np.ascontiguousarray(np.array(values_4d).T)
 
 
-def lines_to_vtk_polydata(lines, colors="RGB"):
+def lines_to_vtk_polydata(lines, colors=None):
     """Create a vtkPolyData with lines and colors.
 
     Parameters
     ----------
     lines : list
         list of N curves represented as 2D ndarrays
-    colors : array (N, 3), list of arrays, tuple (3,), array (K,), "RGB"
-        If None or False, no coloring is done
-        If "RGB" then a standard orientation colormap is used for every line.
+    colors : array (N, 3), list of arrays, tuple (3,), array (K,)
+        If None or False, a standard orientation colormap is used for every
+        line.
         If one tuple of color is used. Then all streamlines will have the same
         colour.
         If an array (N, 3) is given, where N is equal to the number of lines.
@@ -188,9 +188,6 @@ def lines_to_vtk_polydata(lines, colors="RGB"):
     #           - if/else tested and work in normal simple case
     color_is_scalar = False
     if colors is None or colors is False:
-        # No color array is used
-        return poly_data, None
-    elif isinstance(colors, str) and colors.lower() == "rgb":
         # set automatic rgb colors
         cols_arr = line_colors(lines)
         colors_mapper = np.repeat(lines_range, points_per_line, axis=0)


### PR DESCRIPTION
Due to backward compatibilities, I revert a previous change. By default, the streamlines will be colored with a standard orientation colormap instead of no color.

fix #135