### PR TITLE
[FIX]  Compatibility with VTK 9

### DIFF
--- a/fury/actor.py
+++ b/fury/actor.py
@@ -412,7 +412,6 @@ def contour_from_roi(data, affine=None,
     skin_extractor.SetInputData(image_resliced.GetOutput())
 
     skin_extractor.SetValue(0, 1)
-
     skin_normals = vtk.vtkPolyDataNormals()
     skin_normals.SetInputConnection(skin_extractor.GetOutputPort())
     skin_normals.SetFeatureAngle(60.0)
@@ -424,9 +423,8 @@ def contour_from_roi(data, affine=None,
     skin_actor = vtk.vtkActor()
 
     skin_actor.SetMapper(skin_mapper)
-    skin_actor.GetProperty().SetOpacity(opacity)
-
     skin_actor.GetProperty().SetColor(color[0], color[1], color[2])
+    skin_actor.GetProperty().SetOpacity(opacity)
 
     return skin_actor
 
@@ -473,11 +471,11 @@ def contour_from_label(data, affine=None, color=None):
     else:
         opacity = np.ones((nb_surfaces, 1)).astype(np.float)
 
-    for roi_id in unique_roi_id:
+    for i, roi_id in enumerate(unique_roi_id):
         roi_data = np.isin(data, roi_id).astype(np.int)
         roi_surface = contour_from_roi(roi_data, affine,
-                                       color=color[int(roi_id)-1],
-                                       opacity=opacity[int(roi_id)-1])
+                                       color=color[i],
+                                       opacity=opacity[i])
         unique_roi_surfaces.AddPart(roi_surface)
 
     return unique_roi_surfaces

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -309,8 +309,14 @@ def surface(vertices, faces=None, colors=None, smooth=None, subdivision=3):
         triangles = np.ascontiguousarray(triangles, 'int64')
 
     cells = vtk.vtkCellArray()
-    cells.SetCells(triangles.shape[0],
-                   numpy_support.numpy_to_vtkIdTypeArray(triangles, deep=True))
+    if vtk.vtkVersion.GetVTKMajorVersion() >= 9:
+        cells.SetData(
+            triangles.shape[0],
+            numpy_support.numpy_to_vtkIdTypeArray(triangles, deep=True))
+    else:
+        cells.SetCells(
+            triangles.shape[0],
+            numpy_support.numpy_to_vtkIdTypeArray(triangles, deep=True))
     triangle_poly_data.SetPolys(cells)
 
     clean_poly_data = vtk.vtkCleanPolyData()
@@ -998,7 +1004,10 @@ def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
     points.SetData(all_xyz_vtk)
 
     cells = vtk.vtkCellArray()
-    cells.SetCells(ncells, all_faces_vtk)
+    if vtk.vtkVersion.GetVTKMajorVersion() >= 9:
+        cells.SetData(ncells, all_faces_vtk)
+    else:
+        cells.SetCells(ncells, all_faces_vtk)
 
     if global_cm:
         if colormap is None:
@@ -1217,7 +1226,10 @@ def _tensor_slicer_mapper(evals, evecs, affine=None, mask=None, sphere=None,
     points.SetData(all_xyz_vtk)
 
     cells = vtk.vtkCellArray()
-    cells.SetCells(ncells, all_faces_vtk)
+    if vtk.vtkVersion.GetVTKMajorVersion() >= 9:
+        cells.SetData(ncells, all_faces_vtk)
+    else:
+        cells.SetCells(ncells, all_faces_vtk)
 
     cols = np.ascontiguousarray(
         np.reshape(cols, (cols.shape[0] * cols.shape[1],

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1000,7 +1000,7 @@ def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
         cells = numpy_to_vtk_cells(all_faces, is_coords=False)
     else:
         all_faces = np.hstack((3 * np.ones((len(all_faces), 1)),
-                              all_faces))
+                               all_faces))
         ncells = len(all_faces)
 
         all_faces = np.ascontiguousarray(all_faces.ravel(), dtype='i8')

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -261,8 +261,8 @@ def test_contour_from_roi():
             from dipy.tracking.local_tracking import LocalTracking
 
         hardi_img, gtab, labels_img = read_stanford_labels()
-        data = hardi_img.get_data()
-        labels = labels_img.get_data()
+        data = np.asanyarray(hardi_img.dataobj)
+        labels = np.asanyarray(labels_img.dataobj)
         affine = hardi_img.affine
 
         white_matter = (labels == 1) | (labels == 2)
@@ -919,6 +919,7 @@ def test_cones_vertices_faces(interactive=False):
     npt.assert_equal(report.objects, 3)
     scene.clear()
 
+test_cones_vertices_faces()
 
 def test_geometry_actor(interactive=False):
 

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -314,8 +314,8 @@ def test_contour_from_roi():
 @pytest.mark.skipif(skip_osx, reason="This test does not work on macOS + "
                                      "Travis. It works on a local machine"
                                      " with 3 different version of VTK. There"
-                                     " is 2 problem to check: Travis macOS vs"
-                                     " Azure macOS and an issue with"
+                                     " are 2 problems to check: Travis macOS"
+                                     " vs Azure macOS and an issue with"
                                      " vtkAssembly + actor opacity.")
 def test_contour_from_label(interactive=False):
 

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -10,6 +10,7 @@ from scipy.ndimage.measurements import center_of_mass
 from fury import shaders
 from fury import actor, window
 from fury.actor import grid
+from fury.decorators import skip_osx
 from fury.primitive import prim_sphere, prim_square, repeat_primitive
 from fury.utils import shallow_copy, rotate, get_actor_from_primitive
 from fury.testing import assert_greater, assert_greater_equal
@@ -310,6 +311,12 @@ def test_contour_from_roi():
         # window.show(r2)
 
 
+@pytest.mark.skipif(skip_osx, reason="This test does not work on macOS + "
+                                     "Travis. It works on a local machine"
+                                     " with 3 different version of VTK. There"
+                                     " is 2 problem to check: Travis macOS vs"
+                                     " Azure macOS and an issue with"
+                                     " vtkAssembly + actor opacity.")
 def test_contour_from_label(interactive=False):
 
     # Render volumne

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -315,12 +315,12 @@ def test_contour_from_label(interactive=False):
     # Render volumne
     scene = window.Scene()
     data = np.zeros((50, 50, 50))
-    data[5:15, 1:10, 10:50] = 1.
+    data[5:15, 1:10, 25] = 1.
     data[25:35, 1:10, 25] = 2.
-    # data[40:49, 1:10, 25] = 3.
+    data[40:49, 1:10, 25] = 3.
 
     color = np.array([[255, 0, 0, 0.6],
-                    #   [0, 255, 0, 0.5],
+                      [0, 255, 0, 0.5],
                       [0, 0, 255, 1.0]])
 
     surface = actor.contour_from_label(data, color=color)
@@ -329,7 +329,7 @@ def test_contour_from_label(interactive=False):
     scene.reset_camera()
     scene.reset_clipping_range()
     if interactive:
-        window.show(scene, order_transparent=True)
+        window.show(scene)
 
     # Test Errors
     with npt.assert_raises(ValueError):
@@ -351,10 +351,10 @@ def test_contour_from_label(interactive=False):
     scene2.reset_camera()
     scene2.reset_clipping_range()
     if interactive:
-        window.show(scene2, order_transparent=False)
+        window.show(scene2)
 
     arr = window.snapshot(scene, 'test_surface.png', offscreen=True,
-                          order_transparent=True)
+                          order_transparent=False)
     arr2 = window.snapshot(scene2, 'test_surface2.png', offscreen=True,
                            order_transparent=True)
 
@@ -364,14 +364,11 @@ def test_contour_from_label(interactive=False):
                                      find_objects=True)
     report2 = window.analyze_snapshot(arr2, find_objects=True)
 
-    print(report.colors_found, report.objects)
-    import ipdb; ipdb.set_trace()
     npt.assert_equal(report.objects, 3)
     npt.assert_equal(report2.objects, 1)
 
     actor.contour_from_label(data)
 
-test_contour_from_label(True)
 
 def test_streamtube_and_line_actors():
     scene = window.Scene()

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -315,9 +315,9 @@ def test_contour_from_label():
     # Render volumne
     scene = window.Scene()
     data = np.zeros((50, 50, 50))
-    data[15:20, 25, 25] = 1.
-    data[25, 20:30, 25] = 2.
-    data[25, 40:50, 30:50] = 3.
+    data[5:15, 1:10, 25] = 1.
+    data[25:35, 20:30, 25] = 2.
+    data[40:49, 40:50, 30:50] = 3.
 
     color = np.array(
         [[1, 0, 0, 0.6],
@@ -354,7 +354,7 @@ def test_contour_from_label():
     # window.show(scene2)
 
     arr = window.snapshot(scene, 'test_surface.png', offscreen=True,
-                          order_transparent=True)
+                          order_transparent=False)
     arr2 = window.snapshot(scene2, 'test_surface2.png', offscreen=True,
                            order_transparent=True)
 
@@ -1223,7 +1223,7 @@ def test_matplotlib_figure():
     plt.plot(names, values)
     plt.suptitle('Categorical Plotting')
 
-    arr = matplotlib_figure_to_numpy(fig, dpi=300, transparent=True)
+    arr = matplotlib_figure_to_numpy(fig, dpi=500, transparent=True)
     fig_actor = actor.figure(arr, 'cubic')
     fig_actor2 = actor.figure(arr, 'cubic')
     scene = window.Scene()
@@ -1235,7 +1235,8 @@ def test_matplotlib_figure():
     scene.add(fig_actor2)
     ax_actor.SetPosition(0, 500, -800)
     fig_actor2.SetPosition(500, 800, -400)
-    display = window.snapshot(scene, order_transparent=True)
+    display = window.snapshot(scene, 'test_mpl.png', order_transparent=False,
+                              offscreen=True)
     res = window.analyze_snapshot(display, bg_color=(255, 255, 255.),
                                   colors=[(31, 119, 180), (255, 0, 0)],
                                   find_objects=False)

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -310,7 +310,7 @@ def test_contour_from_roi():
         # window.show(r2)
 
 
-def test_contour_from_label():
+def test_contour_from_label(interactive=False):
 
     # Render volumne
     scene = window.Scene()
@@ -319,17 +319,17 @@ def test_contour_from_label():
     data[25:35, 20:30, 25] = 2.
     data[40:49, 40:50, 30:50] = 3.
 
-    color = np.array(
-        [[1, 0, 0, 0.6],
-         [0, 1, 0, 0.5],
-         [0, 0, 1, 1.0]])
+    color = np.array([[255, 0, 0, 0.6],
+                      [0, 255, 0, 0.5],
+                      [0, 0, 255, 1.0]])
 
     surface = actor.contour_from_label(data, color=color)
 
     scene.add(surface)
     scene.reset_camera()
     scene.reset_clipping_range()
-    # window.show(scene)
+    if interactive:
+        window.show(scene)
 
     # Test Errors
     with npt.assert_raises(ValueError):
@@ -342,16 +342,16 @@ def test_contour_from_label():
     data2[20:30, 25, 25] = 1.
     data2[25, 20:30, 25] = 2.
 
-    color2 = np.array(
-        [[1, 0, 1],
-         [1, 1, 0]])
+    color2 = np.array([[255, 0, 255],
+                       [255, 255, 0]])
 
     surface2 = actor.contour_from_label(data2, color=color2)
 
     scene2.add(surface2)
     scene2.reset_camera()
     scene2.reset_clipping_range()
-    # window.show(scene2)
+    if interactive:
+        window.show(scene2)
 
     arr = window.snapshot(scene, 'test_surface.png', offscreen=True,
                           order_transparent=False)

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -919,7 +919,6 @@ def test_cones_vertices_faces(interactive=False):
     npt.assert_equal(report.objects, 3)
     scene.clear()
 
-test_cones_vertices_faces()
 
 def test_geometry_actor(interactive=False):
 

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -315,12 +315,12 @@ def test_contour_from_label(interactive=False):
     # Render volumne
     scene = window.Scene()
     data = np.zeros((50, 50, 50))
-    data[5:15, 1:10, 25] = 1.
-    data[25:35, 20:30, 25] = 2.
-    data[40:49, 40:50, 30:50] = 3.
+    data[5:15, 1:10, 10:50] = 1.
+    data[25:35, 1:10, 25] = 2.
+    # data[40:49, 1:10, 25] = 3.
 
     color = np.array([[255, 0, 0, 0.6],
-                      [0, 255, 0, 0.5],
+                    #   [0, 255, 0, 0.5],
                       [0, 0, 255, 1.0]])
 
     surface = actor.contour_from_label(data, color=color)
@@ -329,7 +329,7 @@ def test_contour_from_label(interactive=False):
     scene.reset_camera()
     scene.reset_clipping_range()
     if interactive:
-        window.show(scene)
+        window.show(scene, order_transparent=True)
 
     # Test Errors
     with npt.assert_raises(ValueError):
@@ -351,21 +351,27 @@ def test_contour_from_label(interactive=False):
     scene2.reset_camera()
     scene2.reset_clipping_range()
     if interactive:
-        window.show(scene2)
+        window.show(scene2, order_transparent=False)
 
     arr = window.snapshot(scene, 'test_surface.png', offscreen=True,
-                          order_transparent=False)
+                          order_transparent=True)
     arr2 = window.snapshot(scene2, 'test_surface2.png', offscreen=True,
                            order_transparent=True)
 
-    report = window.analyze_snapshot(arr, find_objects=True)
+    report = window.analyze_snapshot(arr, colors=[(255, 0, 0),
+                                                  (0, 255, 0),
+                                                  (0, 0, 255)],
+                                     find_objects=True)
     report2 = window.analyze_snapshot(arr2, find_objects=True)
 
+    print(report.colors_found, report.objects)
+    import ipdb; ipdb.set_trace()
     npt.assert_equal(report.objects, 3)
     npt.assert_equal(report2.objects, 1)
 
     actor.contour_from_label(data)
 
+test_contour_from_label(True)
 
 def test_streamtube_and_line_actors():
     scene = window.Scene()

--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -285,13 +285,12 @@ def test_stereo():
     scene.reset_camera()
 
     mono = window.snapshot(scene, fname='stereo_off.png', offscreen=True,
-                           size=(300, 300), order_transparent=True,
-                           stereo='off')
+                           size=(300, 300), stereo='off')
 
     with npt.assert_warns(UserWarning):
         stereo = window.snapshot(scene, fname='stereo_horizontal.png',
                                  offscreen=True, size=(300, 300),
-                                 order_transparent=True, stereo='On')
+                                 stereo='On')
 
     # mono render should have values in the center
     # horizontal split stereo render should be empty in the center

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -91,6 +91,8 @@ def numpy_to_vtk_cells(data, is_coords=True):
 
     Returns
     -------
+    vtk_cell : vtkCellArray
+        connectivity + offset information
 
     """
     data = np.array(data)

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -126,10 +126,10 @@ def numpy_to_vtk_cells(data, is_coords=True):
                                        array_type=vtk_array_type))
     else:
         for i in range(nb_cells):
-            current_len = len(points[i])
+            current_len = len(data[i])
             end_position = current_position + current_len
             connectivity += [current_len]
-            connectivity += range(current_position, end_position)
+            connectivity += list(range(current_position, end_position))
             current_position = end_position
 
         connectivity = np.array(connectivity)

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -112,7 +112,7 @@ def numpy_to_vtk_cells(data, is_coords=True):
 
             if is_coords:
                 end_position = current_position + current_len
-                connectivity += range(current_position, end_position)
+                connectivity += list(range(current_position, end_position))
                 current_position = end_position
 
         connectivity = np.array(connectivity, np.intp)

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -395,7 +395,10 @@ def set_polydata_triangles(polydata, triangles):
     vtk_triangles = numpy_support.numpy_to_vtkIdTypeArray(vtk_triangles,
                                                           deep=True)
     vtk_cells = vtk.vtkCellArray()
-    vtk_cells.SetCells(len(triangles), vtk_triangles)
+    if vtk.vtkVersion.GetVTKMajorVersion() >= 9:
+        vtk_cells.SetData(len(triangles), vtk_triangles)
+    else:
+        vtk_cells.SetCells(len(triangles), vtk_triangles)
     polydata.SetPolys(vtk_cells)
     return polydata
 


### PR DESCRIPTION
This PR update some FURY functions due to some changes in VTK 9. The main change is better management of vtkCellArray.

Wheels available on Pypi only for Windows and macOS. Concerning Linux, you have to download the wheel on VTK website. (https://discourse.vtk.org/t/vtk-9-wheels-on-pypi/3340/4)


VTK Releases Announcement :  https://blog.kitware.com/vtk-9-0-0-available-for-download/
VTK API changes from 8.2 to 9.0: https://vtk.org/Wiki/VTK/API_Changes_8_2_0_to_9_0_0
VTK 9 build process : https://vtk.org/doc/nightly/html/md__home_kitware_dashboards_buildbot_vtk_nightly-master-ike-linux-shared-release_doc_nightly_osm749dd663df9981384f2598c108aac3b0.html