### PR TITLE
ENH: Refactor actor.odf_slicer for increased performances

### DIFF
--- a/docs/examples/viz_fiber_odf.py
+++ b/docs/examples/viz_fiber_odf.py
@@ -1,0 +1,224 @@
+"""
+====================================
+Brain Fiber ODF Visualisation
+====================================
+
+This example demonstrate how to create a simple viewer for fiber
+orientation distribution functions (ODF) using fury's odf_slicer.
+"""
+
+# First, we import some useful modules and methods.
+import numpy as np
+import nibabel as nib
+from fury import actor, window, ui
+from fury.data import read_viz_dmri, fetch_viz_dmri, fetch_viz_icons
+from fury.utils import fix_winding_order
+from dipy.reconst.shm import sh_to_sf_matrix
+from dipy.data import get_sphere
+
+###############################################################################
+# Here, we fetch and load the fiber ODF volume to display. The ODF are
+# expressed as spherical harmonics (SH) coefficients in a 3D grid.
+fetch_viz_dmri()
+fetch_viz_icons()
+
+fodf_img = nib.load(read_viz_dmri('fodf.nii.gz'))
+sh = fodf_img.get_fdata()
+affine = fodf_img.affine
+grid_shape = sh.shape[:-1]
+
+###############################################################################
+# We then define a low resolution sphere used to visualize SH coefficients
+# as spherical functions (SF) as well as a matrix `B_low` to project SH
+# onto the sphere.
+sphere_low = get_sphere('repulsion100')
+B_low = sh_to_sf_matrix(sphere_low, 8, return_inv=False)
+
+###############################################################################
+# Now, we create a slicer for each orientation to display a slice in
+# the middle of the volume and we add them to a `scene`.
+
+# Change these values to test various parameters combinations.
+scale = 0.5
+norm = False
+colormap = None
+radial_scale = True
+opacity = 1.0
+global_cm = False
+
+# ODF slicer for axial slice
+odf_actor_z = actor.odf_slicer(sh, affine=affine, sphere=sphere_low,
+                               scale=scale, norm=norm,
+                               radial_scale=radial_scale, opacity=opacity,
+                               colormap=colormap, global_cm=global_cm,
+                               B_matrix=B_low)
+
+# ODF slicer for coronal slice
+odf_actor_y = actor.odf_slicer(sh, affine=affine, sphere=sphere_low,
+                               scale=scale, norm=norm,
+                               radial_scale=radial_scale, opacity=opacity,
+                               colormap=colormap, global_cm=global_cm,
+                               B_matrix=B_low)
+odf_actor_y.display_extent(0, grid_shape[0] - 1, grid_shape[1]//2,
+                           grid_shape[1]//2, 0, grid_shape[2] - 1)
+
+# ODF slicer for sagittal slice
+odf_actor_x = actor.odf_slicer(sh, affine=affine, sphere=sphere_low,
+                               scale=scale, norm=norm,
+                               radial_scale=radial_scale, opacity=opacity,
+                               colormap=colormap, global_cm=global_cm,
+                               B_matrix=B_low)
+odf_actor_x.display_extent(grid_shape[0]//2, grid_shape[0]//2, 0,
+                           grid_shape[1] - 1, 0, grid_shape[2] - 1)
+
+scene = window.Scene()
+scene.add(odf_actor_z)
+scene.add(odf_actor_y)
+scene.add(odf_actor_x)
+
+show_m = window.ShowManager(scene, reset_camera=True, size=(1200, 900))
+show_m.initialize()
+
+###############################################################################
+# Now that we have a `ShowManager` containing our slicer, we can go on and
+# configure our UI for changing the slices to visualize.
+line_slider_z = ui.LineSlider2D(min_value=0,
+                                max_value=grid_shape[2] - 1,
+                                initial_value=grid_shape[2] / 2,
+                                text_template="{value:.0f}",
+                                length=140)
+
+line_slider_y = ui.LineSlider2D(min_value=0,
+                                max_value=grid_shape[1] - 1,
+                                initial_value=grid_shape[1] / 2,
+                                text_template="{value:.0f}",
+                                length=140)
+
+line_slider_x = ui.LineSlider2D(min_value=0,
+                                max_value=grid_shape[0] - 1,
+                                initial_value=grid_shape[0] / 2,
+                                text_template="{value:.0f}",
+                                length=140)
+
+###############################################################################
+# We also define a high resolution sphere to demonstrate the capability to
+# dynamically change the sphere used for SH to SF projection.
+sphere_high = get_sphere('symmetric362')
+
+# We fix the order of the faces' three vertices to a clockwise winding. This
+# ensures all faces have a normal going away from the center of the sphere.
+sphere_high.faces = fix_winding_order(sphere_high.vertices,
+                                      sphere_high.faces, True)
+B_high = sh_to_sf_matrix(sphere_high, 8, return_inv=False)
+
+###############################################################################
+# We add a combobox for choosing the sphere resolution during execution.
+sphere_dict = {'Low resolution': (sphere_low, B_low),
+               'High resolution': (sphere_high, B_high)}
+combobox = ui.ComboBox2D(items=list(sphere_dict))
+scene.add(combobox)
+
+###############################################################################
+# Here we will write callbacks for the sliders and combo box and register them.
+
+
+def change_slice_z(slider):
+    i = int(np.round(slider.value))
+    odf_actor_z.slice_along_axis(i)
+
+
+def change_slice_y(slider):
+    i = int(np.round(slider.value))
+    odf_actor_y.slice_along_axis(i, 'yaxis')
+
+
+def change_slice_x(slider):
+    i = int(np.round(slider.value))
+    odf_actor_x.slice_along_axis(i, 'xaxis')
+
+
+def change_sphere(combobox):
+    sphere, B = sphere_dict[combobox.selected_text]
+    odf_actor_x.update_sphere(sphere.vertices, sphere.faces, B)
+    odf_actor_y.update_sphere(sphere.vertices, sphere.faces, B)
+    odf_actor_z.update_sphere(sphere.vertices, sphere.faces, B)
+
+
+line_slider_z.on_change = change_slice_z
+line_slider_y.on_change = change_slice_y
+line_slider_x.on_change = change_slice_x
+combobox.on_change = change_sphere
+
+###############################################################################
+# We then add labels for the sliders and position them inside a panel.
+
+
+def build_label(text):
+    label = ui.TextBlock2D()
+    label.message = text
+    label.font_size = 18
+    label.font_family = 'Arial'
+    label.justification = 'left'
+    label.bold = False
+    label.italic = False
+    label.shadow = False
+    label.background_color = (0, 0, 0)
+    label.color = (1, 1, 1)
+
+    return label
+
+
+line_slider_label_z = build_label(text="Z Slice")
+line_slider_label_y = build_label(text="Y Slice")
+line_slider_label_x = build_label(text="X Slice")
+
+panel = ui.Panel2D(size=(300, 200),
+                   color=(1, 1, 1),
+                   opacity=0.1,
+                   align="right")
+panel.center = (1030, 120)
+
+panel.add_element(line_slider_label_x, (0.1, 0.75))
+panel.add_element(line_slider_x, (0.38, 0.75))
+panel.add_element(line_slider_label_y, (0.1, 0.55))
+panel.add_element(line_slider_y, (0.38, 0.55))
+panel.add_element(line_slider_label_z, (0.1, 0.35))
+panel.add_element(line_slider_z, (0.38, 0.35))
+
+show_m.scene.add(panel)
+
+###############################################################################
+# Then, we can render all the widgets and everything else in the screen and
+# start the interaction using ``show_m.start()``.
+#
+# However, if you change the window size, the panel will not update its
+# position properly. The solution to this issue is to update the position of
+# the panel using its ``re_align`` method every time the window size changes.
+size = scene.GetSize()
+
+
+def win_callback(obj, _event):
+    global size
+    if size != obj.GetSize():
+        size_old = size
+        size = obj.GetSize()
+        size_change = [size[0] - size_old[0], 0]
+        panel.re_align(size_change)
+
+
+show_m.initialize()
+
+###############################################################################
+# Finally, please set the following variable to ``True`` to interact with the
+# datasets in 3D.
+interactive = False
+
+if interactive:
+    show_m.add_window_callback(win_callback)
+    show_m.render()
+    show_m.start()
+else:
+    window.record(scene, out_path='odf_slicer_3D.png', size=(1200, 900),
+                  reset_camera=False)
+
+del show_m

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -819,7 +819,7 @@ def axes(scale=(1, 1, 1), colorx=(1, 0, 0), colory=(0, 1, 0), colorz=(0, 0, 1),
     return arrow(centers, dirs, colors, scales)
 
 
-def odf_slicer(odfs, sphere, affine=None, mask=None, scale=2.2,
+def odf_slicer(odfs, sphere, affine=None, mask=None, scale=0.5,
                norm=True, radial_scale=True, opacity=1.0, colormap=None,
                global_cm=False, B_matrix=None):
     """
@@ -874,10 +874,11 @@ def odf_slicer(odfs, sphere, affine=None, mask=None, scale=2.2,
     if mask is not None:
         valid_odf_mask = np.logical_and(valid_odf_mask, mask)
     indices = np.nonzero(valid_odf_mask)
+    shape = odfs.shape[:-1]
 
     # create and return an instance of OdfSlicerActor
     return OdfSlicerActor(odfs[indices], sphere, indices, scale, norm,
-                          radial_scale, global_cm, colormap, opacity,
+                          radial_scale, shape, global_cm, colormap, opacity,
                           affine, B_matrix)
 
 

--- a/fury/actors/odf_slicer.py
+++ b/fury/actors/odf_slicer.py
@@ -18,8 +18,8 @@ class OdfSlicerActor(vtk.vtkActor):
     vertices: ndarray
         The sphere vertices used for SH to SF projection.
     faces: ndarray
-        Indices of sphere vertices forming triangles. Ordered
-        clockwise. (see fury.utils.fix_winding_order)
+        Indices of sphere vertices forming triangles. Should be
+        ordered clockwise (see fury.utils.fix_winding_order).
     indices: tuple
         Indices given in tuple(x_indices, y_indices, z_indices)
         format for mapping 2D ODF array to 3D voxel grid.
@@ -255,18 +255,3 @@ class OdfSlicerActor(vtk.vtkActor):
         else:
             all_colors = np.tile(np.abs(self.vertices)*255, (len(sf), 1))
         return all_colors.astype(np.uint8)
-
-    def _reorder_faces(self, faces):
-        """
-        Rearrange faces for vtk polydata normal generation.
-        """
-        reordered = faces
-        for i in range(len(faces)):
-            a, b, c = tuple(self.vertices[faces[i]])
-            ab = b - a
-            ac = c - a
-            n = a + b + c
-            n /= np.linalg.norm(n)
-            if np.cross(ab, ac).dot(n) < 0:
-                reordered[i] = [faces[i, 0], faces[i, 2], faces[i, 1]]
-        return reordered

--- a/fury/actors/odf_slicer.py
+++ b/fury/actors/odf_slicer.py
@@ -8,49 +8,99 @@ from fury.colormap import create_colormap
 
 
 class OdfSlicerActor(vtk.vtkActor):
+    """
+    VTK actor for visualizing slices of ODF field.
+
+    Parameters
+    ----------
+    odfs : ndarray
+        SF or SH coefficients 2-dimensional array.
+    sphere : dipy.core.sphere.Sphere
+        The sphere used for SH to SF projection.
+    indices: tuple
+        Indices given in tuple(x_indices, y_indices, z_indices)
+        format for mapping 2D ODF array to 3D voxel grid.
+    scale : float
+        Multiplicative factor to apply to ODF amplitudes.
+    norm : bool
+        Normalize SF amplitudes so that the maximum
+        ODF amplitude per voxel along a direction is 1.
+    radial_scale : bool
+        Scale sphere points by ODF values.
+    global_cm : bool
+        If True the colormap will be applied in all ODFs. If False
+        it will be applied individually at each voxel.
+    colormap : None or str
+        The name of the colormap to use. Matplotlib colormaps are supported
+        (e.g., 'inferno'). If None then a RGB colormap is used.
+    opacity : float
+        Takes values from 0 (fully transparent) to 1 (opaque).
+    affine : array
+        optional 4x4 transformation array from native
+        coordinates to world coordinates.
+    mask : ndarray
+        Optional 3D mask to apply to ODF field.
+    B : ndarray (n_coeffs, n_vertices)
+        Optional SH to SF matrix for projecting `odfs` given in SH
+        coefficents on the `sphere`. If None, then the input is assumed
+        to be expressed in SF coefficients.
+    """
     def __init__(self, odfs, sphere, indices, scale, norm, radial_scale,
                  global_cm, colormap, opacity, affine=None, mask=None, B=None):
-        """
-        When B is specified, odfs expressed in SH coeffients
-        """
         self.vertices = sphere.vertices
         self.faces = sphere.faces
         self.odfs = odfs
         self.indices = indices
         self.B = B
-        self.norm = norm
-        self.scale = scale
         self.radial_scale = radial_scale
         self.colormap = colormap
         self.global_cm = global_cm
-        if self.B is None:
-            if self.norm:
-                self.odfs /= np.abs(self.odfs).max(axis=-1, keepdims=True)
-            if self.scale:
-                self.odfs *= scale
 
+        # If a B matrix is given, odfs are expected to
+        # be in SH basis coefficients.
+        if self.B is not None:
+            # In that case, we need to save our normalisation and scale
+            # to apply them after conversion from SH to SF.
+            self.norm = norm
+            self.scale = scale
+        else:
+            # If our input is in SF coefficients, we can normalise and
+            # scale it only once, here.
+            if norm:
+                self.odfs /= np.abs(self.odfs).max(axis=-1, keepdims=True)
+            self.odfs *= scale
+
+        # Set mask and dimensions of 3D volume.
         if mask is not None:
+            # If a mask is given, we directly use its content and shape
             self.grid_shape = mask.shape
             self.mask = mask
         else:
+            # If no mask is given, we create the smallest grid
+            # containing the maximum indices in `indices`
             self.grid_shape = tuple(np.array(self.indices).max(axis=-1) + 1)
             self.mask = np.ones(self.grid_shape, dtype=np.bool)
 
-        self.w_verts = None
-        self.w_pos = None
-        if affine is not None:
+        # Compute world coordinates of an affine is supplied
+        self.is_world = affine is not None
+        if self.is_world:
             self.w_verts = self.vertices.dot(affine[:3, :3])
             self.w_pos =\
                 np.append(np.asarray(self.indices).T,
                           np.ones((len(self.odfs), 1)), axis=-1).dot(affine)
             self.w_pos = self.w_pos[..., :-1]
 
+        # Initialize mapper and slice to the
+        # middle of the volume along Z axis
         self.mapper = vtk.vtkPolyDataMapper()
         self.SetMapper(self.mapper)
         self.slice_along_axis(self.grid_shape[-1]//2)
         self.set_opacity(opacity)
 
     def set_opacity(self, opacity):
+        """
+        Set opacity value of ODFs to display.
+        """
         self.GetProperty().SetOpacity(opacity)
 
     def display_extent(self, x1, x2, y1, y2, z1, z2):
@@ -66,6 +116,10 @@ class OdfSlicerActor(vtk.vtkActor):
         self._update_mapper(mask)
 
     def slice_along_axis(self, slice_index, axis='zaxis'):
+        """
+        Slice ODF field at given `slice_index` along axis
+        in ['xaxis', 'yaxis', zaxis'].
+        """
         if axis == 'xaxis':
             self.display_extent(slice_index, slice_index,
                                 0, self.grid_shape[1] - 1,
@@ -81,11 +135,9 @@ class OdfSlicerActor(vtk.vtkActor):
         else:
             raise ValueError('Invalid axis name {0}.'.format(axis))
 
-    @deprecate_with_version('Method display() is deprecated. '
-                            'Use slice_along_axis() instead.')
     def display(self, x=None, y=None, z=None):
         if x is None and y is None and z is None:
-            self.slice_along_axis(self.shape[2]//2)
+            self.slice_along_axis(self.grid_shape[2]//2)
         elif x is not None:
             self.slice_along_axis(x, 'xaxis')
         elif y is not None:
@@ -94,54 +146,84 @@ class OdfSlicerActor(vtk.vtkActor):
             self.slice_along_axis(z, 'zaxis')
 
     def _update_mapper(self, mask):
-        # World positions of nonzero voxels
-        w_pos = \
-            self.w_pos[mask[self.indices]]\
-            if self.w_pos is not None\
-            else np.asarray(self.indices).T
-        sph_dirs = \
-            self.w_verts\
-            if self.w_verts is not None else\
-            self.vertices
+        """
+        Map vtkPolyData for ODFs inside `mask` to the actor.
+        """
+        polydata = vtk.vtkPolyData()
 
-        if len(w_pos) == 0:
+        offsets = self._get_odf_offsets(mask)
+        if len(offsets) == 0:
+            self.mapper.SetInputData(polydata)
             return None
 
-        # Convert to SF if input is expressed as SH
-        if self.B is not None:
-            sf = self.odfs[mask[self.indices]].dot(self.B)
-            if self.norm:
-                sf /= np.abs(sf).max(axis=-1, keepdims=True)
-            sf *= self.scale
-        else:
-            sf = self.odfs
+        sph_dirs = self._get_sphere_directions()
+        sf = self._get_sf(mask)
 
-        if self.radial_scale:
-            all_vertices =\
-                np.tile(sph_dirs, (len(w_pos), 1)) * sf.reshape(-1, 1) +\
-                np.repeat(w_pos, len(sph_dirs), axis=0)
-        else:
-            all_vertices =\
-                np.tile(sph_dirs, (len(w_pos), 1)) * self.scale +\
-                np.repeat(w_pos, len(sph_dirs), axis=0)
-
-        all_faces =\
-            np.tile(self.faces, (len(w_pos), 1)) + \
-            np.repeat(np.arange(len(w_pos)) * len(sph_dirs),
-                      len(self.faces)).reshape(-1, 1)
-
+        all_vertices = self._get_all_vertices(offsets, sph_dirs, sf)
+        all_faces = self._get_all_faces(len(offsets), len(sph_dirs))
         all_colors = self._generate_color_for_vertices(sf)
 
-        polydata = vtk.vtkPolyData()
         set_polydata_triangles(polydata, all_faces)
         set_polydata_vertices(polydata, all_vertices)
         set_polydata_colors(polydata, all_colors)
+
         self.mapper.SetInputData(polydata)
+
+    def _get_odf_offsets(self, mask):
+        """
+        Get the position of non-zero voxels inside `mask`.
+        """
+        if self.is_world:
+            return self.w_pos[mask[self.indices]]
+        return np.asarray(self.indices).T
+
+    def _get_sphere_directions(self):
+        """
+        Get the sphere directions onto which is projected the signal.
+        """
+        if self.is_world:
+            return self.w_verts
+        return self.vertices
+
+    def _get_sf(self, mask):
+        """
+        Get SF coefficients inside `mask`.
+        """
+        # when odfs are expressed in SH coefficients
+        if self.B is not None:
+            sf = self.odfs[mask[self.indices]].dot(self.B)
+            # normalisation and scaling is done on SF coefficients
+            if self.norm:
+                sf /= np.abs(sf).max(axis=-1, keepdims=True)
+            return sf * self.scale
+        # when odfs are in SF coefficients, the normalisation and scaling
+        # are done during initialisation. We simply return them:
+        return self.odfs
+
+    def _get_all_vertices(self, offsets, sph_dirs, sf):
+        """
+        Get array of all the vertices of the ODFs to display.
+        """
+        if self.radial_scale:
+            # apply SF amplitudes to all sphere
+            # directions and offset each voxel
+            return np.tile(sph_dirs, (len(offsets), 1)) * sf.reshape(-1, 1) +\
+                   np.repeat(offsets, len(sph_dirs), axis=0)
+        # return scaled spheres offsetted by `offsets`
+        return np.tile(sph_dirs, (len(offsets), 1)) * self.scale +\
+            np.repeat(offsets, len(sph_dirs), axis=0)
+
+    def _get_all_faces(self, nb_odfs, nb_dirs):
+        """
+        Get array of all the faces of the ODFs to display.
+        """
+        return np.tile(self.faces, (nb_odfs, 1)) +\
+            np.repeat(np.arange(nb_odfs) * nb_dirs, len(self.faces))\
+            .reshape(-1, 1)
 
     def _generate_color_for_vertices(self, sf):
         """
-        *Calls to create_colormap are expensive. To increase
-        compute time, use colormap=None.
+        Get array of all vertices colors.
         """
         if self.global_cm:
             if self.colormap is None:
@@ -152,8 +234,11 @@ class OdfSlicerActor(vtk.vtkActor):
                     .astype(np.uint8)
         elif self.colormap is not None:
             all_colors =\
-                (np.array([create_colormap(sf_i, self.colormap)
-                           for sf_i in sf]) * 255).reshape(-1, 3)\
+                (create_colormap(
+                    ((sf - sf.min(axis=-1, keepdims=True))
+                     / (sf.max(axis=-1, keepdims=True)
+                     - sf.min(axis=-1, keepdims=True))).ravel(),
+                    self.colormap) * 255)\
                 .astype(np.uint8)
         else:
             all_colors =\

--- a/fury/actors/odf_slicer.py
+++ b/fury/actors/odf_slicer.py
@@ -55,7 +55,6 @@ class OdfSlicerActor(vtk.vtkActor):
         self.radial_scale = radial_scale
         self.colormap = colormap
         self.global_cm = global_cm
-        print(self.odfs.shape)
 
         # declare a mask to be instantiated in slice_along_axis
         self.mask = None
@@ -81,7 +80,7 @@ class OdfSlicerActor(vtk.vtkActor):
         # Compute world coordinates of an affine is supplied
         self.is_world = affine is not None
         if self.is_world:
-            self.w_verts = apply_affine(affine, self.vertices)
+            self.w_verts = self.vertices.dot(affine[:3, :3])
             self.w_pos = apply_affine(affine, np.asarray(self.indices).T)
 
         # Initialize mapper and slice to the
@@ -103,7 +102,7 @@ class OdfSlicerActor(vtk.vtkActor):
         y1 (inclusive) to y2 (inclusive), z1 (inclusive) to z2
         (inclusive).
         """
-        mask = np.zeros(self.grid_shape, dtype=np.bool)
+        mask = np.zeros(self.grid_shape, dtype=bool)
         mask[x1:x2 + 1, y1:y2 + 1, z1:z2 + 1] = True
         self.mask = mask
 

--- a/fury/actors/odf_slicer.py
+++ b/fury/actors/odf_slicer.py
@@ -1,0 +1,162 @@
+import numpy as np
+import vtk
+
+from fury.deprecator import deprecate_with_version
+from fury.utils import (set_polydata_vertices, set_polydata_triangles,
+                        set_polydata_normals, set_polydata_colors)
+from fury.colormap import create_colormap
+
+
+class OdfSlicerActor(vtk.vtkActor):
+    def __init__(self, odfs, sphere, indices, scale, norm, radial_scale,
+                 global_cm, colormap, opacity, affine=None, mask=None, B=None):
+        """
+        When B is specified, odfs expressed in SH coeffients
+        """
+        self.vertices = sphere.vertices
+        self.faces = sphere.faces
+        self.odfs = odfs
+        self.indices = indices
+        self.B = B
+        self.norm = norm
+        self.scale = scale
+        self.radial_scale = radial_scale
+        self.colormap = colormap
+        self.global_cm = global_cm
+        if self.B is None:
+            if self.norm:
+                self.odfs /= np.abs(self.odfs).max(axis=-1, keepdims=True)
+            if self.scale:
+                self.odfs *= scale
+
+        if mask is not None:
+            self.grid_shape = mask.shape
+            self.mask = mask
+        else:
+            self.grid_shape = tuple(np.array(self.indices).max(axis=-1) + 1)
+            self.mask = np.ones(self.grid_shape, dtype=np.bool)
+
+        self.w_verts = None
+        self.w_pos = None
+        if affine is not None:
+            self.w_verts = self.vertices.dot(affine[:3, :3])
+            self.w_pos =\
+                np.append(np.asarray(self.indices).T,
+                          np.ones((len(self.odfs), 1)), axis=-1).dot(affine)
+            self.w_pos = self.w_pos[..., :-1]
+
+        self.mapper = vtk.vtkPolyDataMapper()
+        self.SetMapper(self.mapper)
+        self.slice_along_axis(self.grid_shape[-1]//2)
+        self.set_opacity(opacity)
+
+    def set_opacity(self, opacity):
+        self.GetProperty().SetOpacity(opacity)
+
+    def display_extent(self, x1, x2, y1, y2, z1, z2):
+        """
+        Set visible volume from x1 (inclusive) to x2 (inclusive),
+        y1 (inclusive) to y2 (inclusive), z1 (inclusive) to z2
+        (inclusive).
+        """
+        mask = np.zeros_like(self.mask)
+        mask[x1:x2 + 1, y1:y2 + 1, z1:z2 + 1] = True
+        mask = np.bitwise_and(mask, self.mask)
+
+        self._update_mapper(mask)
+
+    def slice_along_axis(self, slice_index, axis='zaxis'):
+        if axis == 'xaxis':
+            self.display_extent(slice_index, slice_index,
+                                0, self.grid_shape[1] - 1,
+                                0, self.grid_shape[2] - 1)
+        elif axis == 'yaxis':
+            self.display_extent(0, self.grid_shape[0] - 1,
+                                slice_index, slice_index,
+                                0, self.grid_shape[2] - 1)
+        elif axis == 'zaxis':
+            self.display_extent(0, self.grid_shape[0] - 1,
+                                0, self.grid_shape[1] - 1,
+                                slice_index, slice_index)
+        else:
+            raise ValueError('Invalid axis name {0}.'.format(axis))
+
+    @deprecate_with_version('Method display() is deprecated. '
+                            'Use slice_along_axis() instead.')
+    def display(self, x=None, y=None, z=None):
+        if x is None and y is None and z is None:
+            self.slice_along_axis(self.shape[2]//2)
+        elif x is not None:
+            self.slice_along_axis(x, 'xaxis')
+        elif y is not None:
+            self.slice_along_axis(y, 'yaxis')
+        elif z is not None:
+            self.slice_along_axis(z, 'zaxis')
+
+    def _update_mapper(self, mask):
+        # World positions of nonzero voxels
+        w_pos = \
+            self.w_pos[mask[self.indices]]\
+            if self.w_pos is not None\
+            else np.asarray(self.indices).T
+        sph_dirs = \
+            self.w_verts\
+            if self.w_verts is not None else\
+            self.vertices
+
+        if len(w_pos) == 0:
+            return None
+
+        # Convert to SF if input is expressed as SH
+        if self.B is not None:
+            sf = self.odfs[mask[self.indices]].dot(self.B)
+            if self.norm:
+                sf /= np.abs(sf).max(axis=-1, keepdims=True)
+            sf *= self.scale
+        else:
+            sf = self.odfs
+
+        if self.radial_scale:
+            all_vertices =\
+                np.tile(sph_dirs, (len(w_pos), 1)) * sf.reshape(-1, 1) +\
+                np.repeat(w_pos, len(sph_dirs), axis=0)
+        else:
+            all_vertices =\
+                np.tile(sph_dirs, (len(w_pos), 1)) * self.scale +\
+                np.repeat(w_pos, len(sph_dirs), axis=0)
+
+        all_faces =\
+            np.tile(self.faces, (len(w_pos), 1)) + \
+            np.repeat(np.arange(len(w_pos)) * len(sph_dirs),
+                      len(self.faces)).reshape(-1, 1)
+
+        all_colors = self._generate_color_for_vertices(sf)
+
+        polydata = vtk.vtkPolyData()
+        set_polydata_triangles(polydata, all_faces)
+        set_polydata_vertices(polydata, all_vertices)
+        set_polydata_colors(polydata, all_colors)
+        self.mapper.SetInputData(polydata)
+
+    def _generate_color_for_vertices(self, sf):
+        """
+        *Calls to create_colormap are expensive. To increase
+        compute time, use colormap=None.
+        """
+        if self.global_cm:
+            if self.colormap is None:
+                raise IOError("if global_cm=True, colormap must be defined")
+            else:
+                all_colors =\
+                    (create_colormap(sf.ravel(), self.colormap) * 255)\
+                    .astype(np.uint8)
+        elif self.colormap is not None:
+            all_colors =\
+                (np.array([create_colormap(sf_i, self.colormap)
+                           for sf_i in sf]) * 255).reshape(-1, 3)\
+                .astype(np.uint8)
+        else:
+            all_colors =\
+                np.tile(np.abs(self.vertices)*255, (len(sf), 1))\
+                .astype(np.uint8)
+        return all_colors

--- a/fury/actors/odf_slicer.py
+++ b/fury/actors/odf_slicer.py
@@ -174,6 +174,8 @@ class OdfSlicerActor(vtk.vtkActor):
         all_faces = self._get_all_faces(len(offsets), len(sph_dirs))
         all_colors = self._generate_color_for_vertices(sf)
 
+        # TODO: There is a lot of deep copy here.
+        # Optimize (see viz_network.py example).
         set_polydata_triangles(polydata, all_faces)
         set_polydata_vertices(polydata, all_vertices)
         set_polydata_colors(polydata, all_colors)

--- a/fury/colormap.py
+++ b/fury/colormap.py
@@ -314,7 +314,7 @@ def create_colormap(v, name='plasma', auto=True):
         'inferno'. 'jet' is popular but can be often misleading and we will
         deprecate it the future.
     auto : bool,
-        if auto is True then v is interpolated to [0, 10] from v.min()
+        if auto is True then v is interpolated to [0, 1] from v.min()
         to v.max()
 
     Notes

--- a/fury/data/__init__.py
+++ b/fury/data/__init__.py
@@ -5,11 +5,13 @@ from os.path import join as pjoin, dirname
 from fury.data.fetcher import (fetch_viz_icons, read_viz_icons,
                                fetch_viz_wiki_nw, fetch_viz_textures,
                                read_viz_textures, fetch_viz_models,
-                               read_viz_models)
+                               read_viz_models, fetch_viz_dmri,
+                               read_viz_dmri)
 
 DATA_DIR = pjoin(dirname(__file__), 'files')
 
 __all__ = ['fetch_viz_icons', 'read_viz_icons', 'DATA_DIR',
            'fetch_viz_textures', 'read_viz_textures',
            'fetch_viz_wiki_nw', 'fetch_viz_models',
-           'read_viz_models']
+           'read_viz_models', 'fetch_viz_dmri',
+           'read_viz_dmri']

--- a/fury/data/fetcher.py
+++ b/fury/data/fetcher.py
@@ -32,6 +32,9 @@ MODEL_DATA_URL = \
 TEXTURE_DATA_URL = \
     "https://raw.githubusercontent.com/fury-gl/fury-data/master/textures/"
 
+DMRI_DATA_URL = \
+    "https://raw.githubusercontent.com/fury-gl/fury-data/master/dmri/"
+
 
 class FetcherError(Exception):
     pass
@@ -304,6 +307,15 @@ fetch_viz_models = _make_fetcher(
     doc=" Download the models for shader tutorial"
     )
 
+fetch_viz_dmri = _make_fetcher(
+    "fetch_viz_dmri",
+    pjoin(fury_home, "dmri"),
+    DMRI_DATA_URL,
+    ['fodf.nii.gz'],
+    ['fodf.nii.gz'],
+    ['767ca3e4cd296e78421d83c32201b30be2d859c332210812140caac1b93d492b']
+)
+
 fetch_viz_textures = _make_fetcher(
     "fetch_viz_textures",
     pjoin(fury_home, "textures"),
@@ -414,4 +426,23 @@ def read_viz_textures(fname):
 
     """
     folder = pjoin(fury_home, 'textures')
+    return pjoin(folder, fname)
+
+
+def read_viz_dmri(fname):
+    """Read specific dMRI image.
+
+    Parameters
+    ----------
+    fname: str
+        Filename of the texture.
+        This should be found in folder HOME/.fury/dmri/.
+
+    Returns
+    -------
+    path : str
+        Complete path of dMRI image.
+
+    """
+    folder = pjoin(fury_home, 'dmri')
     return pjoin(folder, fname)

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -21,6 +21,7 @@ matplotlib, have_matplotlib, _ = optional_package('matplotlib')
 
 if have_dipy:
     from dipy.data import get_sphere
+    from dipy.reconst.shm import sh_to_sf_matrix
     from dipy.tracking.streamline import (center_streamlines,
                                           transform_streamlines)
     from dipy.align.tests.test_streamlinear import fornix_streamlines
@@ -506,109 +507,74 @@ def test_bundle_maps():
 
 @pytest.mark.skipif(not have_dipy, reason="Requires DIPY")
 def test_odf_slicer(interactive=False):
-
-    sphere = get_sphere('symmetric362')
-
+    # Prepare our data
+    sphere = get_sphere('repulsion100')
     shape = (11, 11, 11, sphere.vertices.shape[0])
+    odfs = np.ones(shape)
 
-    fid, fname = mkstemp(suffix='_odf_slicer.mmap')
-    print(fid)
-    print(fname)
+    affine = np.array([[2.0, 0.0, 0.0, 3.0],
+                       [0.0, 2.0, 0.0, 3.0],
+                       [0.0, 0.0, 2.0, 1.0],
+                       [0.0, 0.0, 0.0, 1.0]])
+    mask = np.ones(odfs.shape[:3], bool)
+    mask[:4, :4, :4] = False
 
-    odfs = np.memmap(fname, dtype=np.float64, mode='w+',
-                     shape=shape)
+    # Test that affine and mask work
+    odf_actor = actor.odf_slicer(odfs, sphere, affine=affine, mask=mask,
+                                 scale=.25, colormap='blues')
 
-    odfs[:] = 1
-
-    affine = np.eye(4)
-    scene = window.Scene()
-
-    mask = np.ones(odfs.shape[:3])
-    mask[:4, :4, :4] = 0
-
-    odfs[..., 0] = 1
-
-    odf_actor = actor.odf_slicer(odfs, affine,
-                                 mask=mask, sphere=sphere, scale=.25,
-                                 colormap='blues')
-    fa = 0. * np.zeros(odfs.shape[:3])
-    fa[:, 0, :] = 1.
-    fa[:, -1, :] = 1.
-    fa[0, :, :] = 1.
-    fa[-1, :, :] = 1.
-    fa[5, 5, 5] = 1
-
-    k = 5
+    k = 2
     I, J, _ = odfs.shape[:3]
+    odf_actor.display_extent(0, I - 1, 0, J - 1, k, k)
 
-    fa_actor = actor.slicer(fa, affine)
-    fa_actor.display_extent(0, I, 0, J, k, k)
+    scene = window.Scene()
     scene.add(odf_actor)
     scene.reset_camera()
     scene.reset_clipping_range()
 
-    odf_actor.display_extent(0, I, 0, J, k, k)
-    odf_actor.GetProperty().SetOpacity(1.0)
     if interactive:
         window.show(scene, reset_camera=False)
 
     arr = window.snapshot(scene)
     report = window.analyze_snapshot(arr, find_objects=True)
-    npt.assert_equal(report.objects, 11 * 11)
+    npt.assert_equal(report.objects, 11 * 11 - 16)
 
+    # Test that global colormap works
+    odf_actor = actor.odf_slicer(odfs, sphere, mask=mask, scale=.25,
+                                 colormap='blues', norm=False, global_cm=True)
     scene.clear()
-    scene.add(fa_actor)
-    scene.reset_camera()
-    scene.reset_clipping_range()
-    if interactive:
-        window.show(scene)
-
-    mask[:] = 0
-    mask[5, 5, 5] = 1
-    fa[5, 5, 5] = 0
-    fa_actor = actor.slicer(fa, None)
-    fa_actor.display(None, None, 5)
-    odf_actor = actor.odf_slicer(odfs, None, mask=mask,
-                                 sphere=sphere, scale=.25,
-                                 colormap='blues',
-                                 norm=False, global_cm=True)
-    scene.clear()
-    scene.add(fa_actor)
     scene.add(odf_actor)
     scene.reset_camera()
     scene.reset_clipping_range()
     if interactive:
         window.show(scene)
 
+    # Test that the most basic odf_slicer instanciation works
+    odf_actor = actor.odf_slicer(odfs, sphere)
     scene.clear()
     scene.add(odf_actor)
-    scene.add(fa_actor)
-    odfs[:, :, :] = 1
-    mask = np.ones(odfs.shape[:3])
-    odf_actor = actor.odf_slicer(odfs, None, mask=mask,
-                                 sphere=sphere, scale=.25,
-                                 colormap='blues',
-                                 norm=False, global_cm=True)
+    scene.reset_camera()
+    scene.reset_clipping_range()
+    if interactive:
+        window.show(scene)
 
+    # Test that odf_slicer.display works properly
     scene.clear()
     scene.add(odf_actor)
-    scene.add(fa_actor)
     scene.add(actor.axes((11, 11, 11)))
     for i in range(11):
         odf_actor.display(i, None, None)
-        fa_actor.display(i, None, None)
         if interactive:
             window.show(scene)
     for j in range(11):
         odf_actor.display(None, j, None)
-        fa_actor.display(None, j, None)
         if interactive:
             window.show(scene)
-    # with mask equal to zero everything should be black
+
+    # With mask equal to zero everything should be black
     mask = np.zeros(odfs.shape[:3])
-    odf_actor = actor.odf_slicer(odfs, None, mask=mask,
-                                 sphere=sphere, scale=.25,
-                                 colormap='blues',
+    odf_actor = actor.odf_slicer(odfs, sphere, mask=mask,
+                                 scale=.25, colormap='blues',
                                  norm=False, global_cm=True)
     scene.clear()
     scene.add(odf_actor)
@@ -617,30 +583,53 @@ def test_odf_slicer(interactive=False):
     if interactive:
         window.show(scene)
 
-    npt.assert_raises(IOError, actor.odf_slicer, odfs, None, mask=None,
-                      sphere=sphere, scale=.25, colormap=None, norm=False,
-                      global_cm=True)
+    # global_cm=True with colormap=None should raise an error
+    npt.assert_raises(IOError, actor.odf_slicer, odfs, sphere, mask=None,
+                      scale=.25, colormap=None, norm=False, global_cm=True)
 
     # colormap=None and global_cm=False results in directionally encoded colors
+    odf_actor = actor.odf_slicer(odfs, sphere, mask=None,
+                                 scale=.25, colormap=None,
+                                 norm=False, global_cm=False)
     scene.clear()
     scene.add(odf_actor)
-    scene.add(fa_actor)
-    odfs[:, :, :] = 1
-    odf_actor = actor.odf_slicer(odfs, None, mask=None,
-                                 sphere=sphere, scale=.25,
-                                 colormap=None,
-                                 norm=False, global_cm=False)
+    scene.reset_camera()
+    scene.reset_clipping_range()
+    if interactive:
+        window.show(scene)
 
-    report = window.analyze_scene(scene)
-    npt.assert_equal(report.actors, 1)
-    npt.assert_equal(report.actors_classnames[0], 'vtkLODActor')
+    # Test that SH coefficients input works
+    B = sh_to_sf_matrix(sphere, return_inv=False)
+    odfs = np.zeros((11, 11, 11, B.shape[0]))
+    odfs[..., 0] = 1.0
+
+    odf_actor = actor.odf_slicer(odfs, sphere, B_matrix=B)
+    scene.clear()
+    scene.add(odf_actor)
+    scene.reset_camera()
+    scene.reset_clipping_range()
+    if interactive:
+        window.show(scene)
+
+    # Test that constant colormap color works. All ODFs should be white.
+    odf_actor = actor.odf_slicer(odfs, sphere, B_matrix=B,
+                                 colormap=(255, 255, 255))
+    scene.clear()
+    scene.add(odf_actor)
+    scene.reset_camera()
+    scene.reset_clipping_range()
+    if interactive:
+        window.show(scene)
+
+    # Test that we can change the sphere on an active actor
+    new_sphere = get_sphere('symmetric362')
+    new_B = sh_to_sf_matrix(new_sphere, return_inv=False)
+    odf_actor.update_sphere(new_sphere, new_B)
+    if interactive:
+        window.show(scene)
 
     del odf_actor
-    odfs._mmap.close()
     del odfs
-    os.close(fid)
-
-    os.remove(fname)
 
 
 def test_peak_slicer(interactive=False):

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -394,7 +394,8 @@ def set_polydata_triangles(polydata, triangles):
     else:
         isize = vtk.vtkIdTypeArray().GetDataTypeSize()
         req_dtype = np.int32 if isize == 4 else np.int64
-        all_triangles = np.insert(triangles, 0, 3, axis=1).flatten()
+        all_triangles =\
+            np.insert(triangles, 0, 3, axis=1).astype(req_dtype).flatten()
         vtk_triangles = numpy_support.numpy_to_vtkIdTypeArray(all_triangles,
                                                               deep=True)
         vtk_cells.SetCells(len(triangles), vtk_triangles)

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -394,9 +394,7 @@ def set_polydata_triangles(polydata, triangles):
     else:
         isize = vtk.vtkIdTypeArray().GetDataTypeSize()
         req_dtype = np.int32 if isize == 4 else np.int64
-        all_triangles = np.hstack(
-            np.c_[np.ones(len(triangles), dtype=req_dtype) * 3,
-                  triangles.astype(req_dtype)])
+        all_triangles = np.insert(triangles, 0, 3, axis=1).flatten()
         vtk_triangles = numpy_support.numpy_to_vtkIdTypeArray(all_triangles,
                                                               deep=True)
         vtk_cells.SetCells(len(triangles), vtk_triangles)


### PR DESCRIPTION
Hi,
I did some refactoring of `actor.odf_slicer` with the objective to make it faster and less memory greedy.
Basically:
* I replaced `for` loops by `numpy` array operations;
* I added the option to supply ODFs in SH coefficients, when given a B matrix;
* I added a method to change the sphere used for visualization when using SH coefficients;
* I changed the `numpy` method called in `utils.set_polydata_triangle` for one that completes faster;
* I applied the affine transform to the grid as well as to the ODFs themselves, as suggested [here](https://github.com/fury-gl/fury/issues/10);
* I moved the class `OdfSlicerActor` to the new module `fury.actors.odf_slicer` to make some space in `fury.actor` module;
* I wrote tests.

If there is some ODF data available somewhere, I would gladly add an example too.

Below are some screenshots showing new functionalities.

**Real-time ODF volume slicing**
![real-time-slicing](https://user-images.githubusercontent.com/41654474/107582438-79bc9c80-6bc7-11eb-8973-e239aa262bbc.gif)

**Changing sphere resolution during execution**
![update-sphere](https://user-images.githubusercontent.com/41654474/107582453-82ad6e00-6bc7-11eb-8806-eb90bfe3e047.gif)
