### PR TITLE
Add Option to generate the documentation without examples

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,10 +21,18 @@ clean:
 	rm -rf "$(SOURCEDIR)/reference"
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) clean
 
+html-no-examples:
+	$(SPHINXBUILD) -D plot_gallery=0 -b html $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/html"
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
 upload:
 	python upload_to_gh-pages.py
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
+	@echo $@
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)."

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 -   ``source``: Contains main *.rst files
 -   ``tutorials``: python script describe how to use the api
--   ``examples``: Fury app showcases 
+-   ``examples``: Fury app showcases
 -   ``build``: Contains the generated documentation
 
 ## Doc generation steps:
@@ -25,9 +25,21 @@ $ pip install -U -r requirements/docs.txt
 $ make -C . clean && make -C . html
 ```
 
+To generate the documentation without running the examples:
+
+```bash
+$ make -C . clean && make -C . html-no-examples
+```
 #### Under Windows
 
 ```bash
 $ ./make.bat clean
 $ ./make.bat html
+```
+
+To generate the documentation without running the examples:
+
+```bash
+$ ./make.bat clean
+$ ./make.bat html-no-examples
 ```

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -46,6 +46,13 @@ if "%1" == "upload" (
 	exit /B
 )
 
+if "%1" == "html-no-examples" (
+	%SPHINXBUILD% -D plot_gallery=0 -b html %SPHINXOPTS% %(SOURCEDIR% %BUILDDIR%
+	echo
+	echo "Build finished. The HTML pages are in %BUILDDIR%"
+	exit /B
+)
+
 
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
 goto end

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -155,10 +155,19 @@ Building the documentation
 
     $ make -C . clean && make -C . html
 
+To generate the documentation without running the examples::
+
+    $ make -C . clean && make -C . html-no-examples
+
 or under Windows::
 
     $ ./make.bat clean
     $ ./make.bat html
+
+To generate the documentation without running the examples under Windows::
+
+    $ ./make.bat clean
+    $ ./make.bat html-no-examples
 
 
 **Step 3.** Congratulations! the ``build`` folder has been generated! Go to ``build/html`` and open with browser ``index.html`` to see your generated documentation.


### PR DESCRIPTION
All is in the title. This PR allow the user to generate the documentation faster (without running the examples).

@Nibba2018, can you test it on Windows? it is ok on Linux and MacOsx