### PR TITLE
Release 0.6.1 preparation 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -12,6 +12,9 @@ Bago Amirbekian <Bago.Amirbekian@ucsf.edu> Bago Amirbekian <mrbago@gmail.com>
 Ranveer Aggarwal <ranveeraggarwal@gmail.com> Ranveer Aggarwal <ranveeraggarwal@users.noreply.github.com>
 Omar Ocegueda <jomaroceguedag@gmail.com> omarocegueda <jomaroceguedag@gmail.com>
 Etienne St-Onge <etienne.st-onge@usherbrooke.ca> Etienne <stonge.etienne@gmail.com>
+Etienne St-Onge <etienne.st-onge@usherbrooke.ca> Etienne St-Onge <ch185690@carlsen.tch.harvard.edu>
+Etienne St-Onge <etienne.st-onge@usherbrooke.ca> Etienne St-Onge <Etienne.St-Onge@usherbrooke.ca>
+Etienne St-Onge <etienne.st-onge@usherbrooke.ca> Etienne St-Onge <etienne.st-onge@usherbrooke.ca>
 Soham Biswas <sohambiswas41@gmail.com> Nibba2018 <sohambiswas41@gmail.com>
 Soham Biswas <sohambiswas41@gmail.com> nibba <nibba@pop-os.localdomain>
 Vivek Choudhary <choudhary.vivek98@gmail.com> paulnicolashunter <choudhary.vivek98@gmail.com>
@@ -26,4 +29,5 @@ Shreyas Bhujbal <shreyasb2@gmail.com> kakashihatakae <shreyasb2@gmail.com>
 Melina Raglin <raglin.11@buckeyemail.osu.edu> mlraglin <43075495+mlraglin@users.noreply.github.com>
 Melina Raglin <raglin.11@buckeyemail.osu.edu> Melina Raglin <43075495+mlraglin@users.noreply.github.com>
 Lenix Lobo <lenixlobo@gmail.com> lenixlobo <lenixlobo@gmail.com>
-
+Nasim Anousheh <nasimanousheh@gmail.com> Nasim <nasimanousheh@gmail.com>
+Kesshi Jordan <Kesshi.Jordan@ucsf.edu> kesshijordan <Kesshi.Jordan@ucsf.edu>

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,13 +16,15 @@ Contributors
 ------------
 
 * Javier Guaje
+* Soham Biswas
+* Lenix Lobo
+* Nasim Anousheh
 * Ariel Rokem, University of Washington, WA, USA
 * Matthew Brett, Birmingham University, Birmingham, UK
 * Yaroslav Halchenko
 * Kesshi jordan
 * Prashil
 * Matthew Brett
-* kesshijordan
 * Kevin Sitek
 * Bago Amirbekian
 * Omar Ocegueda
@@ -44,8 +46,6 @@ Contributors
 * Gauvin Alexandre
 * Ian Nimmo-Smith
 * Yaroslav Halchenko
-* Soham Biswas
-* Lenix Lobo
 * Vivek Choudhary
 * Saransh Jain
 * Shreyas Bhujbal
@@ -54,7 +54,6 @@ Contributors
 * Melina Raglin
 * Tushar
 * Naman Bansal
-* Nasim Anousheh
 * Gottipati Gautam
 * Liam Donohue
 * Devanshu Modi

--- a/docs/source/posts/2020/2020-06-07-week-2-lenix.rst
+++ b/docs/source/posts/2020/2020-06-07-week-2-lenix.rst
@@ -1,5 +1,5 @@
 First week of coding!!
-==================
+======================
 
 .. post:: June 7 2020
    :author: Lenix Lobo
@@ -11,8 +11,8 @@ This week : Geometry Shaders!
 
 What did you do this week?
 --------------------------
-To get a better understanding of the working of the shader pipeline, the mentors assigned me a challenging task of implementing a Dynamic Texture. The basic idea is to create a 'volumetric' texture by stacking layer of textures. Such an example is an ideal use case for a geometry shader. Since i had not much prior experience with Geometry shaders before, i spent the initial days going through existing implementations of similar ideas in OpenGL/DirectX.  
-After working on the code, the final image rendered is given below. 
+To get a better understanding of the working of the shader pipeline, the mentors assigned me a challenging task of implementing a Dynamic Texture. The basic idea is to create a 'volumetric' texture by stacking layer of textures. Such an example is an ideal use case for a geometry shader. Since i had not much prior experience with Geometry shaders before, i spent the initial days going through existing implementations of similar ideas in OpenGL/DirectX.
+After working on the code, the final image rendered is given below.
 
 .. image:: https://raw.githubusercontent.com/lenixlobo/fury-outputs/master/blog-week-2.png
 

--- a/docs/source/posts/2020/2020-06-28-week-5-soham.rst
+++ b/docs/source/posts/2020/2020-06-28-week-5-soham.rst
@@ -10,7 +10,7 @@ Hello and welcome to my 5th weekly check-in, I will be sharing my progress of py
 
 What did you do this week?
 --------------------------
-Last week due to the ``vtkTextActor`` sizing issue I was not able to continue my work with ``ComboBox2D`` UI element. Thus, I decided to work on the "Physics Engine Integration" part of my project. It took me quite a while to understand the terminology of various methods and algorithms used for detection and physics simulation. Nevertheless, I was able to create a couple of rigid body examples to showcase the integration procedure. For physics calculations we used pyBullet and for rendering we used FURY. In other words, pyBullet will handle the backend part of the simulation and FURY will handle the frontend. I have documented the entire integration process `here <https://docs.google.com/document/d/1XJcG1TL5ZRJZDyi8V76leYZt_maxGp0kOB7OZIxKsTA/edit?usp=sharing>`_ in detail.
+Last week due to the ``vtkTextActor`` sizing issue I was not able to continue my work with ``ComboBox2D`` UI element. Thus, I decided to work on the "Physics Engine Integration" part of my project. It took me quite a while to understand the terminology of various methods and algorithms used for detection and physics simulation. Nevertheless, I was able to create a couple of rigid body examples to showcase the integration procedure. For physics calculations we used pyBullet and for rendering we used FURY. In other words, pyBullet will handle the backend part of the simulation and FURY will handle the frontend. I have documented the entire integration process `here <https://docs.google.com/document/d/1XJcG1TL5ZRJZDyi8V76leYZt_maxGp0kOB7OZIxKsTA/edit?usp=sharing>`__ in detail.
 
 Ball Collision Simulation:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/posts/2020/2020-08-02-week-10-soham.rst
+++ b/docs/source/posts/2020/2020-08-02-week-10-soham.rst
@@ -6,7 +6,7 @@ Single Actor, Physics, Scrollbars.
    :tags: google
    :category: gsoc
 
-Hello and welcome to my 10th weekly check-in. Second evaluation ended this week and now we move on to our 3rd and final coding period. In today's check-in I will be sharing my progress with the single actor physics simulation that I facing some issues with and I will also be discussing my future plans regarding UI components. The official repository of my sub-org, FURY can always be found `here <https://github.com/fury-gl/fury/>`_.
+Hello and welcome to my 10th weekly check-in. Second evaluation ended this week and now we move on to our 3rd and final coding period. In today's check-in I will be sharing my progress with the single actor physics simulation that I facing some issues with and I will also be discussing my future plans regarding UI components. The official repository of my sub-org, FURY can always be found `here <https://github.com/fury-gl/fury/>`__.
 
 What did you do this week?
 --------------------------

--- a/docs/source/posts/2020/2020-08-18-release-announcement.rst
+++ b/docs/source/posts/2020/2020-08-18-release-announcement.rst
@@ -1,0 +1,48 @@
+FURY 0.6.1 Released
+===================
+
+.. post:: August 18 2020
+   :author: skoudoro
+   :tags: fury
+   :category: release
+
+
+The FURY project is happy to announce the release of FURY 0.6.1!
+FURY is a free and open source software library for scientific visualization and 3D animations.
+
+You can show your support by `adding a star <https://github.com/fury-gl/fury/stargazers>`_ on FURY github project.
+
+This Release is mainly a maintenance release. The **major highlights** of this release are:
+
+.. include:: ../../release_notes/releasev0.6.1.rst
+    :start-after: --------------
+    :end-before: Details
+
+.. note:: The complete release notes are available :ref:`here <releasev0.6.1>`
+
+**To upgrade or install FURY**
+
+Run the following command in your terminal::
+
+    pip install --upgrade fury
+
+or::
+
+    conda install -c conda-forge fury
+
+
+**Questions or suggestions?**
+
+For any questions go to http://fury.gl, or send an e-mail to fury@python.org
+We can also join our `discord community <https://discord.gg/6btFPPj>`_
+
+We would like to thanks to :ref:`all contributors <community>` for this release:
+
+.. include:: ../../release_notes/releasev0.6.1.rst
+    :start-after: commits.
+    :end-before: We closed
+
+
+On behalf of the :ref:`FURY developers <community>`,
+
+Serge K.

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -7,6 +7,7 @@ For a full list of the features implemented in the most recent release cycle, ch
 .. toctree::
    :maxdepth: 1
 
+   release_notes/releasev0.6.1
    release_notes/releasev0.6.0
    release_notes/releasev0.5.1
    release_notes/releasev0.4.0

--- a/docs/source/release_notes/releasev0.6.1.rst
+++ b/docs/source/release_notes/releasev0.6.1.rst
@@ -1,0 +1,86 @@
+.. _releasev0.6.1:
+
+===================================
+ Release notes v0.6.1 (2020-08-20)
+===================================
+
+Quick Overview
+--------------
+
+* Added Shaders Manager.
+* Standardized colors across API.
+* Added a new UI Tab.
+* Added Physics Engine Tutorial.
+* Large documentation update, examples and tutorials (4 new).
+* Increased tests coverage and code quality.
+
+Details
+-------
+
+GitHub stats for 2020/07/21 - 2020/08/20 (tag: v0.6.0)
+
+These lists are automatically generated, and may be incomplete or contain duplicates.
+
+The following 8 authors contributed 164 commits.
+
+* Eleftherios Garyfallidis
+* Javier Guaje
+* Lenix Lobo
+* Melina Raglin
+* Nasim Anousheh
+* Serge Koudoro
+* Soham Biswas
+* Vivek Choudhary
+
+
+We closed a total of 42 issues, 15 pull requests and 27 regular issues;
+this is the full list (generated with the script
+:file:`tools/github_stats.py`):
+
+Pull Requests (15):
+
+* :ghpull:`288`: Shader manager
+* :ghpull:`292`: Disable VTK Warnings on release version
+* :ghpull:`289`: Rename parameter scale to scales
+* :ghpull:`287`: Add Physics simulation examples.
+* :ghpull:`284`: Colliding particles in the box
+* :ghpull:`275`: Tab UI tutorial
+* :ghpull:`208`: Added tutorial for RadioButton and CheckBox UI
+* :ghpull:`281`: Radio checkbox tutorial using Fury API
+* :ghpull:`283`: Standardize colors across API
+* :ghpull:`282`: Standardize Colors array name
+* :ghpull:`252`: Tab ui
+* :ghpull:`279`: Decreasing the size of the sun in solarsystem tutorial
+* :ghpull:`273`: Python GSoC Weekly blogs
+* :ghpull:`276`: Update Deprecated test
+* :ghpull:`272`: Python GSoC Blogs upto 19th July 2020
+
+Issues (27):
+
+* :ghissue:`260`: Changes to shader API in VTK 9
+* :ghissue:`116`: Update Shader system
+* :ghissue:`288`: Shader manager
+* :ghissue:`292`: Disable VTK Warnings on release version
+* :ghissue:`270`: Disable VTK Warnings on release version
+* :ghissue:`289`: Rename parameter scale to scales
+* :ghissue:`236`: Pybullet examples
+* :ghissue:`287`: Add Physics simulation examples.
+* :ghissue:`205`: Create a tutorial for checkbox/radiobutton UI
+* :ghissue:`284`: Colliding particles in the box
+* :ghissue:`275`: Tab UI tutorial
+* :ghissue:`208`: Added tutorial for RadioButton and CheckBox UI
+* :ghissue:`281`: Radio checkbox tutorial using Fury API
+* :ghissue:`283`: Standardize colors across API
+* :ghissue:`269`: Fixed bug in tutorial with accessing colors for latest release
+* :ghissue:`242`: Standardize colors across API
+* :ghissue:`243`: Single Color in Primitive Does Not Work
+* :ghissue:`271`: Some issues with actor.box after release 0.6.0
+* :ghissue:`282`: Standardize Colors array name
+* :ghissue:`280`: Unable to extract colors from a Box
+* :ghissue:`252`: Tab ui
+* :ghissue:`279`: Decreasing the size of the sun in solarsystem tutorial
+* :ghissue:`278`: Changing Size of Sun in viz_solar_system.py Tutorial
+* :ghissue:`273`: Python GSoC Weekly blogs
+* :ghissue:`277`: Sun
+* :ghissue:`276`: Update Deprecated test
+* :ghissue:`272`: Python GSoC Blogs upto 19th July 2020

--- a/docs/tutorials/02_ui/viz_radio_buttons.py
+++ b/docs/tutorials/02_ui/viz_radio_buttons.py
@@ -1,7 +1,7 @@
 """
-======================================
+========================================
 Sphere Color Control using Radio Buttons
-======================================
+========================================
 
 This example shows how to use the UI API. We will demonstrate how to
 create a Sphere and control its color using radio buttons.
@@ -14,7 +14,7 @@ import numpy as np
 
 ########################################################################
 # Sphere and Radio Buttons
-# ======================
+# ========================
 #
 # Add a Sphere to the scene.
 

--- a/docs/tutorials/05_physics/README.rst
+++ b/docs/tutorials/05_physics/README.rst
@@ -1,0 +1,4 @@
+Physics
+-------
+
+These tutorials show how to use connect FURY with a physics engine library.

--- a/fury/deprecator.py
+++ b/fury/deprecator.py
@@ -216,7 +216,7 @@ def deprecated_params(old_name, new_name=None, since='', until='',
     ----------
     old_name : str or list/tuple thereof
         The old name of the argument.
-    new_name : str or list/tuple thereof or `None`, optional
+    new_name : str or list/tuple thereof or ``None``, optional
         The new name of the argument. Set this to `None` to remove the
         argument ``old_name`` instead of renaming it.
     since : str or number or list/tuple thereof, optional
@@ -227,9 +227,9 @@ def deprecated_params(old_name, new_name=None, since='', until='',
         error.
     version_comparator : callable
         Callable accepting string as argument, and return 1 if string
-        represents a higher version than encoded in the `version_comparator`, 0
-        if the version is equal, and -1 if the version is lower.  For example,
-        the `version_comparator` may compare the input version string to the
+        represents a higher version than encoded in the ``version_comparator``,
+        0 if the version is equal, and -1 if the version is lower. For example,
+        the ``version_comparator`` may compare the input version string to the
         current package version string.
     arg_in_kwargs : bool or list/tuple thereof, optional
         If the argument is not a named argument (for example it
@@ -267,36 +267,36 @@ def deprecated_params(old_name, new_name=None, since='', until='',
     --------
     The deprecation warnings are not shown in the following examples.
     To deprecate a positional or keyword argument::
-        >>> from fury.deprecator import deprecated_params
-        >>> @deprecated_params('sig', 'sigma', '0.3')
-        ... def test(sigma):
-        ...     return sigma
-        >>> test(2)
-        2
-        >>> test(sigma=2)
-        2
-        >>> test(sig=2)  # doctest: +SKIP
-        2
+    >>> from fury.deprecator import deprecated_params
+    >>> @deprecated_params('sig', 'sigma', '0.3')
+    ... def test(sigma):
+    ...     return sigma
+    >>> test(2)
+    2
+    >>> test(sigma=2)
+    2
+    >>> test(sig=2)  # doctest: +SKIP
+    2
     To deprecate an argument caught inside the ``**kwargs`` the
     ``arg_in_kwargs`` has to be set::
-        >>> @deprecated_params('sig', 'sigma', '1.0',
-        ...                    arg_in_kwargs=True)
-        ... def test(**kwargs):
-        ...     return kwargs['sigma']
-        >>> test(sigma=2)
-        2
-        >>> test(sig=2)  # doctest: +SKIP
-        2
+    >>> @deprecated_params('sig', 'sigma', '1.0',
+    ...                    arg_in_kwargs=True)
+    ... def test(**kwargs):
+    ...     return kwargs['sigma']
+    >>> test(sigma=2)
+    2
+    >>> test(sig=2)  # doctest: +SKIP
+    2
 
     It is also possible to replace multiple arguments. The ``old_name``,
     ``new_name`` and ``since`` have to be `tuple` or `list` and contain the
     same number of entries::
-        >>> @deprecated_params(['a', 'b'], ['alpha', 'beta'],
-        ...                    ['0.2', 0.4])
-        ... def test(alpha, beta):
-        ...     return alpha, beta
-        >>> test(a=2, b=3)  # doctest: +SKIP
-        (2, 3)
+    >>> @deprecated_params(['a', 'b'], ['alpha', 'beta'],
+    ...                    ['0.2', 0.4])
+    ... def test(alpha, beta):
+    ...     return alpha, beta
+    >>> test(a=2, b=3)  # doctest: +SKIP
+    (2, 3)
 
     """
     if isinstance(old_name, (list, tuple)):


### PR DESCRIPTION
# Summary

Preparation for 0.6.1 release, targeting Tuesday, August 18th. 

Just a note that any PR can block the release. If they are not in, it will be for the next release in
October.

# Release checklist
- [x] add release_notes 0.6.0 and update release-history.rst
- [x] Update .mailmap
- [x] Check the copyright years in LICENSE
- [x] Check documentation
- [x] Check Tutorial
- [x] Update index.rst
- [x] Add a blog post
- [x] Update website
- [x] Update deprecation cycle : delete if expired since 3 releases.