### PR TITLE
Opacity bug fix for point and sphere actors

### DIFF
--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1386,7 +1386,7 @@ def dots(points, color=(1, 0, 0), opacity=1, dot_size=5):
     return aPolyVertexActor
 
 
-def point(points, colors, _opacity=1., point_radius=0.1, theta=8, phi=8):
+def point(points, colors, point_radius=0.1, phi=8, theta=8, opacity=1.):
     """Visualize points as sphere glyphs
 
     Parameters
@@ -1394,10 +1394,10 @@ def point(points, colors, _opacity=1., point_radius=0.1, theta=8, phi=8):
     points : ndarray, shape (N, 3)
     colors : ndarray (N,3) or tuple (3,)
     point_radius : float
-    theta : int
     phi : int
+    theta : int
     opacity : float, optional
-        Takes values from 0 (fully transparent) to 1 (opaque)
+        Takes values from 0 (fully transparent) to 1 (opaque). Default is 1.
 
     Returns
     -------
@@ -1413,12 +1413,12 @@ def point(points, colors, _opacity=1., point_radius=0.1, theta=8, phi=8):
     >>> # window.show(scene)
 
     """
-    return sphere(centers=points, colors=colors, radii=point_radius,
-                  theta=theta, phi=phi, vertices=None, faces=None)
+    return sphere(centers=points, colors=colors, radii=point_radius, phi=phi,
+                  theta=theta, vertices=None, faces=None, opacity=opacity)
 
 
-def sphere(centers, colors, radii=1., theta=16, phi=16,
-           vertices=None, faces=None):
+def sphere(centers, colors, radii=1., phi=16, theta=16,
+           vertices=None, faces=None, opacity=1):
     """Visualize one or many spheres with different colors and radii
 
     Parameters
@@ -1429,13 +1429,16 @@ def sphere(centers, colors, radii=1., theta=16, phi=16,
         RGB or RGBA (for opacity) R, G, B and A should be at the range [0, 1]
     radii : float or ndarray, shape (N,)
         Sphere radius
-    theta : int
     phi : int
+    theta : int
     vertices : ndarray, shape (N, 3)
         The point cloud defining the sphere.
     faces : ndarray, shape (M, 3)
         If faces is None then a sphere is created based on theta and phi angles
         If not then a sphere is created with the provided vertices and faces.
+    opacity : float, optional
+        Takes values from 0 (fully transparent) to 1 (opaque). Default is 1.
+
 
     Returns
     -------
@@ -1461,6 +1464,8 @@ def sphere(centers, colors, radii=1., theta=16, phi=16,
     actor = repeat_sources(centers=centers, colors=colors,
                            active_scalars=radii, source=src,
                            vertices=vertices, faces=faces)
+
+    actor.GetProperty().SetOpacity(opacity)
 
     return actor
 

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -848,8 +848,9 @@ def test_dots(interactive=False):
 def test_points(interactive=False):
     points = np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0]])
     colors = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    opacity = 0.5
 
-    points_actor = actor.point(points, colors)
+    points_actor = actor.point(points, colors, opacity=opacity)
 
     scene = window.Scene()
     scene.add(points_actor)
@@ -860,6 +861,7 @@ def test_points(interactive=False):
         window.show(scene, reset_camera=False)
 
     npt.assert_equal(scene.GetActors().GetNumberOfItems(), 1)
+    npt.assert_equal(points_actor.GetProperty().GetOpacity(), opacity)
 
     arr = window.snapshot(scene)
     report = window.analyze_snapshot(arr,
@@ -886,10 +888,11 @@ def test_spheres(interactive=False):
 
     xyzr = np.array([[0, 0, 0, 10], [100, 0, 0, 25], [200, 0, 0, 50]])
     colors = np.array([[1, 0, 0, 0.3], [0, 1, 0, 0.4], [0, 0, 1., 0.99]])
+    opacity = 0.5
 
     scene = window.Scene()
     sphere_actor = actor.sphere(centers=xyzr[:, :3], colors=colors[:],
-                                radii=xyzr[:, 3])
+                                radii=xyzr[:, 3], opacity=opacity)
     scene.add(sphere_actor)
 
     if interactive:
@@ -899,6 +902,7 @@ def test_spheres(interactive=False):
     report = window.analyze_snapshot(arr,
                                      colors=colors)
     npt.assert_equal(report.objects, 3)
+    npt.assert_equal(sphere_actor.GetProperty().GetOpacity(), opacity)
 
     # test with an unique color for all centers
     scene.clear()


### PR DESCRIPTION
Fixes #335 

Earlier, 
![vr](https://user-images.githubusercontent.com/65067354/103434316-cf477600-4c25-11eb-8320-bda5507f0a30.png)

Now, 
![vr2](https://user-images.githubusercontent.com/65067354/103434317-d078a300-4c25-11eb-9514-e4b2bce4b85f.png)

Earlier, opacity argument wasn't manipulating the opacity of point actors and sphere actors. That issue is resolved by this fix. Unit tests are included for the same.