### PR TITLE
Render a video on an actor.

### DIFF
--- a/docs/examples/viz_play_video.py
+++ b/docs/examples/viz_play_video.py
@@ -1,0 +1,91 @@
+"""
+=======================================================
+Play a video in the 3D world
+=======================================================
+
+The goal of this demo is to show how to visualize a video
+on a rectangle by updating a texture.
+"""
+
+from fury import window, actor
+import numpy as np
+import cv2
+
+import time
+
+
+# The VideoCapturer Class
+# This Class wraps OpenCV Videocapture
+class VideoCapturer:
+
+    def __init__(self, video, time):
+        self.path = video
+        self.video = cv2.VideoCapture(self.path)
+        self.fps = int(self.video.get(cv2.CAP_PROP_FPS))
+        self.frames = int(self.video.get(cv2.CAP_PROP_FRAME_COUNT))
+        self.time = time
+
+    # A generator to yield video frames on every call
+    def get_frame(self):
+        start = time.time()
+        for _ in range(self.frames):
+            isframe, frame = self.video.read()
+            dur = time.time() - start
+            if dur > self.time:
+                break
+            if isframe:
+                yield cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        self.video.release()
+        yield None
+
+
+class VideoPlayer:
+
+    def __init__(self, video, time=10):
+        # Initializes the Video object with the given Video
+        self.video = VideoCapturer(video, time)
+        self.video_generator = self.video.get_frame()
+        self.current_video_frame = next(self.video_generator)
+        # Initialize Scene
+        self.initialize_scene()
+        # Create a Show Manager and Initialize it
+        self.show_manager = window.ShowManager(self.scene,
+                                               size=(900, 768),
+                                               reset_camera=False,
+                                               order_transparent=True)
+        self.show_manager.initialize()
+
+    # Initialize the Scene with actors
+    def initialize_scene(self):
+        self.scene = window.Scene()
+        # Initialize a Plane actor with the 1st video frame along with
+        # the actor grid which is to be updated in each iteration
+        self.plane_actor = actor.texture(self.current_video_frame)
+        self.scene.add(self.plane_actor)
+
+    # The timer_callback function getting called by the show manager
+    def timer_callback(self, _obj, _event):
+        self.current_video_frame = next(self.video_generator)
+        if isinstance(self.current_video_frame, np.ndarray):
+            # update texture of the actor with the current frame image
+            # by updating the actor grid
+            actor.texture_update(self.plane_actor, self.current_video_frame)
+            self.show_manager.scene.azimuth(1.5)  # to rotate the camera
+        else:
+            self.show_manager.exit()
+        self.show_manager.render()
+
+    def run(self):
+        # Add a timer callback to show manager after with
+        # video frame duration as the interval
+        self.frame_duration = int(1000/self.video.fps)
+        self.show_manager.add_timer_callback(True,
+                                             self.frame_duration,
+                                             self.timer_callback)
+        self.show_manager.start()
+
+
+# Create VideoPlayer Object and run it
+video_url = "http://commondatastorage.googleapis.com/" +\
+            "gtv-videos-bucket/sample/BigBuckBunny.mp4"
+VideoPlayer(video_url).run()

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -2445,6 +2445,32 @@ def texture(rgb, interp=True):
     return act
 
 
+def texture_update(texture_actor, arr):
+    """
+    Updates texture of an actor by updating the vtkImageData
+    assigned to the vtkTexture object.
+
+    Parameters
+    ----------
+    texture_actor: vtkActor
+        Actor whose texture is to be updated.
+    arr : ndarray
+        Input 2D image in the form of RGB or RGBA array.
+        This is the new image to be rendered on the actor.
+        Dtype should be uint8.
+
+    Implementation
+    --------------
+    Check docs/examples/viz_video_on_plane.py
+    """
+    grid = texture_actor.GetTexture().GetInput()
+    dim = arr.shape[-1]
+    img_data = np.flip(arr.swapaxes(0, 1), axis=1)\
+                 .reshape((-1, dim), order='F')
+    vtkarr = numpy_support.numpy_to_vtk(img_data, deep=False)
+    grid.GetPointData().SetScalars(vtkarr)
+
+
 def _textured_sphere_source(theta=60, phi=60):
     tss = vtk.vtkTexturedSphereSource()
     tss.SetThetaResolution(theta)

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -1235,6 +1235,38 @@ def test_texture_mapping():
     npt.assert_equal(res.colors_found, [True, True])
 
 
+def test_texture_update():
+    arr = np.zeros((512, 212, 3), dtype='uint8')
+    arr[:256, :] = np.array([255, 0, 0])
+    arr[256:, :] = np.array([0, 255, 0])
+    # create a texture on plane
+    tp = actor.texture(arr, interp=True)
+    scene = window.Scene()
+    scene.add(tp)
+    display = window.snapshot(scene)
+    res1 = window.analyze_snapshot(display, bg_color=(0, 0, 0),
+                                   colors=[(255, 255, 255),
+                                           (255, 0, 0),
+                                           (0, 255, 0)],
+                                   find_objects=False)
+
+    # update the texture
+    new_arr = np.zeros((512, 212, 3), dtype='uint8')
+    new_arr[:, :] = np.array([255, 255, 255])
+    actor.texture_update(tp, new_arr)
+    display = window.snapshot(scene)
+    res2 = window.analyze_snapshot(display, bg_color=(0, 0, 0),
+                                   colors=[(255, 255, 255),
+                                           (255, 0, 0),
+                                           (0, 255, 0)],
+                                   find_objects=False)
+
+    # Test for original colors
+    npt.assert_equal(res1.colors_found, [False, True, True])
+    # Test for changed colors of the actor
+    npt.assert_equal(res2.colors_found, [True, False, False])
+
+
 def test_figure_vs_texture_actor():
     arr = (255 * np.ones((512, 212, 4))).astype('uint8')
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -9,3 +9,4 @@ sphinx_rtd_theme
 networkx
 ablog >= 0.10.5
 pybullet>=2.7.0
+opencv-python


### PR DESCRIPTION
Render a video on an actor.
======================

This PR Consists of 2 parts:

- Function to change the texture of a vtkActor
- A demo file to visualize, rendering of a Video.

## Function to change the texture of a vtkActor

### Changes in fury.actor

Fury actors didn't have a function to change the texture of an already textured vtkActor. There was a requirement for this function while rendering a video on an Actor. The function accepts an actor object and an image. The image gets mapped in the same mapper as configured while creating the actor.

### Tests

To test the function an actor is created with a black texture which is changed and tested with the new texture.

## A demo file to visualize, rendering of a Video

The goal of this demo is to show how to visualize a video on a Plane, which can be extended to potentially all shapes

### The Video Class 

This class wraps OpenCV VideoCapture with the required functionalities 

### The Animation Class

This class creates an object of the video class and initializes the scene with an Actor.

The run() function adds a timer callback to the show_manager that changes the frame of the video on every call after a specific interval.

[How it Looks](https://user-images.githubusercontent.com/55960431/104075477-e7785000-5238-11eb-9d63-1936e08534df.mp4)

