### PR TITLE
Release 0.6.0 preparation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -25,4 +25,5 @@ Shreyas Bhujbal <shreyasb2@gmail.com> Shreyas Bhujbal <shreyasbhujbal@zoho.com>
 Shreyas Bhujbal <shreyasb2@gmail.com> kakashihatakae <shreyasb2@gmail.com>
 Melina Raglin <raglin.11@buckeyemail.osu.edu> mlraglin <43075495+mlraglin@users.noreply.github.com>
 Melina Raglin <raglin.11@buckeyemail.osu.edu> Melina Raglin <43075495+mlraglin@users.noreply.github.com>
+Lenix Lobo <lenixlobo@gmail.com> lenixlobo <lenixlobo@gmail.com>
 

--- a/.mailmap
+++ b/.mailmap
@@ -23,4 +23,6 @@ Javier Guaje <jrguajeg@gmail.com> Javier Guaje <jrguajeg@iu.edu>
 Javier Guaje <jrguajeg@gmail.com> Javier Guaje <guaje@users.noreply.github.com>
 Shreyas Bhujbal <shreyasb2@gmail.com> Shreyas Bhujbal <shreyasbhujbal@zoho.com>
 Shreyas Bhujbal <shreyasb2@gmail.com> kakashihatakae <shreyasb2@gmail.com>
+Melina Raglin <raglin.11@buckeyemail.osu.edu> mlraglin <43075495+mlraglin@users.noreply.github.com>
+Melina Raglin <raglin.11@buckeyemail.osu.edu> Melina Raglin <43075495+mlraglin@users.noreply.github.com>
 

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -51,6 +51,8 @@ Contributors
 * Shreyas Bhujbal
 * Ibrahim Anis
 * Filipi Nascimento Silva
+* Melina Raglin
+* Tushar
 * Naman Bansal
 * Nasim Anousheh
 * Gottipati Gautam

--- a/docs/source/ext/github_tools.py
+++ b/docs/source/ext/github_tools.py
@@ -388,10 +388,10 @@ def github_stats(**kwargs):
         f = open(fpath, 'w')
         orig_stdout = sys.stdout
         sys.stdout = f
-        print(".. _{}".format(fname))
+        print(".. _{}".format(fname.replace('.rst', ':')))
         print()
         print(("==============================\n"
-               " Release notes version {}\n"
+               " Release notes v{}\n  ()"
                "==============================").format(version))
 
     # By default, search one month back

--- a/docs/source/posts/2020/2020-07-20-release-announcement.rst
+++ b/docs/source/posts/2020/2020-07-20-release-announcement.rst
@@ -1,0 +1,48 @@
+FURY 0.6.0 Released
+===================
+
+.. post:: July 20 2020
+   :author: skoudoro
+   :tags: fury
+   :category: release
+
+
+The FURY project is happy to announce the release of FURY 0.6.0!
+FURY is a free and open source software library for scientific visualization and 3D animations.
+
+You can show your support by `adding a star <https://github.com/fury-gl/fury/stargazers>`_ on FURY github project.
+
+The **major highlights** of this release are:
+
+.. include:: ../../release_notes/releasev0.6.0.rst
+    :start-after: --------------
+    :end-before: Details
+
+.. note:: The complete release notes are available :ref:`here <releasev0.6.0>`
+
+**To upgrade or install FURY**
+
+Run the following command in your terminal::
+
+    pip install --upgrade fury
+
+or::
+
+    conda install -c conda-forge fury
+
+
+**Questions or suggestions?**
+
+For any questions go to http://fury.gl, or send an e-mail to fury@python.org
+We can also join our `discord community <https://discord.gg/6btFPPj>`_
+
+We would like to thanks to :ref:`all contributors <community>` for this release:
+
+.. include:: ../../release_notes/releasev0.6.0.rst
+    :start-after: commits.
+    :end-before: We closed
+
+
+On behalf of the :ref:`FURY developers <community>`,
+
+Serge K.

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -7,6 +7,7 @@ For a full list of the features implemented in the most recent release cycle, ch
 .. toctree::
    :maxdepth: 1
 
+   release_notes/releasev0.6.0
    release_notes/releasev0.5.1
    release_notes/releasev0.4.0
    release_notes/releasev0.3.0

--- a/docs/source/release_notes/releasev0.6.0.rst
+++ b/docs/source/release_notes/releasev0.6.0.rst
@@ -34,7 +34,7 @@ The following 9 authors contributed 266 commits.
 * Serge Koudoro
 * Soham Biswas
 * Tushar
-* lenixlobo
+* Lenix Lobo
 
 
 We closed a total of 60 issues, 25 pull requests and 35 regular issues;

--- a/docs/source/release_notes/releasev0.6.0.rst
+++ b/docs/source/release_notes/releasev0.6.0.rst
@@ -1,0 +1,108 @@
+.. _releasev0.6.0:
+
+=========================================
+ Release notes v0.6.0 (2020-07-20)
+=========================================
+
+Quick Overview
+--------------
+
+* Added new features: Picking and DoubleClick callback
+* Added Signed Distance Field actor.
+* Added a new UI ComboBox
+* Added multiples primitives (Rhombocuboctahedron, ...)
+* Huge improvement of multiple UI and actors
+* Fixed Compatibility with VTK9
+* Large documentation update, examples and tutorials (5 new)
+* Added a blog system
+* Increased tests coverage and code quality
+
+Details
+-------
+
+GitHub stats for 2020/04/09 - 2020/07/20 (tag: v0.5.1)
+
+These lists are automatically generated, and may be incomplete or contain duplicates.
+
+The following 9 authors contributed 266 commits.
+
+* Eleftherios Garyfallidis
+* Liam Donohue
+* Marc-Alexandre Côté
+* Melina Raglin
+* Naman Bansal
+* Serge Koudoro
+* Soham Biswas
+* Tushar
+* lenixlobo
+
+
+We closed a total of 60 issues, 25 pull requests and 35 regular issues;
+this is the full list (generated with the script
+:file:`tools/github_stats.py`):
+
+Pull Requests (25):
+
+* :ghpull:`241`: Adding  a Blog system to fury
+* :ghpull:`268`: Clip Text Overflow
+* :ghpull:`267`: SDF tutorial
+* :ghpull:`250`: SDF based FURY actors
+* :ghpull:`246`: ComboBox UI tutorial
+* :ghpull:`265`: Adding new Earth coordinates tutorial
+* :ghpull:`240`: ComboBox2D UI element
+* :ghpull:`169`: Use primitive for box, cube, square, rectangle actors
+* :ghpull:`262`: Solar System Tutorial
+* :ghpull:`248`: Setting Bounding Box for TextBlock2D
+* :ghpull:`263`: [NF] Deprecated parameters
+* :ghpull:`127`: [CI] add Python 3.8
+* :ghpull:`255`: Let VTK delete timers on exit.
+* :ghpull:`233`: Picking API and picking tutorial
+* :ghpull:`261`: Adding Earth Animation Tutorial
+* :ghpull:`249`: Octagonal Prism and Frustum Square Pyramid
+* :ghpull:`258`: Updating test of order_transparency for compatibility with vtk 9
+* :ghpull:`259`: Updated Step 3 in README.rst
+* :ghpull:`231`: Adding Double Click Callback
+* :ghpull:`256`: Install ssl certificate for azure pipeline windows
+* :ghpull:`245`: [FIX]  Compatibility with VTK 9
+* :ghpull:`244`: Added new texture tutorial
+* :ghpull:`235`: Function to use Hexadecimal color code in Colormap
+* :ghpull:`238`: Added Rhombocuboctahedron, 2D and 3D star to primitive
+* :ghpull:`237`: update copyright years
+
+Issues (35):
+
+* :ghissue:`241`: Adding  a Blog system to fury
+* :ghissue:`268`: Clip Text Overflow
+* :ghissue:`264`: Re-implementation of Text Overflow in ListBox2D
+* :ghissue:`267`: SDF tutorial
+* :ghissue:`247`: PR idea: create SDF alternatives to FURY primitive actors
+* :ghissue:`250`: SDF based FURY actors
+* :ghissue:`246`: ComboBox UI tutorial
+* :ghissue:`265`: Adding new Earth coordinates tutorial
+* :ghissue:`240`: ComboBox2D UI element
+* :ghissue:`169`: Use primitive for box, cube, square, rectangle actors
+* :ghissue:`138`: Box, cone etc. to work similarly to superquadric
+* :ghissue:`262`: Solar System Tutorial
+* :ghissue:`248`: Setting Bounding Box for TextBlock2D
+* :ghissue:`263`: [NF] Deprecated parameters
+* :ghissue:`127`: [CI] add Python 3.8
+* :ghissue:`51`: Improvements from VTK 8.2.0?
+* :ghissue:`255`: Let VTK delete timers on exit.
+* :ghissue:`253`: Programs with timers hang on exit. [VTK9] [Linux]
+* :ghissue:`233`: Picking API and picking tutorial
+* :ghissue:`261`: Adding Earth Animation Tutorial
+* :ghissue:`249`: Octagonal Prism and Frustum Square Pyramid
+* :ghissue:`258`: Updating test of order_transparency for compatibility with vtk 9
+* :ghissue:`254`: unexpected order transparent behavior [VTK9] [Ubuntu 18.04]
+* :ghissue:`259`: Updated Step 3 in README.rst
+* :ghissue:`251`: Developer installation instructions should describe -e option
+* :ghissue:`226`: Adding DoubleClick event
+* :ghissue:`231`: Adding Double Click Callback
+* :ghissue:`256`: Install ssl certificate for azure pipeline windows
+* :ghissue:`245`: [FIX]  Compatibility with VTK 9
+* :ghissue:`244`: Added new texture tutorial
+* :ghissue:`235`: Function to use Hexadecimal color code in Colormap
+* :ghissue:`238`: Added Rhombocuboctahedron, 2D and 3D star to primitive
+* :ghissue:`197`: Added Rhombocuboctahedron, 2D and 3D star to primitive
+* :ghissue:`237`: update copyright years
+* :ghissue:`216`: Utiltiy function to use Hexadecimal color code

--- a/docs/source/release_notes/releasev0.6.0.rst
+++ b/docs/source/release_notes/releasev0.6.0.rst
@@ -7,15 +7,15 @@
 Quick Overview
 --------------
 
-* Added new features: Picking and DoubleClick callback
+* Added new features: Picking and DoubleClick callback.
 * Added Signed Distance Field actor.
-* Added a new UI ComboBox
-* Added multiples primitives (Rhombocuboctahedron, ...)
-* Huge improvement of multiple UI and actors
-* Fixed Compatibility with VTK9
-* Large documentation update, examples and tutorials (5 new)
-* Added a blog system
-* Increased tests coverage and code quality
+* Added a new UI ComboBox.
+* Added multiples primitives (Rhombocuboctahedron, ...).
+* Huge improvement of multiple UIs and actors.
+* Fixed Compatibility with VTK9.
+* Large documentation update, examples and tutorials (5 new).
+* Added a blog system.
+* Increased tests coverage and code quality.
 
 Details
 -------

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import versioneer
 # and/or pip.
 if sys.version_info < (2, 7):
     error = """fury does not support Python {0}.{2}.
-               Python 2.7 and above is required.
+               Python 3.5 and above is required.
                Check your Python version like so:
 
                python3 --version


### PR DESCRIPTION
# Summary

Preparation for 0.6.0 release, targeting Monday, July 20th. 

Just a note that any PR can block the release. If they are not in, it will be for the next release in
September.

# Release checklist
- [x] add release_notes 0.6.0 and update release-history.rst
- [x] Update .mailmap
- [x] Check the copyright years in LICENSE
- [x] Check documentation
- [x] Check Tutorial
- [x] Update index.rst
- [x] Add a blog post
- [x] Update website
- [x] Update deprecation cycle : `DeprecationWarning` -> `PendingDeprecationWarning` ->  delete 