### PR TITLE
Standardize Colors array name 

### DIFF
--- a/fury/actor.py
+++ b/fury/actor.py
@@ -599,7 +599,7 @@ def streamtube(lines, colors=None, opacity=1, linewidth=0.1, tube_sides=9,
     poly_mapper = set_input(vtk.vtkPolyDataMapper(), next_input)
     poly_mapper.ScalarVisibilityOn()
     poly_mapper.SetScalarModeToUsePointFieldData()
-    poly_mapper.SelectColorArray("Colors")
+    poly_mapper.SelectColorArray("colors")
     poly_mapper.Update()
 
     # Color Scale with a lookup table
@@ -711,7 +711,7 @@ def line(lines, colors=None, opacity=1, linewidth=1,
     poly_mapper = set_input(vtk.vtkPolyDataMapper(), next_input)
     poly_mapper.ScalarVisibilityOn()
     poly_mapper.SetScalarModeToUsePointFieldData()
-    poly_mapper.SelectColorArray("Colors")
+    poly_mapper.SelectColorArray("colors")
     poly_mapper.Update()
 
     if depth_cue:

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1001,7 +1001,7 @@ def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
         deep=True,
         array_type=vtk.VTK_UNSIGNED_CHAR)
 
-    vtk_colors.SetName("Colors")
+    vtk_colors.SetName("colors")
 
     polydata = vtk.vtkPolyData()
     polydata.SetPoints(points)
@@ -1195,7 +1195,7 @@ def _tensor_slicer_mapper(evals, evecs, affine=None, mask=None, sphere=None,
         deep=True,
         array_type=vtk.VTK_UNSIGNED_CHAR)
 
-    vtk_colors.SetName("Colors")
+    vtk_colors.SetName("colors")
 
     polydata = vtk.vtkPolyData()
     polydata.SetPoints(points)

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -267,7 +267,7 @@ def lines_to_vtk_polydata(lines, colors=None):
                 vtk_colors = numpy_support.numpy_to_vtk(cols_arr, deep=True)
                 color_is_scalar = True
 
-    vtk_colors.SetName("Colors")
+    vtk_colors.SetName("colors")
     poly_data.GetPointData().SetScalars(vtk_colors)
     return poly_data, color_is_scalar
 
@@ -434,7 +434,7 @@ def set_polydata_normals(polydata, normals):
     return polydata
 
 
-def set_polydata_colors(polydata, colors):
+def set_polydata_colors(polydata, colors, array_name="colors"):
     """Set polydata colors with a numpy array (ndarrays Nx3 int).
 
     Parameters
@@ -447,7 +447,7 @@ def set_polydata_colors(polydata, colors):
     vtk_colors = numpy_support.numpy_to_vtk(colors, deep=True,
                                             array_type=vtk.VTK_UNSIGNED_CHAR)
     vtk_colors.SetNumberOfComponents(3)
-    vtk_colors.SetName("RGB")
+    vtk_colors.SetName(array_name)
     polydata.GetPointData().SetScalars(vtk_colors)
     return polydata
 
@@ -561,7 +561,7 @@ def get_actor_from_primitive(vertices, triangles, colors=None,
     set_polydata_triangles(pd, triangles)
     if isinstance(colors, np.ndarray):
         set_polydata_colors(pd, colors)
-    if isinstance(normals, np.ndarray):
+    if isinstance(normals, np.ndarray, array_name="colors"):
         set_polydata_normals(pd, normals)
 
     current_actor = get_actor_from_polydata(pd)

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -560,8 +560,8 @@ def get_actor_from_primitive(vertices, triangles, colors=None,
     set_polydata_vertices(pd, vertices)
     set_polydata_triangles(pd, triangles)
     if isinstance(colors, np.ndarray):
-        set_polydata_colors(pd, colors)
-    if isinstance(normals, np.ndarray, array_name="colors"):
+        set_polydata_colors(pd, colors, array_name="colors")
+    if isinstance(normals, np.ndarray):
         set_polydata_normals(pd, normals)
 
     current_actor = get_actor_from_polydata(pd)


### PR DESCRIPTION
This PR should fix #280, and a part of #269.  Colors array had different names in our codebase so I just normalize this point.