### PR TITLE
Fix the sdf bug by checking the arguments passed

### DIFF
--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1,5 +1,6 @@
 """Module that provide actors to render."""
 
+import warnings
 import os.path as op
 import numpy as np
 import vtk
@@ -2545,9 +2546,9 @@ def sdf(centers, directions=(1, 0, 0), colors=(1, 0, 0), primitives='torus',
         RGB or RGBA (for opacity) R, G, B and A should be at the range [0, 1]
     directions : ndarray, shape (N, 3)
         The orientation vector of the SDF primitive.
-    primitives : str
+    primitives : str, list, tuple, np.ndarray
         The primitive of choice to be rendered.
-        Options are sphere and torus. Default is torus
+        Options are sphere and torus. Default is torus.
     scales : float
         The size of the SDF primitive
 
@@ -2569,6 +2570,9 @@ def sdf(centers, directions=(1, 0, 0), colors=(1, 0, 0), primitives='torus',
 
     if isinstance(primitives,  (list, tuple, np.ndarray)):
         primlist = [prims[prim] for prim in primitives]
+        if len(primitives) < len(centers):
+            primlist = primlist + [2] * (len(centers) - len(primitives))
+            warnings.warn("Not enough primitives provided, defaulting to torus")
         rep_prims = np.repeat(primlist, verts.shape[0])
     else:
         rep_prims = np.repeat(prims[primitives], rep_centers.shape[0], axis=0)

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -2572,7 +2572,8 @@ def sdf(centers, directions=(1, 0, 0), colors=(1, 0, 0), primitives='torus',
         primlist = [prims[prim] for prim in primitives]
         if len(primitives) < len(centers):
             primlist = primlist + [2] * (len(centers) - len(primitives))
-            warnings.warn("Not enough primitives provided, defaulting to torus")
+            warnings.warn("Not enough primitives provided,\
+             defaulting to torus", category=UserWarning)
         rep_prims = np.repeat(primlist, verts.shape[0])
     else:
         rep_prims = np.repeat(prims[primitives], rep_centers.shape[0], axis=0)

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -1350,3 +1350,46 @@ def test_sdf_actor(interactive=False):
     arr = window.snapshot(scene)
     report = window.analyze_snapshot(arr, colors=colors)
     npt.assert_equal(report.objects, 3)
+
+    scene.clear()
+    primitive = ['sphere']
+    with npt.assert_warns(UserWarning):
+        sdf_actor = actor.sdf(centers, directions,
+                          colors, primitive, scales)
+
+    scene.add(sdf_actor)
+    scene.add(actor.axes())
+    if interactive:
+        window.show(scene)
+
+    arr = window.snapshot(scene)
+    report = window.analyze_snapshot(arr, colors=colors)
+    npt.assert_equal(report.objects, 3)
+
+    scene.clear()
+    primitive = 'sphere'
+    sdf_actor = actor.sdf(centers, directions,
+                          colors, primitive, scales)
+    scene.add(sdf_actor)
+    scene.add(actor.axes())
+    if interactive:
+        window.show(scene)
+
+    arr = window.snapshot(scene)
+    report = window.analyze_snapshot(arr, colors=colors)
+    npt.assert_equal(report.objects, 3)
+
+    scene.clear()
+    primitive = ['sphere', 'ellipsoid']
+    with npt.assert_warns(UserWarning):
+        sdf_actor = actor.sdf(centers, directions,
+                          colors, primitive, scales)
+
+    scene.add(sdf_actor)
+    scene.add(actor.axes())
+    if interactive:
+        window.show(scene)
+
+    arr = window.snapshot(scene)
+    report = window.analyze_snapshot(arr, colors=colors)
+    npt.assert_equal(report.objects, 3)

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -1351,6 +1351,22 @@ def test_sdf_actor(interactive=False):
     report = window.analyze_snapshot(arr, colors=colors)
     npt.assert_equal(report.objects, 3)
 
+    # Draw 3 spheres as the primitive type is str
+    scene.clear()
+    primitive = 'sphere'
+    sdf_actor = actor.sdf(centers, directions,
+                          colors, primitive, scales)
+    scene.add(sdf_actor)
+    scene.add(actor.axes())
+    if interactive:
+        window.show(scene)
+
+    arr = window.snapshot(scene)
+    report = window.analyze_snapshot(arr, colors=colors)
+    npt.assert_equal(report.objects, 3)
+
+    # A sphere and default back to two torus
+    # as the primitive type is list
     scene.clear()
     primitive = ['sphere']
     with npt.assert_warns(UserWarning):
@@ -1366,19 +1382,8 @@ def test_sdf_actor(interactive=False):
     report = window.analyze_snapshot(arr, colors=colors)
     npt.assert_equal(report.objects, 3)
 
-    scene.clear()
-    primitive = 'sphere'
-    sdf_actor = actor.sdf(centers, directions,
-                          colors, primitive, scales)
-    scene.add(sdf_actor)
-    scene.add(actor.axes())
-    if interactive:
-        window.show(scene)
-
-    arr = window.snapshot(scene)
-    report = window.analyze_snapshot(arr, colors=colors)
-    npt.assert_equal(report.objects, 3)
-
+    # One sphere and ellipsoid each
+    # Default to torus
     scene.clear()
     primitive = ['sphere', 'ellipsoid']
     with npt.assert_warns(UserWarning):

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -1370,8 +1370,8 @@ def test_sdf_actor(interactive=False):
     scene.clear()
     primitive = ['sphere']
     with npt.assert_warns(UserWarning):
-        sdf_actor = actor.sdf(centers, directions,
-                          colors, primitive, scales)
+        sdf_actor = actor.sdf(centers, directions, colors,
+                              primitive, scales)
 
     scene.add(sdf_actor)
     scene.add(actor.axes())
@@ -1388,7 +1388,7 @@ def test_sdf_actor(interactive=False):
     primitive = ['sphere', 'ellipsoid']
     with npt.assert_warns(UserWarning):
         sdf_actor = actor.sdf(centers, directions,
-                          colors, primitive, scales)
+                              colors, primitive, scales)
 
     scene.add(sdf_actor)
     scene.add(actor.axes())


### PR DESCRIPTION
Closes #310 
If enough primitives are not provided, we default to a torus. Another possible solution could be trying to broadcast the NumPy arrays before defaulting to a torus.