### PR TITLE
fixed discord icon bug in documentation

### DIFF
--- a/docs/source/_templates/page.html
+++ b/docs/source/_templates/page.html
@@ -190,6 +190,7 @@
   {% extends "!page.html" %}
   {% block footer %} {{ super() }}
     <link rel="stylesheet" href="{{ pathto('_static/css/blog.css', 1) }}" type="text/css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.14.0/css/all.min.css" integrity="sha512-1PKOgIY59xJ8Co8+NE6FZ+LOAZKjy+KY8iq0G4B3CyeY6wYHN3yt9PW0XpSriVlkMXe40PTKnXrLnZ9+fkDaog==" crossorigin="anonymous" />
     <style>
     /* Sidebar header (and topbar for mobile) */
     .wy-side-nav-search, .wy-nav-top {

--- a/docs/source/community.rst
+++ b/docs/source/community.rst
@@ -10,9 +10,9 @@ Join Us!
 .. raw:: html
 
     <ul style="list-style-type:none;">
-        <li style="display: block"><a href='https://discord.gg/6btFPPj'><i class="fa fa-discord fa-fw"></i> Discord</a></li>
+        <li style="display: block"><a href='https://discord.gg/6btFPPj'><i class="fab fa-discord fa-fw"></i> Discord</a></li>
         <li style="display: block"><a href='https://mail.python.org/mailman3/lists/fury.python.org'><i class="fa fa-envelope fa-fw"></i> Mailing list</a></li>
-        <li style="display: block"><a href='https://github.com/fury-gl/fury'><i class="fa fa-github fa-fw"></i> Github</a></li>
+        <li style="display: block"><a href='https://github.com/fury-gl/fury'><i class="fab fa-github fa-fw"></i> Github</a></li>
     <ul>
 
 Contributors


### PR DESCRIPTION
Fixes #313
The discord icon was not available in Font-Awesome v4.x. 
Had to use Font-Awesome v5.x CDN and changed the syntax according to the new version of FA.
I tried pulling the only brands.css, but it didn't worked well.