### PR TITLE
Add support for clipping side in clip_overflow_text

### DIFF
--- a/fury/tests/test_ui.py
+++ b/fury/tests/test_ui.py
@@ -1598,3 +1598,14 @@ def test_clip_overflow():
     text.message = "A very very long message to clip text overflow"
     ui.clip_overflow(text, rectangle.size[0], 'left')
     npt.assert_equal("... overflow", text.message)
+
+    text.message = "A very very long message to clip text overflow"
+    ui.clip_overflow(text, rectangle.size[0], 'LeFT')
+    npt.assert_equal("... overflow", text.message)
+
+    text.message = "A very very long message to clip text overflow"
+    ui.clip_overflow(text, rectangle.size[0], 'RigHT')
+    npt.assert_equal("A very ve...", text.message)
+
+    npt.assert_raises(ValueError, ui.clip_overflow,
+                      text, rectangle.size[0], 'middle')

--- a/fury/tests/test_ui.py
+++ b/fury/tests/test_ui.py
@@ -1586,3 +1586,15 @@ def test_clip_overflow():
     text.message = "A very very long message to clip text overflow"
     ui.clip_overflow(text, rectangle.size[0])
     npt.assert_equal("A very ve...", text.message)
+
+    text.message = "Hello"
+    ui.clip_overflow(text, rectangle.size[0], 'left')
+    npt.assert_equal("Hello", text.message)
+
+    text.message = "Hello wassup"
+    ui.clip_overflow(text, rectangle.size[0], 'left')
+    npt.assert_equal("...lo wassup", text.message)
+
+    text.message = "A very very long message to clip text overflow"
+    ui.clip_overflow(text, rectangle.size[0], 'left')
+    npt.assert_equal("... overflow", text.message)

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -27,8 +27,8 @@ def clip_overflow(textblock, width, side='right'):
     width : int
         Required width of the clipped text.
     side : string
-        "right" : Clips the overflowing text from right. This is the default behaviour
-        "left" :  Clips the overflowing text from left.
+        Clips the overflowing text according to side.
+        It takes values "left" or "right".
 
     Returns
     -------

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -26,7 +26,7 @@ def clip_overflow(textblock, width, side='right'):
         The textblock object whose text needs to be clipped.
     width : int
         Required width of the clipped text.
-    side : string
+    side : str, optional
         Clips the overflowing text according to side.
         It takes values "left" or "right".
 

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -17,7 +17,7 @@ from fury.actor import grid
 TWO_PI = 2 * np.pi
 
 
-def clip_overflow(textblock, width):
+def clip_overflow(textblock, width, side='right'):
     """Clips overflowing text of TextBlock2D with respect to width.
 
     Parameters
@@ -26,6 +26,9 @@ def clip_overflow(textblock, width):
         The textblock object whose text needs to be clipped.
     width : int
         Required width of the clipped text.
+    side : string
+        "right" : Clips the overflowing text from right. This is the default behaviour
+        "left" :  Clips the overflowing text from left.
 
     Returns
     -------
@@ -42,6 +45,9 @@ def clip_overflow(textblock, width):
         textblock.have_bg = prev_bg
         return original_str
 
+    if side == 'left':
+        original_str = original_str[::-1]
+
     while start_ptr < end_ptr:
         mid_ptr = (start_ptr + end_ptr)//2
         textblock.message = original_str[:mid_ptr] + "..."
@@ -53,6 +59,8 @@ def clip_overflow(textblock, width):
         if mid_ptr == (start_ptr + end_ptr)//2 or\
            textblock.size[0] == width:
             textblock.have_bg = prev_bg
+            if side == 'left':
+                textblock.message = textblock.message[::-1]
             return textblock.message
 
 

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -35,6 +35,10 @@ def clip_overflow(textblock, width, side='right'):
     clipped text : str
         Clipped version of the text.
     """
+    side = side.lower()
+    if side not in ['left', 'right']:
+        raise ValueError("side can only take values 'left' or 'right'")
+
     original_str = textblock.message
     start_ptr = 0
     end_ptr = len(original_str)


### PR DESCRIPTION
Closes #308 
If we have to clip from left, we reverse the string before processing it and then reverse it again before returning it.
