### PR TITLE
Adding new Earth coordinates tutorial

### DIFF
--- a/docs/tutorials/01_introductory/viz_earth_coordinates.py
+++ b/docs/tutorials/01_introductory/viz_earth_coordinates.py
@@ -41,15 +41,15 @@ earth_actor.SetScale(2, 2, 2)
 # In this function, convert to radians, then to spherical coordinates, and
 # lastly, to cartesian coordinates.
 
+
 def latlong_coordinates(lat, lon):
-    #Convert latitude and longitude to spherical coordinates
+    # Convert latitude and longitude to spherical coordinates
     degrees_to_radians = math.pi/180.0
-    #phi = 90 - latitude
+    # phi = 90 - latitude
     phi = (90-lat)*degrees_to_radians
-    #theta = longitude
+    # theta = longitude
     theta = lon*degrees_to_radians*-1
-    #r is radius 1
-    #now convert to cartesian
+    # now convert to cartesian
     x = np.sin(phi)*np.cos(theta)
     y = np.sin(phi)*np.sin(theta)
     z = np.cos(phi)
@@ -61,9 +61,9 @@ def latlong_coordinates(lat, lon):
 # Use this new function to place some sphere actors on several big cities
 # around the Earth.
 
-locationone = latlong_coordinates(40.730610, -73.935242) #new york city, us
-locationtwo = latlong_coordinates(39.916668, 116.383331) #beijing, china
-locationthree = latlong_coordinates(48.864716, 2.349014) #paris, france
+locationone = latlong_coordinates(40.730610, -73.935242) # new york city, us
+locationtwo = latlong_coordinates(39.916668, 116.383331) # beijing, china
+locationthree = latlong_coordinates(48.864716, 2.349014) # paris, france
 
 ###############################################################################
 # Set the centers, radii, and colors of these spheres, and create a new
@@ -80,14 +80,17 @@ scene.add(sphere_actor)
 # geographical coordinates.
 
 nyc_actor = actor.text_3d("New York City, New York\n40.7128° N, 74.0060° W",
-                         (locationone[0]-0.04, locationone[1], locationone[2]+0.07),
-                         window.colors.white, 0.01)
+                          (locationone[0]-0.04, locationone[1],
+                          locationone[2]+0.07),
+                          window.colors.white, 0.01)
 paris_actor = actor.text_3d("Paris, France\n48.8566° N, 2.3522° E",
-                           (locationthree[0]-0.04, locationthree[1], locationthree[2]-0.07),
-                           window.colors.white, 0.01)
+                           (locationthree[0]-0.04, locationthree[1],
+                            locationthree[2]-0.07),
+                            window.colors.white, 0.01)
 beijing_actor = actor.text_3d("Beijing, China\n39.9042° N, 116.4074° E",
-                             (locationtwo[0]-0.06, locationtwo[1], locationtwo[2]-0.07),
-                             window.colors.white, 0.01)
+                             (locationtwo[0]-0.06, locationtwo[1],
+                              locationtwo[2]-0.07),
+                              window.colors.white, 0.01)
 utils.rotate(paris_actor, (85, 0, 1, 0))
 utils.rotate(beijing_actor, (180, 0, 1, 0))
 utils.rotate(nyc_actor, (5, 1, 0, 0))
@@ -106,6 +109,7 @@ showm = window.ShowManager(scene,
 # location.
 
 counter = itertools.count()
+
 
 def timer_callback(_obj, _event):
     cnt = next(counter)

--- a/docs/tutorials/01_introductory/viz_earth_coordinates.py
+++ b/docs/tutorials/01_introductory/viz_earth_coordinates.py
@@ -61,9 +61,9 @@ def latlong_coordinates(lat, lon):
 # Use this new function to place some sphere actors on several big cities
 # around the Earth.
 
-locationone = latlong_coordinates(40.730610, -73.935242) # new york city, us
-locationtwo = latlong_coordinates(39.916668, 116.383331) # beijing, china
-locationthree = latlong_coordinates(48.864716, 2.349014) # paris, france
+locationone = latlong_coordinates(40.730610, -73.935242)  # new york city, us
+locationtwo = latlong_coordinates(39.916668, 116.383331)  # beijing, china
+locationthree = latlong_coordinates(48.864716, 2.349014)  # paris, france
 
 ###############################################################################
 # Set the centers, radii, and colors of these spheres, and create a new
@@ -81,10 +81,10 @@ scene.add(sphere_actor)
 
 nyc_actor = actor.text_3d("New York City, New York\n40.7128° N, 74.0060° W",
                           (locationone[0]-0.04, locationone[1],
-                          locationone[2]+0.07),
+                           locationone[2]+0.07),
                           window.colors.white, 0.01)
 paris_actor = actor.text_3d("Paris, France\n48.8566° N, 2.3522° E",
-                           (locationthree[0]-0.04, locationthree[1],
+                            (locationthree[0]-0.04, locationthree[1],
                             locationthree[2]-0.07),
                             window.colors.white, 0.01)
 beijing_actor = actor.text_3d("Beijing, China\n39.9042° N, 116.4074° E",

--- a/docs/tutorials/01_introductory/viz_earth_coordinates.py
+++ b/docs/tutorials/01_introductory/viz_earth_coordinates.py
@@ -85,11 +85,11 @@ nyc_actor = actor.text_3d("New York City, New York\n40.7128° N, 74.0060° W",
                           window.colors.white, 0.01)
 paris_actor = actor.text_3d("Paris, France\n48.8566° N, 2.3522° E",
                             (locationthree[0]-0.04, locationthree[1],
-                            locationthree[2]-0.07),
+                             locationthree[2]-0.07),
                             window.colors.white, 0.01)
 beijing_actor = actor.text_3d("Beijing, China\n39.9042° N, 116.4074° E",
-                             (locationtwo[0]-0.06, locationtwo[1],
-                              locationtwo[2]-0.07),
+                              (locationtwo[0]-0.06, locationtwo[1],
+                               locationtwo[2]-0.07),
                               window.colors.white, 0.01)
 utils.rotate(paris_actor, (85, 0, 1, 0))
 utils.rotate(beijing_actor, (180, 0, 1, 0))

--- a/docs/tutorials/01_introductory/viz_earth_coordinates.py
+++ b/docs/tutorials/01_introductory/viz_earth_coordinates.py
@@ -1,0 +1,150 @@
+
+"""
+============================
+Earth Coordinate Conversion
+============================
+
+In this tutorial, we will show how to place actors on specific locations
+on the surface of the Earth using a new function.
+"""
+
+from fury import window, actor, utils, io
+from fury.data import read_viz_textures, fetch_viz_textures
+import math
+import numpy as np
+import itertools
+
+###############################################################################
+# Create a new scene, and load in the image of the Earth using
+# ``fetch_viz_textures`` and ``read_viz_textures``. We will use a 16k
+# resolution texture for maximum detail.
+
+scene = window.Scene()
+
+fetch_viz_textures()
+earth_file = read_viz_textures("1_earth_16k.jpg")
+earth_image = io.load_image(earth_file)
+earth_actor = actor.texture_on_sphere(earth_image)
+scene.add(earth_actor)
+
+###############################################################################
+# Rotate the Earth to make sure the texture is correctly oriented. Change it's
+# scale using ``actor.SetScale()``.
+
+utils.rotate(earth_actor, (-90, 1, 0, 0))
+utils.rotate(earth_actor, (180, 0, 1, 0))
+earth_actor.SetScale(2, 2, 2)
+
+###############################################################################
+# Define the function to convert geographical coordinates of a location in
+# latitude and longitude degrees to coordinates on the ``earth_actor`` surface.
+# In this function, convert to radians, then to spherical coordinates, and
+# lastly, to cartesian coordinates.
+
+def latlong_coordinates(lat, lon):
+    #Convert latitude and longitude to spherical coordinates
+    degrees_to_radians = math.pi/180.0
+    #phi = 90 - latitude
+    phi = (90-lat)*degrees_to_radians
+    #theta = longitude
+    theta = lon*degrees_to_radians*-1
+    #r is radius 1
+    #now convert to cartesian
+    x = np.sin(phi)*np.cos(theta)
+    y = np.sin(phi)*np.sin(theta)
+    z = np.cos(phi)
+    # flipping z to y for FURY coordinates
+    return (x, z, y)
+
+
+###############################################################################
+# Use this new function to place some sphere actors on several big cities
+# around the Earth.
+
+locationone = latlong_coordinates(40.730610, -73.935242) #new york city, us
+locationtwo = latlong_coordinates(39.916668, 116.383331) #beijing, china
+locationthree = latlong_coordinates(48.864716, 2.349014) #paris, france
+
+###############################################################################
+# Set the centers, radii, and colors of these spheres, and create a new
+# ``sphere_actor`` for each location to add to the scene.
+
+centers = np.array([[*locationone], [*locationtwo], [*locationthree]])
+colors = np.random.rand(3, 3)
+radii = np.array([0.005, 0.005, 0.005])
+sphere_actor = actor.sphere(centers, colors, radii)
+scene.add(sphere_actor)
+
+###############################################################################
+# Create some text actors to add to the scene indicating each location and its
+# geographical coordinates.
+
+nyc_actor = actor.text_3d("New York City, New York\n40.7128° N, 74.0060° W",
+                         (locationone[0]-0.04, locationone[1], locationone[2]+0.07),
+                         window.colors.white, 0.01)
+paris_actor = actor.text_3d("Paris, France\n48.8566° N, 2.3522° E",
+                           (locationthree[0]-0.04, locationthree[1], locationthree[2]-0.07),
+                           window.colors.white, 0.01)
+beijing_actor = actor.text_3d("Beijing, China\n39.9042° N, 116.4074° E",
+                             (locationtwo[0]-0.06, locationtwo[1], locationtwo[2]-0.07),
+                             window.colors.white, 0.01)
+utils.rotate(paris_actor, (85, 0, 1, 0))
+utils.rotate(beijing_actor, (180, 0, 1, 0))
+utils.rotate(nyc_actor, (5, 1, 0, 0))
+
+##############################################################################
+# Create a ShowManager object, which acts as the interface between the scene,
+# the window and the interactor.
+
+showm = window.ShowManager(scene,
+                           size=(900, 768), reset_camera=False,
+                           order_transparent=True)
+
+###############################################################################
+# Let's create a ``timer_callback function to add some animation to the Earth.
+# Change the camera position and angle to fly over and zoom in on each new
+# location.
+
+counter = itertools.count()
+
+def timer_callback(_obj, _event):
+    cnt = next(counter)
+    showm.render()
+    if cnt == 0:
+        scene.set_camera(position=(1.5, 3.5, 7.0))
+    if cnt < 200 and cnt > 25:
+        scene.zoom(1.015)
+        scene.pitch(0.01)
+    if cnt == 200:
+        scene.add(nyc_actor)
+    if cnt > 250 and cnt < 350:
+        scene.zoom(0.985)
+    if cnt > 350 and cnt < 425:
+        scene.azimuth(1)
+    if cnt > 425 and cnt < 525:
+        scene.zoom(1.015)
+        scene.pitch(0.011)
+    if cnt == 525:
+        scene.add(paris_actor)
+    if cnt > 575 and cnt < 700:
+        scene.zoom(0.985)
+    if cnt > 700 and cnt < 820:
+        scene.azimuth(1)
+    if cnt > 820 and cnt < 930:
+        scene.zoom(1.015)
+    if cnt == 930:
+        scene.add(beijing_actor)
+    if cnt == 1000:
+        showm.exit()
+
+
+###############################################################################
+# Initialize the ShowManager object, add the timer_callback, and watch the
+# new animation take place!
+
+showm.initialize()
+showm.add_timer_callback(True, 25, timer_callback)
+showm.start()
+
+window.record(showm.scene, size=(900, 768),
+              out_path="viz_earth_coordinates.png")

--- a/fury/data/fetcher.py
+++ b/fury/data/fetcher.py
@@ -317,7 +317,7 @@ fetch_viz_textures = _make_fetcher(
      '8k_mars.jpg', '8k_saturn.jpg',
      '8k_saturn_ring_alpha.png',
      '2k_uranus.jpg', '2k_neptune.jpg',
-     '8k_sun.jpg'],
+     '8k_sun.jpg', '1_earth_16k.jpg'],
     ['1_earth_8k.jpg', '2_no_clouds_8k.jpg',
      '5_night_8k.jpg', 'earth.ppm',
      'jupiter.jpg', 'masonry.bmp',
@@ -328,7 +328,7 @@ fetch_viz_textures = _make_fetcher(
      '8k_mars.jpg', '8k_saturn.jpg',
      '8k_saturn_ring_alpha.png',
      '2k_uranus.jpg', '2k_neptune.jpg',
-     '8k_sun.jpg'],
+     '8k_sun.jpg', '1_earth_16k.jpg'],
     ['0D66DC62768C43D763D3288CE67128AAED27715B11B0529162DC4117F710E26F',
      '5CF740C72287AF7B3ACCF080C3951944ADCB1617083B918537D08CBD9F2C5465',
      'DF443F3E20C7724803690A350D9F6FDB36AD8EBC011B0345FB519A8B321F680A',
@@ -348,7 +348,8 @@ fetch_viz_textures = _make_fetcher(
      'F1F826933C9FF87D64ECF0518D6256B8ED990B003722794F67E96E3D2B876AE4',
      'D15239D46F82D3EA13D2B260B5B29B2A382F42F2916DAE0694D0387B1204A09D',
      'CB42EA82709741D28B0AF44D8B283CBC6DBD0C521A7F0E1E1E010ADE00977DF6',
-     'F22B1CFB306DDCE72A7E3B628668A0175B745038CE6268557CB2F7F1BDF98B9D'],
+     'F22B1CFB306DDCE72A7E3B628668A0175B745038CE6268557CB2F7F1BDF98B9D',
+     '7DD1DAC926101B5D7B7F2E952E53ACF209421B5CCE57C03168BCE0AAD675998A'],
     doc="Download textures for fury"
     )
 


### PR DESCRIPTION
This PR includes a new tutorial for FURY, including a new function to convert longitude and latitude coordinates of any location on Earth to coordinates for a sphere actor on that exact location called ``latlong_coordinates``. This tutorial also demonstrates how to add several actors to a scene at once, as well as create some camera flyover movement in an animation.

The texture used for this tutorial is a new 16k resolution Earth texture, which was added to fetcher.py.

When the animation is run, it will fly over three different cities on Earth, each with their own text label to indicate the city, country, and its coordinates, as produced by ``latlong_coordinates``.