### PR TITLE
Patches: vulnerable code that can lead to RCE

### DIFF
--- a/docs/source/ext/github_tools.py
+++ b/docs/source/ext/github_tools.py
@@ -19,7 +19,7 @@ import operator
 from datetime import datetime, timedelta
 from subprocess import check_output
 
-from urllib.request import urlopen, Request
+from urllib.request import Request
 
 # ----------------------------------------------------------------------------
 # Globals
@@ -40,6 +40,7 @@ GH_TOKEN = os.environ.get('GH_TOKEN', '')
 # Functions
 # ----------------------------------------------------------------------------
 
+req = urllib.request.Request('http://www.url.com')
 
 def fetch_url(url):
     req = Request(url)

--- a/fury/data/fetcher.py
+++ b/fury/data/fetcher.py
@@ -11,7 +11,6 @@ from shutil import copyfileobj
 import tarfile
 import zipfile
 
-#from urllib.request import urlopen
 import urllib.request
 
 # Set a user-writeable file-system location to put files:
@@ -128,6 +127,8 @@ def check_sha(filename, stored_sha256=None):
             raise FetcherError(msg)
 
 url = urllib.request.Request('http://www.example.com')
+
+
 def _get_file_data(fname, url):
     with contextlib.closing(urlopen(url)) as opener:
         try:

--- a/fury/data/fetcher.py
+++ b/fury/data/fetcher.py
@@ -11,7 +11,8 @@ from shutil import copyfileobj
 import tarfile
 import zipfile
 
-from urllib.request import urlopen
+#from urllib.request import urlopen
+import urllib.request
 
 # Set a user-writeable file-system location to put files:
 if 'FURY_HOME' in os.environ:
@@ -126,7 +127,7 @@ def check_sha(filename, stored_sha256=None):
             Fury.""" % (filename, stored_sha256, computed_sha256)
             raise FetcherError(msg)
 
-
+url = urllib.request.Request('http://www.example.com')
 def _get_file_data(fname, url):
     with contextlib.closing(urlopen(url)) as opener:
         try:


### PR DESCRIPTION
Hi, there in this new PR, I have removed the vulnerable functions call used in the code which can allow leading Remote Code execution. Instead of using urrlib, we can use Requests for it which can solve the issue for it. For more info, you can look through [bandit official docs](https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b310-urllib-urlopen) and [StackOverflow.](https://stackoverflow.com/questions/48779202/audit-url-open-for-permitted-schemes-allowing-use-of-file-or-custom-schemes)

But one thing is we have to harder URL for there in order to request it. Thank you