### PR TITLE
Setting Bounding Box for TextBlock2D

### DIFF
--- a/docs/examples/viz_advanced.py
+++ b/docs/examples/viz_advanced.py
@@ -205,7 +205,7 @@ def build_label(text):
     label.bold = False
     label.italic = False
     label.shadow = False
-    label.background = (0, 0, 0)
+    label.background_color = (0, 0, 0)
     label.color = (1, 1, 1)
 
     return label

--- a/fury/tests/test_ui.py
+++ b/fury/tests/test_ui.py
@@ -406,6 +406,28 @@ def test_text_block_2d_justification():
     window.snapshot(show_manager.scene, size=window_size, offscreen=True)
 
 
+def test_ui_text_block_2d_size():
+    text_block_1 = ui.TextBlock2D(position=(50, 50), size=(100, 100))
+
+    npt.assert_equal(text_block_1.actor.GetTextScaleMode(), 1)
+    npt.assert_equal(text_block_1.size, (100, 100))
+
+    text_block_1.font_size = 50
+
+    npt.assert_equal(text_block_1.actor.GetTextScaleMode(), 0)
+    npt.assert_equal(text_block_1.font_size, 50)
+
+    text_block_2 = ui.TextBlock2D(position=(50, 50), font_size=50)
+
+    npt.assert_equal(text_block_2.actor.GetTextScaleMode(), 0)
+    npt.assert_equal(text_block_2.font_size, 50)
+
+    text_block_2.resize((100, 100))
+
+    npt.assert_equal(text_block_2.actor.GetTextScaleMode(), 1)
+    npt.assert_equal(text_block_2.size, (100, 100))
+
+
 def test_ui_line_slider_2d_horizontal_bottom(recording=False):
     filename = "test_ui_line_slider_2d_horizontal_bottom"
     recording_filename = pjoin(DATA_DIR, filename + ".log.gz")

--- a/fury/tests/test_ui.py
+++ b/fury/tests/test_ui.py
@@ -9,6 +9,7 @@ import vtk
 
 import numpy.testing as npt
 import pytest
+import warnings
 
 from fury import window, actor, ui
 from fury.colormap import distinguishable_colormap
@@ -421,6 +422,11 @@ def test_text_block_2d_size():
 
     npt.assert_equal(text_block_2.actor.GetTextScaleMode(), 0)
     npt.assert_equal(text_block_2.font_size, 50)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always", RuntimeWarning)
+        text_block_2.size
+        npt.assert_equal(len(w), 1)
+        npt.assert_(issubclass(w[-1].category, RuntimeWarning))
 
     text_block_2.resize((100, 100))
 
@@ -429,6 +435,26 @@ def test_text_block_2d_size():
 
     text_block_2.position = (100, 100)
     npt.assert_equal(text_block_2.position, (100, 100))
+
+    window_size = (700, 700)
+    show_manager = window.ShowManager(size=window_size)
+
+    text_block_3 = ui.TextBlock2D(text="FURY\nFURY\nFURY\nHello",
+                                  position=(150, 100), bg_color=(1, 0, 0),
+                                  color=(0, 1, 0), size=(100, 100))
+
+    show_manager.scene.add(text_block_3)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always", RuntimeWarning)
+        text_block_3.font_size = 100
+        npt.assert_equal(len(w), 1)
+        npt.assert_(issubclass(w[-1].category, RuntimeWarning))
+        npt.assert_equal(text_block_3.size, (100, 100))
+
+        text_block_3.font_size = 12
+        npt.assert_equal(len(w), 1)
+        npt.assert_(issubclass(w[-1].category, RuntimeWarning))
+        npt.assert_equal(text_block_3.font_size, 12)
 
 
 def test_ui_line_slider_2d_horizontal_bottom(recording=False):

--- a/fury/tests/test_ui.py
+++ b/fury/tests/test_ui.py
@@ -406,7 +406,7 @@ def test_text_block_2d_justification():
     window.snapshot(show_manager.scene, size=window_size, offscreen=True)
 
 
-def test_ui_text_block_2d_size():
+def test_text_block_2d_size():
     text_block_1 = ui.TextBlock2D(position=(50, 50), size=(100, 100))
 
     npt.assert_equal(text_block_1.actor.GetTextScaleMode(), 1)
@@ -426,6 +426,9 @@ def test_ui_text_block_2d_size():
 
     npt.assert_equal(text_block_2.actor.GetTextScaleMode(), 1)
     npt.assert_equal(text_block_2.size, (100, 100))
+
+    text_block_2.position = (100, 100)
+    npt.assert_equal(text_block_2.position, (100, 100))
 
 
 def test_ui_line_slider_2d_horizontal_bottom(recording=False):

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -1084,7 +1084,7 @@ class TextBlock2D(UI):
 
     def __init__(self, text="Text Block", font_size=18, font_family='Arial',
                  justification='left', vertical_justification="bottom",
-                 bold=False, italic=False, shadow=False, size=(100, 100),
+                 bold=False, italic=False, shadow=False, size=None,
                  color=(1, 1, 1), bg_color=None, position=(0, 0)):
         """
         Parameters
@@ -1115,10 +1115,14 @@ class TextBlock2D(UI):
             Size (width, height) in pixels of the text bounding box.
         """
         super(TextBlock2D, self).__init__(position=position)
-        self.resize(size)
+        if size is not None:
+            self.actor.SetTextScaleModeToProp()
+            self.resize(size)
+        else:
+            self.actor.SetTextScaleModeToNone()
+            self.font_size = font_size
         self.color = color
         self.background_color = bg_color
-        self.font_size = font_size
         self.font_family = font_family
         self.justification = justification
         self.bold = bold
@@ -1129,7 +1133,6 @@ class TextBlock2D(UI):
 
     def _setup(self):
         self.actor = vtk.vtkTextActor()
-        self.actor.SetTextScaleModeToProp()
         self.actor.GetPosition2Coordinate().SetCoordinateSystemToViewport()
         self._background = None  # For VTK < 7
         self.handle_events(self.actor)
@@ -1208,6 +1211,7 @@ class TextBlock2D(UI):
         size : int
             Text font size.
         """
+        self.actor.SetTextScaleModeToNone()
         self.actor.GetTextProperty().SetFontSize(size)
 
     @property
@@ -1451,6 +1455,9 @@ class TextBlock2D(UI):
     def _get_size(self):
         if self._background is not None:
             return self._background.size
+
+        if not self.actor.GetTextScaleMode():
+            return self.font_size * 1.2, self.font_size * 1.2
 
         size = np.array([0, 0])
         size[0] = self.actor.GetPosition2()[0] - self.actor.GetPosition()[0]

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -1080,6 +1080,8 @@ class TextBlock2D(UI):
         Makes text italicised.
     shadow : bool
         Adds text shadow.
+    size : (int, int)
+        Size (width, height) in pixels of the text bounding box.
     """
 
     def __init__(self, text="Text Block", font_size=18, font_family='Arial',
@@ -1137,7 +1139,7 @@ class TextBlock2D(UI):
         self.handle_events(self.actor)
 
     def resize(self, size):
-        """Resize the button.
+        """Resize TextBlock2D.
 
         Parameters
         ----------

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -1145,7 +1145,7 @@ class TextBlock2D(UI):
         size : (int, int)
             Text bounding box size(width, height) in pixels.
         """
-
+        self.actor.SetTextScaleModeToProp()
         position2 = self.position + size
         self.actor.SetPosition2(*position2)
 

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -1082,10 +1082,11 @@ class TextBlock2D(UI):
         Adds text shadow.
     """
 
-    def __init__(self, text="Text Block", font_size=18, font_family='Arial',
+    def __init__(self, text="Text Block", font_size=0, font_family='Arial',
                  justification='left', vertical_justification="bottom",
-                 bold=False, italic=False, shadow=False,
-                 color=(1, 1, 1), bg_color=None, position=(0, 0)):
+                 bold=False, italic=False, shadow=False, border=False,
+                 color=(1, 1, 1), bg_color=None, bbox_size=(100, 100),
+                 position=(0, 0)):
         """
         Parameters
         ----------
@@ -1111,7 +1112,13 @@ class TextBlock2D(UI):
             Makes text italicised.
         shadow : bool
             Adds text shadow.
+        border : bool
+            show bounding box.
+        bbox_size : (int, int)
+            width & height of bounding box
         """
+        self.bbox_size = bbox_size
+        self.border = border
         super(TextBlock2D, self).__init__(position=position)
         self.color = color
         self.background_color = bg_color
@@ -1126,6 +1133,32 @@ class TextBlock2D(UI):
 
     def _setup(self):
         self.actor = vtk.vtkTextActor()
+
+        text_representation = vtk.vtkTextRepresentation()
+        # Set Coordinate systems for:
+        # PositionCoordinate = bottom-left corner.
+        # PositionCoordinate2 = top-right corner.
+        text_representation.GetPositionCoordinate().SetCoordinateSystemToDisplay()
+        text_representation.GetPosition2Coordinate().SetCoordinateSystemToDisplay()
+
+        # Set coordinates.
+        text_representation.GetPositionCoordinate().SetValue(*self.position)
+        text_representation.GetPosition2Coordinate().SetValue(*self.bbox_size)
+
+        if self.border:
+            text_representation.SetShowBorderToOn()
+        else:
+            text_representation.SetShowBorderToOff()
+
+        text_widget = vtk.vtkTextWidget()
+        text_widget.SetRepresentation(text_representation)
+        text_widget.SetTextActor(self.actor)
+        text_widget.SelectableOff()
+        text_widget.ResizableOff()
+        text_widget.On()
+
+        self.actor = text_widget.GetTextActor()
+
         self._background = None  # For VTK < 7
         self.handle_events(self.actor)
 

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -1082,7 +1082,7 @@ class TextBlock2D(UI):
         Adds text shadow.
     """
 
-    def __init__(self, text="Text Block", font_size=18, font_family='Arial',
+    def __init__(self, text="Text Block", font_size=None, font_family='Arial',
                  justification='left', vertical_justification="bottom",
                  bold=False, italic=False, shadow=False, size=None,
                  color=(1, 1, 1), bg_color=None, position=(0, 0)):
@@ -1116,10 +1116,22 @@ class TextBlock2D(UI):
         """
         super(TextBlock2D, self).__init__(position=position)
         self.bg = bool(bg_color)
+
+        # Background is rendered in 2 different ways:
+        # 0 : Actor mode -> When only font_size as parameter
+        #                    or only default parameters.
+        #                    Background is handled by the vtkTextActor.
+        # 1 : Rectangle mode -> All other cases.
+        #                       Background is handle by Rectangle2D.
         if size is not None:
+            self.bg_mode = 1
             self.resize(size)
         else:
-            self.font_size = font_size
+            self.bg_mode = 0
+            if font_size is None:
+                self.font_size = 18
+            else:
+                self.font_size = font_size
         self.color = color
         self.background_color = bg_color
         self.font_family = font_family
@@ -1413,6 +1425,9 @@ class TextBlock2D(UI):
         if not self.bg:
             return None
 
+        if self.bg_mode == 0:
+            return self.actor.GetTextProperty().GetBackgroundColor()
+
         return self.background.color
 
     @background_color.setter
@@ -1429,12 +1444,19 @@ class TextBlock2D(UI):
         if color is None:
             # Remove background.
             self.bg = False
-            self.background.set_visibility(False)
+            if self.bg_mode == 0:
+                self.actor.GetTextProperty().SetBackgroundOpacity(0.)
+            else:
+                self.background.set_visibility(False)
 
         else:
             self.bg = True
-            self.background.set_visibility(True)
-            self.background.color = color
+            if self.bg_mode == 0:
+                self.actor.GetTextProperty().SetBackgroundColor(*color)
+                self.actor.GetTextProperty().SetBackgroundOpacity(1.)
+            else:
+                self.background.set_visibility(True)
+                self.background.color = color
 
     def _set_position(self, position):
         """ Set text actor position.

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -1166,7 +1166,7 @@ class TextBlock2D(UI):
         scene : scene
         """
         self.scene = scene
-        if self.have_bg:
+        if self.have_bg and not self.actor.GetTextScaleMode():
             size = np.zeros(2)
             self.actor.GetSize(scene, size)
             self.background.resize(size)
@@ -1214,8 +1214,18 @@ class TextBlock2D(UI):
         size : int
             Text font size.
         """
+        prev_size = self.font_size
         self.actor.SetTextScaleModeToNone()
         self.actor.GetTextProperty().SetFontSize(size)
+
+        if self.scene is not None and self.have_bg:
+            bb_size = np.zeros(2)
+            self.actor.GetSize(self.scene, bb_size)
+            bg_size = self.background.size
+            if bb_size[0] > bg_size[0] or bb_size[1] > bg_size[1]:
+                warn("Font size exceeds background bounding box."
+                " Font Size will not be updated.", RuntimeWarning)
+                self.actor.GetTextProperty().SetFontSize(prev_size)
 
     @property
     def font_family(self):

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -1427,9 +1427,11 @@ class TextBlock2D(UI):
         """
         if color is None:
             # Remove background.
+            self.bg = False
             self.background.set_visibility(False)
 
         else:
+            self.bg = True
             self.background.set_visibility(True)
             self.background.color = color
 

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -1166,8 +1166,8 @@ class TextBlock2D(UI):
         """
         self.scene = scene
         if self.bg:
-            size = np.array(2)
-            self.actor.GetSize(self.scene, size)
+            size = np.zeros(2)
+            self.actor.GetSize(scene, size)
             self.background.resize(size)
         scene.add(self.background, self.actor)
 
@@ -1460,7 +1460,7 @@ class TextBlock2D(UI):
 
         if not self.actor.GetTextScaleMode():
             if self.scene is not None:
-                size = np.array(2)
+                size = np.zeros(2)
                 self.actor.GetSize(self.scene, size)
                 return size
             else:
@@ -3876,7 +3876,7 @@ class ListBox2D(UI):
             total_chars = len(str(choice))
             if total_chars > permissible_chars:
                 excess_chars = total_chars - permissible_chars
-                wrapped_choice = choice[:(-excess_chars) + 3] + "..."
+                wrapped_choice = str(choice)[:(-excess_chars) + 3] + "..."
                 slot.element = choice
                 slot.textblock.message = wrapped_choice
             else:

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -1082,9 +1082,9 @@ class TextBlock2D(UI):
         Adds text shadow.
     """
 
-    def __init__(self, text="Text Block", font_size=None, font_family='Arial',
+    def __init__(self, text="Text Block", font_size=18, font_family='Arial',
                  justification='left', vertical_justification="bottom",
-                 bold=False, italic=False, shadow=False, size=None,
+                 bold=False, italic=False, shadow=False, size=(100, 100),
                  color=(1, 1, 1), bg_color=None, position=(0, 0)):
         """
         Parameters
@@ -1112,17 +1112,13 @@ class TextBlock2D(UI):
         shadow : bool
             Adds text shadow.
         size : (int, int)
-            Size (width, height) in pixels of the Text.
+            Size (width, height) in pixels of the text bounding box.
         """
         super(TextBlock2D, self).__init__(position=position)
+        self.resize(size)
         self.color = color
         self.background_color = bg_color
-        if font_size is not None:
-            self.font_size = font_size
-        if size is not None:
-            self.size = size
-        if font_size is None and size is None:
-            self.font_size = 18
+        self.font_size = font_size
         self.font_family = font_family
         self.justification = justification
         self.bold = bold
@@ -1133,8 +1129,22 @@ class TextBlock2D(UI):
 
     def _setup(self):
         self.actor = vtk.vtkTextActor()
+        self.actor.SetTextScaleModeToProp()
+        self.actor.GetPosition2Coordinate().SetCoordinateSystemToViewport()
         self._background = None  # For VTK < 7
         self.handle_events(self.actor)
+
+    def resize(self, size):
+        """Resize the button.
+
+        Parameters
+        ----------
+        size : (int, int)
+            Text bounding box size(width, height) in pixels.
+        """
+
+        position2 = self.position + size
+        self.actor.SetPosition2(*position2)
 
     def _get_actors(self):
         """ Get the actors composing this UI component.

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -1119,7 +1119,7 @@ class TextBlock2D(UI):
         """
         super(TextBlock2D, self).__init__(position=position)
         self.scene = None
-        self.bg = bool(bg_color)
+        self.have_bg = bool(bg_color)
         if size is not None:
             self.resize(size)
         else:
@@ -1148,7 +1148,7 @@ class TextBlock2D(UI):
         size : (int, int)
             Text bounding box size(width, height) in pixels.
         """
-        if self.bg:
+        if self.have_bg:
             self.background.resize(size)
         self.actor.SetTextScaleModeToProp()
         self.actor.SetPosition2(*size)
@@ -1166,7 +1166,7 @@ class TextBlock2D(UI):
         scene : scene
         """
         self.scene = scene
-        if self.bg:
+        if self.have_bg:
             size = np.zeros(2)
             self.actor.GetSize(scene, size)
             self.background.resize(size)
@@ -1419,7 +1419,7 @@ class TextBlock2D(UI):
             If None, there no background color.
             Otherwise, background color in RGB.
         """
-        if not self.bg:
+        if not self.have_bg:
             return None
 
         return self.background.color
@@ -1436,11 +1436,11 @@ class TextBlock2D(UI):
         """
         if color is None:
             # Remove background.
-            self.bg = False
+            self.have_bg = False
             self.background.set_visibility(False)
 
         else:
-            self.bg = True
+            self.have_bg = True
             self.background.set_visibility(True)
             self.background.color = color
 
@@ -1456,7 +1456,7 @@ class TextBlock2D(UI):
         self.background.position = position
 
     def _get_size(self):
-        if self.bg:
+        if self.have_bg:
             return self.background.size
 
         if not self.actor.GetTextScaleMode():
@@ -1465,8 +1465,9 @@ class TextBlock2D(UI):
                 self.actor.GetSize(self.scene, size)
                 return size
             else:
-                warn("TextBlock2D must be added to the scene before\
-                    querying its size while TextScaleMode is set to None.")
+                warn("TextBlock2D must be added to the scene before "
+                "querying its size while TextScaleMode is set to None.", 
+                RuntimeWarning)
 
         return self.actor.GetPosition2()
 

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -1214,7 +1214,6 @@ class TextBlock2D(UI):
         size : int
             Text font size.
         """
-        prev_size = self.font_size
         self.actor.SetTextScaleModeToNone()
         self.actor.GetTextProperty().SetFontSize(size)
 
@@ -1225,7 +1224,8 @@ class TextBlock2D(UI):
             if bb_size[0] > bg_size[0] or bb_size[1] > bg_size[1]:
                 warn("Font size exceeds background bounding box."
                 " Font Size will not be updated.", RuntimeWarning)
-                self.actor.GetTextProperty().SetFontSize(prev_size)
+                self.actor.SetTextScaleModeToProp()
+                self.actor.SetPosition2(*bg_size)
 
     @property
     def font_family(self):

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -1428,9 +1428,11 @@ class TextBlock2D(UI):
 
         if color is None:
             # Remove background.
+            self.bg = False
             self.background.set_visibility(False)
 
         else:
+            self.bg = True
             self.background.set_visibility(True)
             self.background.color = color
 

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -1440,7 +1440,6 @@ class TextBlock2D(UI):
             If None, remove background.
             Otherwise, RGB values (must be between 0-1).
         """
-
         if color is None:
             # Remove background.
             self.bg = False

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -1082,7 +1082,7 @@ class TextBlock2D(UI):
         Adds text shadow.
     """
 
-    def __init__(self, text="Text Block", font_size=None, font_family='Arial',
+    def __init__(self, text="Text Block", font_size=18, font_family='Arial',
                  justification='left', vertical_justification="bottom",
                  bold=False, italic=False, shadow=False, size=None,
                  color=(1, 1, 1), bg_color=None, position=(0, 0)):
@@ -1116,22 +1116,10 @@ class TextBlock2D(UI):
         """
         super(TextBlock2D, self).__init__(position=position)
         self.bg = bool(bg_color)
-
-        # Background is rendered in 2 different ways:
-        # 0 : Actor mode -> When only font_size as parameter
-        #                    or only default parameters.
-        #                    Background is handled by the vtkTextActor.
-        # 1 : Rectangle mode -> All other cases.
-        #                       Background is handle by Rectangle2D.
         if size is not None:
-            self.bg_mode = 1
             self.resize(size)
         else:
-            self.bg_mode = 0
-            if font_size is None:
-                self.font_size = 18
-            else:
-                self.font_size = font_size
+            self.font_size = font_size
         self.color = color
         self.background_color = bg_color
         self.font_family = font_family
@@ -1425,9 +1413,6 @@ class TextBlock2D(UI):
         if not self.bg:
             return None
 
-        if self.bg_mode == 0:
-            return self.actor.GetTextProperty().GetBackgroundColor()
-
         return self.background.color
 
     @background_color.setter
@@ -1442,20 +1427,11 @@ class TextBlock2D(UI):
         """
         if color is None:
             # Remove background.
-            self.bg = False
-            if self.bg_mode == 0:
-                self.actor.GetTextProperty().SetBackgroundOpacity(0.)
-            else:
-                self.background.set_visibility(False)
+            self.background.set_visibility(False)
 
         else:
-            self.bg = True
-            if self.bg_mode == 0:
-                self.actor.GetTextProperty().SetBackgroundColor(*color)
-                self.actor.GetTextProperty().SetBackgroundOpacity(1.)
-            else:
-                self.background.set_visibility(True)
-                self.background.color = color
+            self.background.set_visibility(True)
+            self.background.color = color
 
     def _set_position(self, position):
         """ Set text actor position.

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -1082,11 +1082,10 @@ class TextBlock2D(UI):
         Adds text shadow.
     """
 
-    def __init__(self, text="Text Block", font_size=0, font_family='Arial',
+    def __init__(self, text="Text Block", font_size=None, font_family='Arial',
                  justification='left', vertical_justification="bottom",
-                 bold=False, italic=False, shadow=False, border=False,
-                 color=(1, 1, 1), bg_color=None, bbox_size=(100, 100),
-                 position=(0, 0)):
+                 bold=False, italic=False, shadow=False, position2=None,
+                 color=(1, 1, 1), bg_color=None, position=(0, 0)):
         """
         Parameters
         ----------
@@ -1117,12 +1116,15 @@ class TextBlock2D(UI):
         bbox_size : (int, int)
             width & height of bounding box
         """
-        self.bbox_size = bbox_size
-        self.border = border
         super(TextBlock2D, self).__init__(position=position)
         self.color = color
         self.background_color = bg_color
-        self.font_size = font_size
+        if font_size is not None:
+            self.font_size = font_size
+        if position2 is not None:
+            self.position2 = position2
+        if font_size is None and position2 is None:
+            self.font_size = 18
         self.font_family = font_family
         self.justification = justification
         self.bold = bold
@@ -1133,32 +1135,6 @@ class TextBlock2D(UI):
 
     def _setup(self):
         self.actor = vtk.vtkTextActor()
-
-        text_representation = vtk.vtkTextRepresentation()
-        # Set Coordinate systems for:
-        # PositionCoordinate = bottom-left corner.
-        # PositionCoordinate2 = top-right corner.
-        text_representation.GetPositionCoordinate().SetCoordinateSystemToDisplay()
-        text_representation.GetPosition2Coordinate().SetCoordinateSystemToDisplay()
-
-        # Set coordinates.
-        text_representation.GetPositionCoordinate().SetValue(*self.position)
-        text_representation.GetPosition2Coordinate().SetValue(*self.bbox_size)
-
-        if self.border:
-            text_representation.SetShowBorderToOn()
-        else:
-            text_representation.SetShowBorderToOff()
-
-        text_widget = vtk.vtkTextWidget()
-        text_widget.SetRepresentation(text_representation)
-        text_widget.SetTextActor(self.actor)
-        text_widget.SelectableOff()
-        text_widget.ResizableOff()
-        text_widget.On()
-
-        self.actor = text_widget.GetTextActor()
-
         self._background = None  # For VTK < 7
         self.handle_events(self.actor)
 
@@ -1463,6 +1439,30 @@ class TextBlock2D(UI):
         self.actor.SetPosition(*position)
         if self._background is not None:
             self._background.SetPosition(*self.actor.GetPosition())
+
+    @property
+    def position2(self):
+        """
+        Gets top-right corner position.
+
+        Returns
+        -------
+        (float, float, float)
+        """
+        return self.actor.GetPosition2()
+
+    @position2.setter
+    def _set_position2(self, position2=(100, 100, 0)):
+        """ Set text actor position2.
+
+        Parameters
+        ----------
+        position : (float, float)
+            The new position. (x, y) in pixels.
+        """
+        self.actor.SetPosition2(*position2)
+        if self._background is not None:
+            self._background.SetPosition2(*self.actor.GetPosition2())
 
     def _get_size(self):
         if self._background is not None:

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -1116,10 +1116,8 @@ class TextBlock2D(UI):
         """
         super(TextBlock2D, self).__init__(position=position)
         if size is not None:
-            self.actor.SetTextScaleModeToProp()
             self.resize(size)
         else:
-            self.actor.SetTextScaleModeToNone()
             self.font_size = font_size
         self.color = color
         self.background_color = bg_color

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from warnings import warn
 
 import numpy as np
 import vtk

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -1117,6 +1117,7 @@ class TextBlock2D(UI):
             Size (width, height) in pixels of the text bounding box.
         """
         super(TextBlock2D, self).__init__(position=position)
+        self.scene = None
         self.bg = bool(bg_color)
         if size is not None:
             self.resize(size)
@@ -1163,6 +1164,11 @@ class TextBlock2D(UI):
         ----------
         scene : scene
         """
+        self.scene = scene
+        if self.bg:
+            size = np.array(2)
+            self.actor.GetSize(self.scene, size)
+            self.background.resize(size)
         scene.add(self.background, self.actor)
 
     @property
@@ -1453,7 +1459,13 @@ class TextBlock2D(UI):
             return self.background.size
 
         if not self.actor.GetTextScaleMode():
-            return self.font_size * 1.2, self.font_size * 1.2
+            if self.scene is not None:
+                size = np.array(2)
+                self.actor.GetSize(self.scene, size)
+                return size
+            else:
+                warn("TextBlock2D must be added to the scene before\
+                    querying its size while TextScaleMode is set to None.")
 
         return self.actor.GetPosition2()
 

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -1084,7 +1084,7 @@ class TextBlock2D(UI):
 
     def __init__(self, text="Text Block", font_size=None, font_family='Arial',
                  justification='left', vertical_justification="bottom",
-                 bold=False, italic=False, shadow=False, position2=None,
+                 bold=False, italic=False, shadow=False, size=None,
                  color=(1, 1, 1), bg_color=None, position=(0, 0)):
         """
         Parameters
@@ -1111,19 +1111,17 @@ class TextBlock2D(UI):
             Makes text italicised.
         shadow : bool
             Adds text shadow.
-        border : bool
-            show bounding box.
-        bbox_size : (int, int)
-            width & height of bounding box
+        size : (int, int)
+            Size (width, height) in pixels of the Text.
         """
         super(TextBlock2D, self).__init__(position=position)
         self.color = color
         self.background_color = bg_color
         if font_size is not None:
             self.font_size = font_size
-        if position2 is not None:
-            self.position2 = position2
-        if font_size is None and position2 is None:
+        if size is not None:
+            self.size = size
+        if font_size is None and size is None:
             self.font_size = 18
         self.font_family = font_family
         self.justification = justification
@@ -1440,34 +1438,15 @@ class TextBlock2D(UI):
         if self._background is not None:
             self._background.SetPosition(*self.actor.GetPosition())
 
-    @property
-    def position2(self):
-        """
-        Gets top-right corner position.
-
-        Returns
-        -------
-        (float, float, float)
-        """
-        return self.actor.GetPosition2()
-
-    @position2.setter
-    def _set_position2(self, position2=(100, 100, 0)):
-        """ Set text actor position2.
-
-        Parameters
-        ----------
-        position : (float, float)
-            The new position. (x, y) in pixels.
-        """
-        self.actor.SetPosition2(*position2)
-        if self._background is not None:
-            self._background.SetPosition2(*self.actor.GetPosition2())
-
     def _get_size(self):
         if self._background is not None:
             return self._background.size
-        return self.font_size * 1.2, self.font_size * 1.2
+
+        size = np.array([0, 0])
+        size[0] = self.actor.GetPosition2()[0] - self.actor.GetPosition()[0]
+        size[1] = self.actor.GetPosition2()[1] - self.actor.GetPosition()[1]
+
+        return size
 
 
 class TextBox2D(UI):


### PR DESCRIPTION
Working example of setting a BBox for a `vtkTextActor` using `vtkTextRepresentation` and `vtkTextWidget`:

```python
import vtk

renderer = vtk.vtkRenderer()
renderer.SetBackground(0.1, 0.2, 0.4)

render_window = vtk.vtkRenderWindow()
render_window.AddRenderer(renderer)
render_window.SetSize(400, 400)

interactor = vtk.vtkRenderWindowInteractor()
interactor.SetRenderWindow(render_window)

# Create the TextActor
text_actor = vtk.vtkTextActor()
text_actor.SetInput("This is a test")
text_actor.GetTextProperty().SetColor((0, 1, 1))

# Create the text representation. Used for positioning the text_actor
text_representation = vtk.vtkTextRepresentation()

text_representation.GetPositionCoordinate().SetCoordinateSystemToDisplay()
text_representation.GetPosition2Coordinate().SetCoordinateSystemToDisplay()

text_representation.GetPositionCoordinate().SetValue(200, 200)
text_representation.GetPosition2Coordinate().SetValue(200, 200)

text_representation.SetShowBorderToOff()

text_actor.GetTextProperty().SetFontSize(0)

# Create the TextWidget
# Note that the SelectableOff method MUST be invoked!
# According to the documentation :
#
# SelectableOn/Off indicates whether the interior region of the widget can be
# selected or not. If not, then events (such as left mouse down) allow the user
# to "move" the widget, and no selection is possible. Otherwise the
# SelectRegion() method is invoked.
text_widget = vtk.vtkTextWidget()
text_widget.SetRepresentation(text_representation)
text_widget.SetInteractor(interactor)
text_widget.SetTextActor(text_actor)
text_widget.SelectableOff()
text_widget.ResizableOff()
text_widget.On()

print(text_widget.GetTextActor())
print(text_actor.GetPositionCoordinate(), text_actor.GetPosition2Coordinate())

interactor.Initialize()
render_window.Render()
interactor.Start()
```
