### PR TITLE
[NF] Deprecated parameters

### DIFF
--- a/fury/deprecator.py
+++ b/fury/deprecator.py
@@ -11,6 +11,7 @@ the Nibabel package for the copyright and license terms.
 import functools
 import warnings
 import re
+from inspect import signature
 from fury import __version__
 from fury.optpkg import optional_package
 # packaging.version.parse is a third-party utility but is used by setuptools
@@ -26,6 +27,16 @@ class ExpiredDeprecationError(RuntimeError):
 
     Error raised when a called function or method has passed out of its
     deprecation period.
+
+    """
+
+    pass
+
+
+class ArgsDeprecationWarning(DeprecationWarning):
+    """Warning for args deprecation.
+
+    Warning raised when a function or method argument has changed or removed.
 
     """
 
@@ -112,6 +123,11 @@ def cmp_pkg_version(version_str, pkg_version_str=__version__):
         return -1
 
 
+def is_bad_version(version_str, version_comparator=cmp_pkg_version):
+    """Return True if `version_str` is too high."""
+    return version_comparator(version_str) == -1
+
+
 def deprecate_with_version(message, since='', until='',
                            version_comparator=cmp_pkg_version,
                            warn_class=DeprecationWarning,
@@ -154,10 +170,6 @@ def deprecate_with_version(message, since='', until='',
         Function returning a decorator.
 
     """
-    def is_bad_version(version_str):
-        """Return True if `version_str` is too high."""
-        return version_comparator(version_str) == -1
-
     messages = [message]
     if (since, until) != ('', ''):
         messages.append('')
@@ -174,7 +186,7 @@ def deprecate_with_version(message, since='', until='',
 
         @functools.wraps(func)
         def deprecated_func(*args, **kwargs):
-            if until and is_bad_version(until):
+            if until and is_bad_version(until, version_comparator):
                 raise error_class(message)
             warnings.warn(message, warn_class, stacklevel=2)
             return func(*args, **kwargs)
@@ -183,4 +195,228 @@ def deprecate_with_version(message, since='', until='',
                                                message)
         return deprecated_func
 
+    return deprecator
+
+
+def deprecated_params(old_name, new_name=None, since='', until='',
+                      version_comparator=cmp_pkg_version,
+                      arg_in_kwargs=False,
+                      warn_class=ArgsDeprecationWarning,
+                      error_class=ExpiredDeprecationError,
+                      alternative=''):
+    """Deprecate a _renamed_ or _removed_ function argument.
+
+    The decorator assumes that the argument with the ``old_name`` was removed
+    from the function signature and the ``new_name`` replaced it at the
+    **same position** in the signature.  If the ``old_name`` argument is
+    given when calling the decorated function the decorator will catch it and
+    issue a deprecation warning and pass it on as ``new_name`` argument.
+
+    Parameters
+    ----------
+    old_name : str or list/tuple thereof
+        The old name of the argument.
+    new_name : str or list/tuple thereof or `None`, optional
+        The new name of the argument. Set this to `None` to remove the
+        argument ``old_name`` instead of renaming it.
+    since : str or number or list/tuple thereof, optional
+        The release at which the old argument became deprecated.
+    until : str or number or list/tuple thereof, optional
+        Last released version at which this function will still raise a
+        deprecation warning.  Versions higher than this will raise an
+        error.
+    version_comparator : callable
+        Callable accepting string as argument, and return 1 if string
+        represents a higher version than encoded in the `version_comparator`, 0
+        if the version is equal, and -1 if the version is lower.  For example,
+        the `version_comparator` may compare the input version string to the
+        current package version string.
+    arg_in_kwargs : bool or list/tuple thereof, optional
+        If the argument is not a named argument (for example it
+        was meant to be consumed by ``**kwargs``) set this to
+        ``True``.  Otherwise the decorator will throw an Exception
+        if the ``new_name`` cannot be found in the signature of
+        the decorated function.
+        Default is ``False``.
+    warn_class : warning, optional
+        Warning to be issued.
+    error_class : Exception, optional
+        Error to be issued
+    alternative : str, optional
+        An alternative function or class name that the user may use in
+        place of the deprecated object if ``new_name`` is None. The deprecation
+        warning will tell the user about this alternative if provided.
+
+    Raises
+    ------
+    TypeError
+        If the new argument name cannot be found in the function
+        signature and arg_in_kwargs was False or if it is used to
+        deprecate the name of the ``*args``-, ``**kwargs``-like arguments.
+        At runtime such an Error is raised if both the new_name
+        and old_name were specified when calling the function and
+        "relax=False".
+
+    Notes
+    -----
+    This function is based on the Astropy (major modification).
+    https://github.com/astropy/astropy. See COPYING file distributed along with
+    the astropy package for the copyright and license terms.
+
+    Examples
+    --------
+    The deprecation warnings are not shown in the following examples.
+    To deprecate a positional or keyword argument::
+        >>> from fury.deprecator import deprecated_params
+        >>> @deprecated_params('sig', 'sigma', '0.3')
+        ... def test(sigma):
+        ...     return sigma
+        >>> test(2)
+        2
+        >>> test(sigma=2)
+        2
+        >>> test(sig=2)  # doctest: +SKIP
+        2
+    To deprecate an argument caught inside the ``**kwargs`` the
+    ``arg_in_kwargs`` has to be set::
+        >>> @deprecated_params('sig', 'sigma', '1.0',
+        ...                    arg_in_kwargs=True)
+        ... def test(**kwargs):
+        ...     return kwargs['sigma']
+        >>> test(sigma=2)
+        2
+        >>> test(sig=2)  # doctest: +SKIP
+        2
+
+    It is also possible to replace multiple arguments. The ``old_name``,
+    ``new_name`` and ``since`` have to be `tuple` or `list` and contain the
+    same number of entries::
+        >>> @deprecated_params(['a', 'b'], ['alpha', 'beta'],
+        ...                    ['0.2', 0.4])
+        ... def test(alpha, beta):
+        ...     return alpha, beta
+        >>> test(a=2, b=3)  # doctest: +SKIP
+        (2, 3)
+
+    """
+    if isinstance(old_name, (list, tuple)):
+        # Normalize input parameters
+        if not isinstance(arg_in_kwargs, (list, tuple)):
+            arg_in_kwargs = [arg_in_kwargs] * len(old_name)
+        if not isinstance(since, (list, tuple)):
+            since = [since] * len(old_name)
+        if not isinstance(until, (list, tuple)):
+            until = [until] * len(old_name)
+        if not isinstance(new_name, (list, tuple)):
+            new_name = [new_name] * len(old_name)
+
+        if len(set([len(old_name), len(new_name), len(since),
+                    len(until), len(arg_in_kwargs)])) != 1:
+            raise ValueError("All parameters should have the same length")
+    else:
+        # To allow a uniform approach later on, wrap all arguments in lists.
+        old_name = [old_name]
+        new_name = [new_name]
+        since = [since]
+        until = [until]
+        arg_in_kwargs = [arg_in_kwargs]
+
+    def deprecator(function):
+        # The named arguments of the function.
+        arguments = signature(function).parameters
+        positions = [None] * len(old_name)
+
+        for i, (o_name, n_name, in_keywords) in enumerate(zip(old_name,
+                                                              new_name,
+                                                              arg_in_kwargs)):
+            # Determine the position of the argument.
+            if in_keywords:
+                continue
+
+            if n_name is not None and n_name not in arguments:
+                # In case the argument is not found in the list of arguments
+                # the only remaining possibility is that it should be caught
+                # by some kind of **kwargs argument.
+                raise TypeError(
+                    f'"{n_name}" was not specified in the function '
+                    'signature. If it was meant to be part of '
+                    '"**kwargs" then set "arg_in_kwargs" to "True"')
+
+            key = o_name if n_name is None else n_name
+            param = arguments[key]
+
+            if param.kind == param.POSITIONAL_OR_KEYWORD:
+                key = o_name if n_name is None else n_name
+                positions[i] = list(arguments.keys()).index(key)
+            elif param.kind == param.KEYWORD_ONLY:
+                # These cannot be specified by position.
+                positions[i] = None
+            else:
+                # positional-only argument, varargs, varkwargs or some
+                # unknown type:
+                raise TypeError(f'cannot replace argument "{new_name[i]}" '
+                                f'of kind {repr(param.kind)}.')
+
+        @functools.wraps(function)
+        def wrapper(*args, **kwargs):
+            for i, (o_name, n_name) in enumerate(zip(old_name, new_name)):
+                messages = [f'"{o_name}" was deprecated', ]
+                if (since[i], until[i]) != ('', ''):
+                    messages.append('')
+                if since[i]:
+                    messages.append(f'* deprecated from version: {since[i]}')
+                if until[i]:
+                    messages.append('* {0} {1} as of version: {2}'.format(
+                        "Raises" if is_bad_version(until[i]) else "Will raise",
+                        error_class,
+                        until[i]))
+                messages.append('')
+                message = '\n'.join(messages)
+
+                # The only way to have oldkeyword inside the function is
+                # that it is passed as kwarg because the oldkeyword
+                # parameter was renamed to newkeyword.
+                if o_name in kwargs:
+                    value = kwargs.pop(o_name)
+                    # Check if the newkeyword was given as well.
+                    newarg_in_args = (positions[i] is not None and
+                                      len(args) > positions[i])
+                    newarg_in_kwargs = n_name in kwargs
+
+                    if newarg_in_args or newarg_in_kwargs:
+                        raise TypeError(
+                            f'cannot specify both "{o_name}"'
+                            ' (deprecated parameter) and '
+                            f'"{n_name}" (new parameter name).')
+
+                    # Pass the value of the old argument with the
+                    # name of the new argument to the function
+                    key = n_name or o_name
+                    kwargs[key] = value
+
+                    if n_name is not None:
+                        message += f'* Use argument "{n_name}" instead.'
+                    elif alternative:
+                        message += f'* Use {alternative} instead.'
+
+                    if until[i] and is_bad_version(until[i],
+                                                   version_comparator):
+                        raise error_class(message)
+                    warnings.warn(message, warn_class, stacklevel=2)
+
+                # Deprecated keyword without replacement is given as
+                # positional argument.
+                elif (not n_name and positions[i] and
+                      len(args) > positions[i]):
+                    if alternative:
+                        message += f'\n        Use {alternative} instead.'
+                    if until[i] and is_bad_version(until[i],
+                                                   version_comparator):
+                        raise error_class(message)
+
+                    warnings.warn(message, warn_class, stacklevel=2)
+
+            return function(*args, **kwargs)
+
+        return wrapper
     return deprecator

--- a/fury/deprecator.py
+++ b/fury/deprecator.py
@@ -337,10 +337,10 @@ def deprecated_params(old_name, new_name=None, since='', until='',
                 # In case the argument is not found in the list of arguments
                 # the only remaining possibility is that it should be caught
                 # by some kind of **kwargs argument.
-                raise TypeError(
-                    f'"{n_name}" was not specified in the function '
-                    'signature. If it was meant to be part of '
-                    '"**kwargs" then set "arg_in_kwargs" to "True"')
+                msg = '"{}" was not specified in the function '.format(n_name)
+                msg += 'signature. If it was meant to be part of '
+                msg += '"**kwargs" then set "arg_in_kwargs" to "True"'
+                raise TypeError(msg)
 
             key = o_name if n_name is None else n_name
             param = arguments[key]
@@ -354,17 +354,18 @@ def deprecated_params(old_name, new_name=None, since='', until='',
             else:
                 # positional-only argument, varargs, varkwargs or some
                 # unknown type:
-                raise TypeError(f'cannot replace argument "{new_name[i]}" '
-                                f'of kind {repr(param.kind)}.')
+                msg = 'cannot replace argument "{}" '.format(n_name)
+                msg += 'of kind {}.'.format(repr(param.kind))
+                raise TypeError(msg)
 
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
             for i, (o_name, n_name) in enumerate(zip(old_name, new_name)):
-                messages = [f'"{o_name}" was deprecated', ]
+                messages = ['"{}" was deprecated'.format(o_name), ]
                 if (since[i], until[i]) != ('', ''):
                     messages.append('')
                 if since[i]:
-                    messages.append(f'* deprecated from version: {since[i]}')
+                    messages.append('* deprecated from version: ' + since[i])
                 if until[i]:
                     messages.append('* {0} {1} as of version: {2}'.format(
                         "Raises" if is_bad_version(until[i]) else "Will raise",
@@ -384,10 +385,10 @@ def deprecated_params(old_name, new_name=None, since='', until='',
                     newarg_in_kwargs = n_name in kwargs
 
                     if newarg_in_args or newarg_in_kwargs:
-                        raise TypeError(
-                            f'cannot specify both "{o_name}"'
-                            ' (deprecated parameter) and '
-                            f'"{n_name}" (new parameter name).')
+                        msg = 'cannot specify both "{}"'.format(o_name)
+                        msg += ' (deprecated parameter) and '
+                        msg += '"{}" (new parameter name).'.format(n_name)
+                        raise TypeError(msg)
 
                     # Pass the value of the old argument with the
                     # name of the new argument to the function
@@ -395,9 +396,10 @@ def deprecated_params(old_name, new_name=None, since='', until='',
                     kwargs[key] = value
 
                     if n_name is not None:
-                        message += f'* Use argument "{n_name}" instead.'
+                        message += '* Use argument "{}" instead.' \
+                            .format(n_name)
                     elif alternative:
-                        message += f'* Use {alternative} instead.'
+                        message += '* Use {} instead.'.format(alternative)
 
                     if until[i] and is_bad_version(until[i],
                                                    version_comparator):
@@ -409,7 +411,7 @@ def deprecated_params(old_name, new_name=None, since='', until='',
                 elif (not n_name and positions[i] and
                       len(args) > positions[i]):
                     if alternative:
-                        message += f'\n        Use {alternative} instead.'
+                        message += '* Use {} instead.'.format(alternative)
                     if until[i] and is_bad_version(until[i],
                                                    version_comparator):
                         raise error_class(message)

--- a/fury/deprecator.py
+++ b/fury/deprecator.py
@@ -365,7 +365,8 @@ def deprecated_params(old_name, new_name=None, since='', until='',
                 if (since[i], until[i]) != ('', ''):
                     messages.append('')
                 if since[i]:
-                    messages.append('* deprecated from version: ' + since[i])
+                    messages.append('* deprecated from version: ' +
+                                    str(since[i]))
                 if until[i]:
                     messages.append('* {0} {1} as of version: {2}'.format(
                         "Raises" if is_bad_version(until[i]) else "Will raise",

--- a/fury/tests/test_deprecator.py
+++ b/fury/tests/test_deprecator.py
@@ -291,6 +291,12 @@ def test_deprecated_argument_not_allowed_use():
         def test3(**kwargs):
             return kwargs
 
+    # wrong number of arguments
+    with pytest.raises(ValueError):
+        @deprecated_params(['a', 'b', 'c'], ['x', 'y'], '0.3')
+        def test4(**kwargs):
+            return kwargs
+
 
 def test_deprecated_argument_remove():
     @deprecated_params('x', None, '0.3', alternative='test2.y')
@@ -299,6 +305,15 @@ def test_deprecated_argument_remove():
 
     @deprecated_params('x', None, '0.3', '0.5', alternative='test2.y')
     def test2(dummy=11, x=3):
+        return dummy, x
+
+    @deprecated_params(['dummy', 'x'], None, '0.3', alternative='test2.y')
+    def test3(dummy=11, x=3):
+        return dummy, x
+
+    @deprecated_params(['dummy', 'x'], None, '0.3', '0.5',
+                       alternative='test2.y')
+    def test4(dummy=11, x=3):
         return dummy, x
 
     with pytest.warns(ArgsDeprecationWarning,
@@ -315,6 +330,13 @@ def test_deprecated_argument_remove():
                       match=r'Use test2\.y instead'):
         npt.assert_equal(test(121, 1), (121, 1))
 
+    with pytest.warns(ArgsDeprecationWarning,
+                      match=r'Use test2\.y instead') as w:
+        npt.assert_equal(test3(121, 1), (121, 1))
+
+    npt.assert_raises(ExpiredDeprecationError, test4, 121, 1)
+    npt.assert_raises(ExpiredDeprecationError, test4, dummy=121, x=1)
+    npt.assert_raises(ExpiredDeprecationError, test4, 121, x=1)
     npt.assert_raises(ExpiredDeprecationError, test2, x=1)
     npt.assert_equal(test(), (11, 3))
     npt.assert_equal(test(121), (121, 3))

--- a/fury/tests/test_deprecator.py
+++ b/fury/tests/test_deprecator.py
@@ -6,7 +6,9 @@ import fury
 from fury.decorators import skip_win, is_py35
 from fury.testing import clear_and_catch_warnings, assert_true
 from fury.deprecator import (cmp_pkg_version, _add_dep_doc, _ensure_cr,
-                             deprecate_with_version, ExpiredDeprecationError)
+                             deprecate_with_version, deprecated_params,
+                             ExpiredDeprecationError,
+                             ArgsDeprecationWarning)
 
 
 @pytest.mark.skipif(skip_win and is_py35,
@@ -163,3 +165,157 @@ def test_deprecate_with_version():
 
     func = dec('foo', until='0.3', error_class=CustomError)(func_no_doc)
     npt.assert_raises(CustomError, func)
+
+
+def test_deprecated_argument():
+    # Tests the decorator with function, method, staticmethod and classmethod.
+    class CustomActor:
+
+        @classmethod
+        @deprecated_params('height', 'scale', '0.3')
+        def test1(cls, scale):
+            return scale
+
+        @staticmethod
+        @deprecated_params('height', 'scale', '0.3')
+        def test2(scale):
+            return scale
+
+        @deprecated_params('height', 'scale', '0.3')
+        def test3(self, scale):
+            return scale
+
+        @deprecated_params('height', 'scale', '0.3', '0.5')
+        def test4(self, scale):
+            return scale
+
+        @deprecated_params('height', 'scale', '0.3', '10.0.0')
+        def test5(self, scale):
+            return scale
+
+    @deprecated_params('height', 'scale', '0.3')
+    def custom_actor(scale):
+        return scale
+
+    @deprecated_params('height', 'scale', '0.3', '0.5')
+    def custom_actor_2(scale):
+        return scale
+
+    for method in [CustomActor().test1, CustomActor().test2,
+                   CustomActor().test3, CustomActor().test4, custom_actor,
+                   custom_actor_2]:
+        # As positional argument only
+        npt.assert_equal(method(1), 1)
+        # As new keyword argument
+        npt.assert_equal(method(scale=1), 1)
+        # As old keyword argument
+        if method.__name__ not in ['test4', 'custom_actor_2']:
+            res = npt.assert_warns(ArgsDeprecationWarning, method, height=1)
+            npt.assert_equal(res, 1)
+        else:
+            npt.assert_raises(ExpiredDeprecationError, method, height=1)
+
+        # Using both. Both keyword
+        npt.assert_raises(TypeError, method, height=2, scale=1)
+        # One positional, one keyword
+        npt.assert_raises(TypeError, method, 1, scale=2)
+
+
+def test_deprecated_argument_in_kwargs():
+    # To rename an argument that is consumed by "kwargs" the "arg_in_kwargs"
+    # parameter is used.
+    @deprecated_params('height', 'scale', '0.3', arg_in_kwargs=True)
+    def test(**kwargs):
+        return kwargs['scale']
+
+    @deprecated_params('height', 'scale', '0.3', '0.5', arg_in_kwargs=True)
+    def test2(**kwargs):
+        return kwargs['scale']
+
+    # As positional argument only
+    npt.assert_raises(TypeError, test, 1)
+
+    # As new keyword argument
+    npt.assert_equal(test(scale=1), 1)
+
+    # Using the deprecated name
+    res = npt.assert_warns(ArgsDeprecationWarning, test, height=1)
+    npt.assert_equal(res, 1)
+
+    npt.assert_raises(ExpiredDeprecationError, test2, height=1)
+
+    # Using both. Both keyword
+    npt.assert_raises(TypeError, test, height=2, scale=1)
+    # One positional, one keyword
+    npt.assert_raises(TypeError, test, 1, scale=2)
+
+
+def test_deprecated_argument_multi_deprecation():
+
+    @deprecated_params(['x', 'y', 'z'], ['a', 'b', 'c'],
+                       [0.3, 0.2, 0.4])
+    def test(a, b, c):
+        return a, b, c
+
+    @deprecated_params(['x', 'y', 'z'], ['a', 'b', 'c'],
+                       '0.3')
+    def test2(a, b, c):
+        return a, b, c
+
+    with pytest.warns(ArgsDeprecationWarning) as w:
+        npt.assert_equal(test(x=1, y=2, z=3), (1, 2, 3))
+        npt.assert_equal(test2(x=1, y=2, z=3), (1, 2, 3))
+    npt.assert_equal(len(w), 6)
+
+    npt.assert_raises(TypeError, test, x=1, y=2, z=3, b=3)
+    npt.assert_raises(TypeError, test, x=1, y=2, z=3, a=3)
+
+
+def test_deprecated_argument_not_allowed_use():
+    # If the argument is supposed to be inside the kwargs one needs to set the
+    # arg_in_kwargs parameter. Without it it raises a TypeError.
+    with pytest.raises(TypeError):
+        @deprecated_params('height', 'scale', '0.3')
+        def test1(**kwargs):
+            return kwargs['scale']
+
+    # Cannot replace "*args".
+    with pytest.raises(TypeError):
+        @deprecated_params('scale', 'args', '0.3')
+        def test2(*args):
+            return args
+
+    # Cannot replace "**kwargs".
+    with pytest.raises(TypeError):
+        @deprecated_params('scale', 'kwargs', '0.3')
+        def test3(**kwargs):
+            return kwargs
+
+
+def test_deprecated_argument_remove():
+    @deprecated_params('x', None, '0.3', alternative='test2.y')
+    def test(dummy=11, x=3):
+        return dummy, x
+
+    @deprecated_params('x', None, '0.3', '0.5', alternative='test2.y')
+    def test2(dummy=11, x=3):
+        return dummy, x
+
+    with pytest.warns(ArgsDeprecationWarning,
+                      match=r'Use test2\.y instead') as w:
+        npt.assert_equal(test(x=1), (11, 1))
+    npt.assert_equal(len(w), 1)
+
+    with pytest.warns(ArgsDeprecationWarning,
+                      match=r'Use test2\.y instead') as w:
+        npt.assert_equal(test(x=1, dummy=10), (10, 1))
+    npt.assert_equal(len(w), 1)
+
+    with pytest.warns(ArgsDeprecationWarning,
+                      match=r'Use test2\.y instead'):
+        npt.assert_equal(test(121, 1), (121, 1))
+
+    npt.assert_raises(ExpiredDeprecationError, test2, x=1)
+    npt.assert_equal(test(), (11, 3))
+    npt.assert_equal(test(121), (121, 3))
+    npt.assert_equal(test(dummy=121), (121, 3))


### PR DESCRIPTION
This PR adds a decorator to deprecate one or multiple parameters from a function.

# Examples

```python
# The deprecation warnings are not shown in the following examples.
# To deprecate a positional or keyword argument
>>> from fury.deprecator import deprecated_params
>>> @deprecated_params('sig', 'sigma', '0.3')
...    def test(sigma):
...        return sigma
>>> test(2)
2
>>> test(sigma=2)
2
>>> test(sig=2)
/Users/koudoro/miniconda3/envs/fury-env-37/bin/ipython:1: ArgsDeprecationWarning: "sig" was deprecated

* deprecated from version: 1.0
* Use argument "sigma" instead.
2

# It is also possible to replace multiple arguments. The ``old_name``,
# ``new_name`` and ``since`` have to be `tuple` or `list` and contain the
# same number of entries::
>>> @deprecated_params(['a', 'b'], ['alpha', 'beta'], since=['0.2', 0.4], until=['0.7', '0.6'])
...    def test(alpha, beta):
...        return alpha, beta
>>> test(a=2, b=3)
/Users/koudoro/miniconda3/envs/fury-env-37/bin/ipython:5: ArgsDeprecationWarning: "a" was deprecated

* deprecated from version: 0.2
* Use argument "alpha" instead.
  
/Users/koudoro/miniconda3/envs/fury-env-37/bin/ipython:5: ArgsDeprecationWarning: "b" was deprecated

* deprecated from version: 0.4
* Use argument "beta" instead.
(2, 3)
```