### PR TITLE
Disable VTK Warnings on release version 

### DIFF
--- a/fury/__init__.py
+++ b/fury/__init__.py
@@ -52,41 +52,41 @@ def get_info(verbose=False):
     return info
 
 
-def enable_warning(warning_origin=None):
-    """Enable global warning.
+def enable_warnings(warning_origins=None):
+    """Enable global warnings.
 
     Parameters
     ----------
-    warning_origin : list
+    warning_origins : list
         list origin ['all', 'fury', 'vtk', 'matplotlib', ...]
 
     """
-    warning_origin = warning_origin or ('all',)
+    warning_origins = warning_origins or ('all',)
 
-    if 'all' in warning_origin or 'vtk' in warning_origin:
+    if 'all' in warning_origins or 'vtk' in warning_origins:
         import vtk
         vtk.vtkObject.GlobalWarningDisplayOn()
 
 
-def disable_warning(warning_origin=None):
-    """Disable global warning display.
+def disable_warnings(warning_origins=None):
+    """Disable global warnings.
 
     Parameters
     ----------
-    warning_origin : list
+    warning_origins : list
         list origin ['all', 'fury', 'vtk', 'matplotlib', ...]
 
     """
-    warning_origin = warning_origin or ('all',)
+    warning_origins = warning_origins or ('all',)
 
-    if 'all' in warning_origin or 'vtk' in warning_origin:
+    if 'all' in warning_origins or 'vtk' in warning_origins:
         import vtk
         vtk.vtkObject.GlobalWarningDisplayOff()
 
 
 # We switch off the warning display during the release
 if not ('post' in __version__) and not ('dev' in __version__):
-    disable_warning()
+    disable_warnings()
 
 # Ignore this specific warning below from vtk < 8.2.
 # FutureWarning: Conversion of the second argument of issubdtype from

--- a/fury/__init__.py
+++ b/fury/__init__.py
@@ -52,6 +52,24 @@ def get_info(verbose=False):
     return info
 
 
+def set_vtk_warning_display(value):
+    """Set On or Off the global warning display.
+
+    Parameters
+    ----------
+    value : bool
+        True = ON, False = OFF. By default, it is "OFF" for the
+        release and "ON" for the dev version
+
+    """
+    import vtk
+    vtk.vtkObject.SetGlobalWarningDisplay(value)
+
+
+# We switch off the warning display during the release
+if not ('post' in __version__) and not ('dev' in __version__):
+    set_vtk_warning_display(False)
+
 # Ignore this specific warning below from vtk < 8.2.
 # FutureWarning: Conversion of the second argument of issubdtype from
 # `complex` to `np.complexfloating` is deprecated. In future, it will be

--- a/fury/__init__.py
+++ b/fury/__init__.py
@@ -52,23 +52,41 @@ def get_info(verbose=False):
     return info
 
 
-def set_vtk_warning_display(value):
-    """Set On or Off the global warning display.
+def enable_warning(warning_origin=None):
+    """Enable global warning.
 
     Parameters
     ----------
-    value : bool
-        True = ON, False = OFF. By default, it is "OFF" for the
-        release and "ON" for the dev version
+    warning_origin : list
+        list origin ['all', 'fury', 'vtk', 'matplotlib', ...]
 
     """
-    import vtk
-    vtk.vtkObject.SetGlobalWarningDisplay(value)
+    warning_origin = warning_origin or ('all',)
+
+    if 'all' in warning_origin or 'vtk' in warning_origin:
+        import vtk
+        vtk.vtkObject.GlobalWarningDisplayOn()
+
+
+def disable_warning(warning_origin=None):
+    """Disable global warning display.
+
+    Parameters
+    ----------
+    warning_origin : list
+        list origin ['all', 'fury', 'vtk', 'matplotlib', ...]
+
+    """
+    warning_origin = warning_origin or ('all',)
+
+    if 'all' in warning_origin or 'vtk' in warning_origin:
+        import vtk
+        vtk.vtkObject.GlobalWarningDisplayOff()
 
 
 # We switch off the warning display during the release
 if not ('post' in __version__) and not ('dev' in __version__):
-    set_vtk_warning_display(False)
+    disable_warning()
 
 # Ignore this specific warning below from vtk < 8.2.
 # FutureWarning: Conversion of the second argument of issubdtype from

--- a/fury/__init__.py
+++ b/fury/__init__.py
@@ -52,34 +52,34 @@ def get_info(verbose=False):
     return info
 
 
-def enable_warnings(warning_origins=None):
+def enable_warnings(warnings_origin=None):
     """Enable global warnings.
 
     Parameters
     ----------
-    warning_origins : list
+    warnings_origin : list
         list origin ['all', 'fury', 'vtk', 'matplotlib', ...]
 
     """
-    warning_origins = warning_origins or ('all',)
+    warnings_origin = warnings_origin or ('all',)
 
-    if 'all' in warning_origins or 'vtk' in warning_origins:
+    if 'all' in warnings_origin or 'vtk' in warnings_origin:
         import vtk
         vtk.vtkObject.GlobalWarningDisplayOn()
 
 
-def disable_warnings(warning_origins=None):
+def disable_warnings(warnings_origin=None):
     """Disable global warnings.
 
     Parameters
     ----------
-    warning_origins : list
+    warnings_origin : list
         list origin ['all', 'fury', 'vtk', 'matplotlib', ...]
 
     """
-    warning_origins = warning_origins or ('all',)
+    warnings_origin = warnings_origin or ('all',)
 
-    if 'all' in warning_origins or 'vtk' in warning_origins:
+    if 'all' in warnings_origin or 'vtk' in warnings_origin:
         import vtk
         vtk.vtkObject.GlobalWarningDisplayOff()
 


### PR DESCRIPTION
This PR adds a utility function to switch ON or OFF the global warning window of VTK. By default, it is ON on the dev version and OFF for the release version. 

fix #270.