### PR TITLE
Saving frames to GIF

### DIFF
--- a/fury/io.py
+++ b/fury/io.py
@@ -264,3 +264,29 @@ def save_polydata(polydata, file_name, binary=False, color_array_name=None):
         writer.SetFileTypeToBinary()
     writer.Update()
     writer.Write()
+
+
+def frames_to_gif(file_name, use_pillow=True):
+    """
+    Saves frames as a gif.
+    """
+
+    file_extension = file_name.split(".")[-1].lower()
+
+    if file_extension != "obj":
+        raise IOError(f"We cannot save {file_name} as  a gif.")
+    elif file_extension == "obj":
+        # how do we take snapshots of
+        # an existing scene? or do we create a scene?
+        pass
+
+    if use_pillow:
+        images = []
+        # add code to generate images from scene
+        # Using `save` from PIL to convert the
+        # Series of Frames into a GIF Image.
+        images[0].save( 'frame_to_gif.gif',
+                        save_all=True,
+                        append_images=images[1:],
+                        optimize=False,
+                        loop=0)


### PR DESCRIPTION
This PR references #323 .

As the existing PRs seem to be unattended, I creating this PR.

However, this isnt complete. i have a few questions like :
- The file_name that we give in the argument, what file is it(animation, scene? ) What is the type?
- Actors can be added to recreate the scene to save images of each frame after a certain time interval to create the gif.

I tried it on the ``` timer callback``` tutorial : https://fury.gl/latest/auto_tutorials/01_introductory/viz_timers.html.

The gif looks like this :

![Bubbles](https://user-images.githubusercontent.com/51290447/107950788-45791f80-6fbd-11eb-98de-dc4ce927e107.gif)

This is the gif generated. However, for this we will have to add actors to the scene everytime.

@skoudoro @Nibba2018 Any help is welcome as I am new to fury. 

The failing tests can be resolved after adding missing code.