### PR TITLE
Let VTK delete timers on exit.

### DIFF
--- a/fury/decorators.py
+++ b/fury/decorators.py
@@ -4,8 +4,8 @@ import re
 import platform
 
 
-skip_osx = platform.system().lower() == "darwin"
-skip_win = platform.system().lower() == "windows"
+skip_osx = is_osx = platform.system().lower() == "darwin"
+skip_win = is_win = platform.system().lower() == "windows"
 is_py35 = sys.version_info.major == 3 and sys.version_info.minor == 5
 SKIP_RE = re.compile(r"(\s*>>>.*?)(\s*)#\s*skip\s+if\s+(.*)$")
 

--- a/fury/deprecator.py
+++ b/fury/deprecator.py
@@ -116,7 +116,7 @@ def deprecate_with_version(message, since='', until='',
                            version_comparator=cmp_pkg_version,
                            warn_class=DeprecationWarning,
                            error_class=ExpiredDeprecationError):
-    """Return decorator function function for deprecation warning / error.
+    """Return decorator function for deprecation warning / error.
 
     The decorated function / method will:
 

--- a/fury/tests/test_ui.py
+++ b/fury/tests/test_ui.py
@@ -1029,8 +1029,8 @@ def test_ui_image_container_2d(interactive=False):
         show_manager.start()
 
 
-@pytest.mark.skipif(skip_win, reason="This test does not work on Windows."
-                                     " Need to be introspected")
+# @pytest.mark.skipif(skip_win, reason="This test does not work on Windows."
+#                                      " Need to be introspected")
 def test_timer():
     """Testing add a timer and exit window and app from inside timer."""
     xyzr = np.array([[0, 0, 0, 10], [100, 0, 0, 50], [300, 0, 0, 100]])

--- a/fury/tests/test_ui.py
+++ b/fury/tests/test_ui.py
@@ -1029,8 +1029,8 @@ def test_ui_image_container_2d(interactive=False):
         show_manager.start()
 
 
-# @pytest.mark.skipif(skip_win, reason="This test does not work on Windows."
-#                                      " Need to be introspected")
+@pytest.mark.skipif(skip_win, reason="This test does not work on Windows."
+                                     " Need to be introspected")
 def test_timer():
     """Testing add a timer and exit window and app from inside timer."""
     xyzr = np.array([[0, 0, 0, 10], [100, 0, 0, 50], [300, 0, 0, 100]])

--- a/fury/tests/test_ui.py
+++ b/fury/tests/test_ui.py
@@ -1071,7 +1071,7 @@ def test_timer():
     showm.add_timer_callback(True, 200, timer_callback)
     showm.start()
 
-    arr = window.snapshot(scene, offscreen=True)
+    arr = window.snapshot(scene)
     npt.assert_(np.sum(arr) > 0)
 
 

--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -125,8 +125,8 @@ def test_deprecated():
         report = window.analyze_renderer(scene)
         npt.assert_equal(report.actors, 0)
         deprecated_warns = [w for w in l_warn
-                            if issubclass(w.category,
-                                          DeprecationWarning)]
+                            if issubclass(w.category, DeprecationWarning)
+                            if "deprecated from version" in str(w.message)]
         npt.assert_equal(len(deprecated_warns), 7)
         npt.assert_(issubclass(l_warn[-1].category, DeprecationWarning))
 

--- a/fury/window.py
+++ b/fury/window.py
@@ -657,10 +657,9 @@ class ShowManager(object):
 
     def exit(self):
         """Close window and terminate interactor."""
-        if self.timers:
-            self.destroy_timers()
         self.iren.GetRenderWindow().Finalize()
         self.iren.TerminateApp()
+        self.timers.clear()
 
 
 def show(scene, title='FURY', size=(300, 300), png_magnify=1,

--- a/fury/window.py
+++ b/fury/window.py
@@ -11,6 +11,7 @@ from vtk.util import numpy_support, colors
 from tempfile import TemporaryDirectory as InTemporaryDirectory
 
 from fury import __version__ as fury_version
+from fury.decorators import is_osx
 from fury.deprecator import deprecate_with_version
 from fury.interactor import CustomInteractorStyle
 from fury.io import load_image, save_image
@@ -659,6 +660,10 @@ class ShowManager(object):
 
     def exit(self):
         """Close window and terminate interactor."""
+        if is_osx and self.timers:
+            # OSX seems to not destroy correctly timers
+            # segfault 11 appears sometimes if we do not do it manually.
+            self.destroy_timers()
         self.iren.GetRenderWindow().Finalize()
         self.iren.TerminateApp()
         self.timers.clear()

--- a/fury/window.py
+++ b/fury/window.py
@@ -465,8 +465,10 @@ class ShowManager(object):
         self.window.SetSize(size[0], size[1])
 
         if self.order_transparent:
+            occlusion_ratio = occlusion_ratio or 0.1
             antialiasing(self.scene, self.window,
-                         multi_samples, max_peels, occlusion_ratio)
+                         multi_samples=0, max_peels=max_peels,
+                         occlusion_ratio=occlusion_ratio)
 
         if self.interactor_style == 'image':
             self.style = vtk.vtkInteractorStyleImage()

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,5 @@
 # List required packages in this file, one per line.
 numpy>=1.7.1
-vtk>=8.1.2
+vtk>=8.1.2,!=9.0.0
 scipy>=1.2.0
 pillow>=5.4.1

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         },
     install_requires=['numpy>=1.7.1',
                       'scipy>=0.9',
-                      'vtk>=8.1.0',
+                      'vtk>=8.1.2,!=9.0.0',
                       'pillow>=5.4.1'],
     license="BSD (3-clause)",
     classifiers=[


### PR DESCRIPTION
Based on @MarcCote PR in [my fork](https://github.com/skoudoro/fury/pull/4):

With this fix and the latest VTK' [release branch](https://gitlab.kitware.com/vtk/vtk/-/tree/release) (which includes the fix for the TimerEvents), all fury tests are green except for `fury/tests/test_window.py::test_order_transparent` :-/. 
Edit: this fixes https://github.com/fury-gl/fury/issues/253