### PR TITLE
Function to use Hexadecimal color code in Colormap

### DIFF
--- a/fury/colormap.py
+++ b/fury/colormap.py
@@ -593,7 +593,7 @@ def distinguishable_colormap(bg=(0, 0, 0), exclude=[], nb_colors=None):
     return _generate_next_color()
 
 
-def hex_to_color(color):
+def hex_to_rgb(color):
     # Converts Hexadecimal color code to rgb()
     if color[0] == "#":
         color = color[1:]

--- a/fury/colormap.py
+++ b/fury/colormap.py
@@ -598,8 +598,8 @@ def hex_to_rgb(color):
     if color[0] == "#":
         color = color[1:]
 
-    r = int("0x" + color[0: 2], 0) / 256
-    g = int("0x" + color[2: 4], 0) / 256
-    b = int("0x" + color[4: 6], 0) / 256
+    r = int("0x" + color[0: 2], 0) / 255
+    g = int("0x" + color[2: 4], 0) / 255
+    b = int("0x" + color[4: 6], 0) / 255
 
     return(np.array([r, g, b]))

--- a/fury/colormap.py
+++ b/fury/colormap.py
@@ -591,3 +591,14 @@ def distinguishable_colormap(bg=(0, 0, 0), exclude=[], nb_colors=None):
         return [c for i, c in zip(range(nb_colors), _generate_next_color())]
 
     return _generate_next_color()
+
+def hex_to_color(color):
+    #Converts Hexadecimal color code to rgb()
+    if color[0] == "#":
+        color = color[1:]
+
+    r = int("0x" + color[0: 2], 0) / 256
+    g = int("0x" + color[2: 4], 0) / 256
+    b = int("0x" + color[4: 6], 0) / 256
+
+    return(np.array([r, g, b]))

--- a/fury/colormap.py
+++ b/fury/colormap.py
@@ -592,8 +592,9 @@ def distinguishable_colormap(bg=(0, 0, 0), exclude=[], nb_colors=None):
 
     return _generate_next_color()
 
+
 def hex_to_color(color):
-    #Converts Hexadecimal color code to rgb()
+    # Converts Hexadecimal color code to rgb()
     if color[0] == "#":
         color = color[1:]
 

--- a/fury/colormap.py
+++ b/fury/colormap.py
@@ -594,7 +594,27 @@ def distinguishable_colormap(bg=(0, 0, 0), exclude=[], nb_colors=None):
 
 
 def hex_to_rgb(color):
-    # Converts Hexadecimal color code to rgb()
+    """Converts Hexadecimal color code to rgb()
+    
+    color : string containting hexcode of color (can also start with a hash)
+    
+    Returns
+    -------
+    c : array, shape(1, 3) matrix of rbg colors corresponding to the 
+        hexcode string given in color.
+    
+    Examples
+    --------
+    >>> from fury import colormap
+    >>> color = "#FFFFFF"
+    >>> c = colormap.hex_to_rgb(color)
+    
+   
+    >>> from fury import colormap
+    >>> color = "FFFFFF"
+    >>> c = colormap.hex_to_rgb(color)
+    
+    """
     if color[0] == "#":
         color = color[1:]
 

--- a/fury/tests/test_colormap.py
+++ b/fury/tests/test_colormap.py
@@ -121,4 +121,4 @@ def test_hex_to_rgb():
     expected = np.array([0.99609375, 0.99609375, 0.99609375])
     hexcode = "#FFFFFF"
     res = colormap.hex_to_rgb(hexcode)
-    npt.asset_array_almost_equal(res, expected)
+    npt.assert_array_almost_equal(res, expected)

--- a/fury/tests/test_colormap.py
+++ b/fury/tests/test_colormap.py
@@ -115,7 +115,8 @@ def test_lab2rgb():
     res = np.round(colormap._lab2rgb(lab_color))
     res[res < 0] = 0
     npt.assert_array_almost_equal(res, expected)
- 
+
+
 def test_hex_to_rgb():
     expected = np.array([1, 1, 1])
     hexcode = "#FFFFFF"

--- a/fury/tests/test_colormap.py
+++ b/fury/tests/test_colormap.py
@@ -115,3 +115,9 @@ def test_lab2rgb():
     res = np.round(colormap._lab2rgb(lab_color))
     res[res < 0] = 0
     npt.assert_array_almost_equal(res, expected)
+ 
+def test_hex_to_rgb():
+    expected = np.array([1, 1, 1])
+    hexcode = "#FFFFFF"
+    res = colormap.hex_to_rgb(hexcode)
+    npt.asset_array_almost_equal(res, expected)

--- a/fury/tests/test_colormap.py
+++ b/fury/tests/test_colormap.py
@@ -118,7 +118,12 @@ def test_lab2rgb():
 
 
 def test_hex_to_rgb():
-    expected = np.array([0.99609375, 0.99609375, 0.99609375])
+    expected = np.array([1, 1, 1])
+    
     hexcode = "#FFFFFF"
     res = colormap.hex_to_rgb(hexcode)
+    npt.assert_array_almost_equal(res, expected)
+    
+    hashed_hexcode = "FFFFFF"
+    res = colormap.hex_to_rgb(hashed_hexcode)
     npt.assert_array_almost_equal(res, expected)

--- a/fury/tests/test_colormap.py
+++ b/fury/tests/test_colormap.py
@@ -118,7 +118,7 @@ def test_lab2rgb():
 
 
 def test_hex_to_rgb():
-    expected = np.array([1, 1, 1])
+    expected = np.array([0.99609375, 0.99609375, 0.99609375])
     hexcode = "#FFFFFF"
     res = colormap.hex_to_rgb(hexcode)
     npt.asset_array_almost_equal(res, expected)


### PR DESCRIPTION
Here is a cleaner PR for #216 

This function will allow users to use hexadecimal color throughout FURY instead of rgb.

Type: Enhancement
Improves User usability.

