### PR TITLE
Fixing UI warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore: Converting `np.character` to a dtype is deprecated. :DeprecationWarning


### PR DESCRIPTION
Context: #317 

The following warning:

`DeprecationWarning: Converting 'np.character' to a dtype is deprecated. The current result is 'np.dtype(np.str_)' which is not strictly correct. Note that 'np.character' is generally deprecated and 'S1' should be used.`

is generated when numpy arrays are converted to vtk arrays in `vtk.util.numpy_support.get_vtk_array_type`. This method is mainly used by the methods in `fury.utils` and `fury.actors`. This warning is generated when arrays contain character values in them, but while test I was not able to find any character values present in the array when the tests are run.

This warning is also the most recurring warning compared to the rest and also the only one in `fury.ui`. I created a file `pytest.ini` to ignore this particular warning and got the following results:

* All Fury test warnings reduced from `892` to `14`
* All Fury UI test warnings reduced from `108` to `0`

I am not sure if there is a better way to fix these.