### PR TITLE
Fixed bug in tutorial with accessing colors for latest release

### DIFF
--- a/docs/tutorials/01_introductory/viz_picking.py
+++ b/docs/tutorials/01_introductory/viz_picking.py
@@ -16,7 +16,7 @@ import numpy as np
 from fury import actor, window, ui, utils, pick
 
 centers = 0.5 * np.array([[0, 0, 0], [100, 0, 0], [200, 0, 0.]])
-colors = np.array([[0.8, 0, 0], [0, 0.8, 0], [0, 0, 0.8]])
+colors = 255 * np.array([[0.8, 0, 0], [0, 0.8, 0], [0, 0, 0.8]])
 radii = 0.1 * np.array([50, 100, 150.])
 
 selected = np.zeros(3, dtype=np.bool)
@@ -55,7 +55,7 @@ num_objects = centers.shape[0]
 ###############################################################################
 # Access the memory of the colors of all the cubes
 
-vcolors = utils.colors_from_actor(fury_actor, 'colors')
+vcolors = utils.colors_from_actor(fury_actor, 'RGB')
 
 ###############################################################################
 # Adding an actor showing the axes of the world coordinates


### PR DESCRIPTION
After the introduction of the new primitives we need to change the name of the color array that we are accessing.

Also the initial colors have different range. Had to multiply with 255.