### PR TITLE
[FIX] Force LUT to be RGB

### DIFF
--- a/fury/actor.py
+++ b/fury/actor.py
@@ -233,6 +233,7 @@ def slicer(data, affine=None, value_range=None, opacity=1.,
             lut = colormap_lookup_table((r1, r2), (0, 0), (0, 0), (0, 1))
 
         plane_colors = vtk.vtkImageMapToColors()
+        plane_colors.SetOutputFormatToRGB()
         plane_colors.SetLookupTable(lut)
         plane_colors.SetInputConnection(image_resliced.GetOutputPort())
         plane_colors.Update()

--- a/fury/window.py
+++ b/fury/window.py
@@ -886,14 +886,15 @@ def antialiasing(scene, win, multi_samples=8, max_peels=4,
     ----------
     scene : Scene
     win : Window
-        Provided by Showmanager.window attribute.
+        Provided by ShowManager.window attribute.
     multi_samples : int
-        Number of samples for anti-aliazing (Default 8).
+        Number of samples for anti-aliasing (Default 8).
         For no anti-aliasing use 0.
     max_peels : int
         Maximum number of peels for depth peeling (Default 4).
     occlusion_ratio : float
-        Occlusion ration for depth peeling (Default 0 - exact image).
+        Occlusion ratio for depth peeling (Default 0 - exact image).
+
     """
     # Use a render window with alpha bits
     # as default is 0 (false))


### PR DESCRIPTION
This PR is due to some change on the alpha channel with VTK9.
The event on the actor is not called if we do not force the LUT to be RGB. This is a quick fix for DIPY Horizon but we need to go deeper in our custom interactor.

See the code below to reproduce the error:
```
from fury import actor, window
import numpy as np

# It is working with this array
# arr = np.random.rand(375).reshape((5, 5, 5, 3)) * 255
# ERROR with the array below
arr = np.random.rand(125).reshape((5, 5, 5)) * 255

def left_click_callback(obj, ev):
    print('CALLBACK')
    print(obj)

fig = actor.slicer(arr)
fig1 = fig.copy()
fig1.display(None, None, 0)
print(fig1.shape)
fig1.SetInterpolate(False)
fig1.AddObserver('UserEvent',
                 left_click_callback, 10000.0)
scene = window.Scene()
showm = window.ShowManager(scene, interactor_style='custom')
showm.initialize()
scene.add(fig1)
showm.start()
```