### PR TITLE
Fixed warnings in test_utils.py

### DIFF
--- a/docs/tutorials/01_introductory/viz_solar_system.py
+++ b/docs/tutorials/01_introductory/viz_solar_system.py
@@ -243,9 +243,11 @@ def update_track(positions_planet, planet_track, planet_orbit_actor):
     positions_planet[:] = np.array(planet_track)
     utils.update_actor(planet_orbit_actor)
 
+
 def calculate_path(r_planet, planet_track, cnt):
     pos_planet = get_orbital_position(r_planet, cnt)
     planet_track.append([pos_planet[0], 0, pos_planet[1]])
+
 
 ##############################################################################
 # Calculating and updating the path/orbit before animation starts

--- a/docs/tutorials/01_introductory/viz_solar_system.py
+++ b/docs/tutorials/01_introductory/viz_solar_system.py
@@ -167,8 +167,6 @@ counter = itertools.count()
 # those to the positions variables for each planet. These variables will be
 # updated within the ``timer_callback`` function.
 
-orbit_points = np.zeros((2200, 3), dtype='float')
-
 mercury_track = []
 venus_track = []
 earth_track = []
@@ -200,7 +198,7 @@ def calculate_path(r_planet, planet_track, cnt):
 
 
 ##############################################################################
-# First we are making two lists that will contain radiuses and track's lists.
+# First we are making two lists that will contain radii and track's lists.
 # and then we are calculating and updating the path/orbit
 # before animation starts.
 
@@ -213,7 +211,7 @@ for r_planet, planets_track in zip(r_planets, planets_tracks):
     calculate_path(r_planet, planets_track, 2200)
 
 ##############################################################################
-# This is for orbit visualization, We are using line actor for orbits.
+# This is for orbit visualization. We are using line actor for orbits.
 # After creating an actor we add it to the scene.
 
 for planets_track in planets_tracks:

--- a/docs/tutorials/01_introductory/viz_solar_system.py
+++ b/docs/tutorials/01_introductory/viz_solar_system.py
@@ -20,45 +20,57 @@ from fury.data import read_viz_textures, fetch_viz_textures
 scene = window.Scene()
 
 ##############################################################################
-# Load in a texture for each of the actors. To do this, we will create
-# a function called ``init_planet``, which will initialize each planet actor
-# given its corresponding filename and actor name.It will also set the
-# position of the planet and rescale it. It will also add each actor to
-# the scene that has already been created.
+# Define information relevant for each planet actor including its
+# texture name, relative position, and scale.
 
-planet_filenames = {"8k_mercury.jpg": [7, (0.4, 0.4, 0.4)],
-                    "8k_venus_surface.jpg": [9, (0.6, 0.6, 0.6)],
-                    "1_earth_8k.jpg": [11, (0.4, 0.4, 0.4)],
-                    "8k_mars.jpg": [13, (0.8, 0.8, 0.8)],
-                    "jupiter.jpg": [16, (2, 2, 2)],
-                    "8k_saturn.jpg": [19, (2, 2, 2)],
-                    "8k_saturn_ring_alpha.png": [19, (3, 0.5, 3)],
-                    "2k_uranus.jpg": [22, (1, 1, 1)],
-                    "2k_neptune.jpg": [25, (1, 1, 1)],
-                    "8k_sun.jpg": [0, (5, 5, 5)]}
+planets_data = [{'filename': '8k_mercury.jpg', 'position': 7,
+                 'scale': (.4, .4, .4)},
+                {'filename': '8k_venus_surface.jpg', 'position': 9,
+                 'scale': (.6, .6, .6)},
+                {'filename': '1_earth_8k.jpg', 'position': 11,
+                 'scale': (.4, .4, .4)},
+                {'filename': '8k_mars.jpg', 'position': 13,
+                 'scale': (.8, .8, .8)},
+                {'filename': 'jupiter.jpg', 'position': 16,
+                 'scale': (2, 2, 2)},
+                {'filename': '8k_saturn.jpg', 'position': 19,
+                 'scale': (2, 2, 2)},
+                {'filename': '8k_saturn_ring_alpha.png', 'position': 19,
+                 'scale': (3, .5, 3)},
+                {'filename': '2k_uranus.jpg', 'position': 22,
+                 'scale': (1, 1, 1)},
+                {'filename': '2k_neptune.jpg', 'position': 25,
+                 'scale': (1, 1, 1)},
+                {'filename': '8k_sun.jpg', 'position': 0,
+                 'scale': (5, 5, 5)}]
 fetch_viz_textures()
 
+##############################################################################
+# To take advantage of the previously defined data structure we are going to
+# create an auxiliary function that will load and apply the respective
+# texture, set its respective properties (relative position and scale),
+# and add the actor to a previously created scene.
 
-def init_planet(filename):
+
+def init_planet(planet_data):
     """Initialize a planet actor.
 
     Parameters
     ----------
-    filename : dict
-        The filename is a dictionary, the key is the name of texture file
-        name and the value is the list of the radius of the orbit of planet
-        and the scale of the planet.
+    planet_data : dict
+        The planet_data is a dictionary, and the keys are filename(texture),
+        position and scale.
 
     Returns
     -------
     planet_actor: actor
         The corresponding sphere actor with texture applied.
     """
-    planet_file = read_viz_textures(filename)
+    planet_file = read_viz_textures(planet_data['filename'])
     planet_image = io.load_image(planet_file)
     planet_actor = actor.texture_on_sphere(planet_image)
-    planet_actor.SetPosition(planet_filenames[filename][0], 0, 0)
-    planet_actor.SetScale(planet_filenames[filename][1])
+    planet_actor.SetPosition(planet_data['position'], 0, 0)
+    planet_actor.SetScale(planet_data['scale'])
     scene.add(planet_actor)
     return planet_actor
 
@@ -68,7 +80,7 @@ def init_planet(filename):
 # in the ``planet_files`` list. Then, assign each actor to its corresponding
 # actor in the list.
 
-planet_actor_list = list(map(init_planet, planet_filenames))
+planet_actor_list = list(map(init_planet, planets_data))
 
 mercury_actor = planet_actor_list[0]
 venus_actor = planet_actor_list[1]
@@ -86,9 +98,7 @@ utils.rotate(jupiter_actor, (90, 1, 0, 0))
 
 ##############################################################################
 # Define the gravitational constant G, the orbital radii of each of the
-# planets, and the central mass of the sun(Because of some bug, for different
-# OS the value of `np.power(10, 30)` is different and that causes visual bug,
-# Therefore we are taking it constant for now). The gravity and mass will be
+# planets, and the central mass of the sun. The gravity and mass will be
 # used to calculate the orbital position, so multiply these two together to
 # create a new constant, which we will call miu.
 
@@ -115,7 +125,7 @@ def get_orbital_position(radius, time):
     orbit_period = get_orbit_period(radius)
     x = radius * np.cos((2*np.pi*time)/orbit_period)
     y = radius * np.sin((2*np.pi*time)/orbit_period)
-    return (x, y)
+    return x, y
 
 
 ##############################################################################
@@ -161,18 +171,21 @@ def calculate_path(r_planet, planet_track, cnt):
 
 
 ##############################################################################
-# First we are making a list that will contain radii form `planet_filenames`.
-# `planet_tracks` is list of 8 empty list for 8 different planets.
-# and `planet_actors` will contain all the planet actor. And then we are
-# calculating and updating the path/orbit before animation starts.
+# First we are making a list that will contain radius from `planets_data`.
+# `planet_tracks` is list of 8 empty lists for 8 different planets.
+# And `planet_actors` will contain all the planet actors.
 
-r_planets = list(set([planet_filenames[i][0] for i in planet_filenames]))
-r_planets.remove(0)         # This will remove radius of orbit of sun
+r_planets = list(set([planet_data['position']
+                      for planet_data in planets_data]))
+r_planets.remove(0)     # This will remove radius of orbit of sun
 
 planet_tracks = [[], [], [], [], [], [], [], []]
 
 planet_actors = [mercury_actor, venus_actor, earth_actor, mars_actor,
                  jupiter_actor, saturn_actor, uranus_actor, neptune_actor]
+
+##############################################################################
+# Here we are calculating and updating the path/orbit before animation starts.
 
 for r_planet, planet_track in zip(r_planets, planet_tracks):
     calculate_path(r_planet, planet_track, r_planet * 85)
@@ -197,7 +210,7 @@ def timer_callback(_obj, _event):
 
     for r_planet, planet_actor in zip(r_planets, planet_actors):
         # if the planet is saturn then we also need to update the position
-        # of its rings too.
+        # of its rings.
         if planet_actor == saturn_actor:
             pos_saturn = update_planet_position(19, saturn_actor, cnt)
             saturn_rings_actor.SetPosition(pos_saturn[0], 0, pos_saturn[1])

--- a/docs/tutorials/01_introductory/viz_solar_system.py
+++ b/docs/tutorials/01_introductory/viz_solar_system.py
@@ -183,39 +183,7 @@ def get_orbit_actor(orbit_points):
 # orbit actors into the scene. Also initialize the track variables for each
 # planet.
 
-orbit_points = np.zeros((2200, 3), dtype='f8')
-
-mercury_orbit_actor = get_orbit_actor(orbit_points)
-scene.add(mercury_orbit_actor)
-positions_mercury = utils.vertices_from_actor(mercury_orbit_actor)
-
-venus_orbit_actor = get_orbit_actor(orbit_points)
-scene.add(venus_orbit_actor)
-positions_venus = utils.vertices_from_actor(venus_orbit_actor)
-
-earth_orbit_actor = get_orbit_actor(orbit_points)
-scene.add(earth_orbit_actor)
-positions_earth = utils.vertices_from_actor(earth_orbit_actor)
-
-mars_orbit_actor = get_orbit_actor(orbit_points)
-scene.add(mars_orbit_actor)
-positions_mars = utils.vertices_from_actor(mars_orbit_actor)
-
-jupiter_orbit_actor = get_orbit_actor(orbit_points)
-scene.add(jupiter_orbit_actor)
-positions_jupiter = utils.vertices_from_actor(jupiter_orbit_actor)
-
-saturn_orbit_actor = get_orbit_actor(orbit_points)
-scene.add(saturn_orbit_actor)
-positions_saturn = utils.vertices_from_actor(saturn_orbit_actor)
-
-uranus_orbit_actor = get_orbit_actor(orbit_points)
-scene.add(uranus_orbit_actor)
-positions_uranus = utils.vertices_from_actor(uranus_orbit_actor)
-
-neptune_orbit_actor = get_orbit_actor(orbit_points)
-scene.add(neptune_orbit_actor)
-positions_neptune = utils.vertices_from_actor(neptune_orbit_actor)
+orbit_points = np.zeros((2200, 3), dtype='float')
 
 mercury_track = []
 venus_track = []
@@ -232,10 +200,9 @@ neptune_track = []
 # ``update_planet_position``.
 
 
-def update_planet_position(r_planet, planet_actor, planet_track, cnt):
+def update_planet_position(r_planet, planet_actor, cnt):
     pos_planet = get_orbital_position(r_planet, cnt)
     planet_actor.SetPosition(pos_planet[0], 0, pos_planet[1])
-    planet_track.append([pos_planet[0], 0, pos_planet[1]])
     return pos_planet
 
 
@@ -273,23 +240,23 @@ def timer_callback(_obj, _event):
     global mercury_track, venus_track, earth_track, mars_track, jupiter_track
     global saturn_track, uranus_track, neptune_track
 
-    update_planet_position(r_mercury, mercury_actor, mercury_track, cnt)
+    update_planet_position(r_mercury, mercury_actor, cnt)
 
-    update_planet_position(r_venus, venus_actor, venus_track, cnt)
+    update_planet_position(r_venus, venus_actor, cnt)
 
-    update_planet_position(r_earth, earth_actor, earth_track, cnt)
+    update_planet_position(r_earth, earth_actor, cnt)
 
-    update_planet_position(r_mars, mars_actor, mars_track, cnt)
+    update_planet_position(r_mars, mars_actor, cnt)
 
-    update_planet_position(r_jupiter, jupiter_actor, jupiter_track, cnt)
+    update_planet_position(r_jupiter, jupiter_actor, cnt)
 
-    pos_saturn = update_planet_position(r_saturn, saturn_actor, saturn_track,
-                                        cnt)
+    pos_saturn = update_planet_position(r_saturn, saturn_actor, cnt)
+
     saturn_rings_actor.SetPosition(pos_saturn[0], 0, pos_saturn[1])
 
-    update_planet_position(r_uranus, uranus_actor, uranus_track, cnt)
+    update_planet_position(r_uranus, uranus_actor, cnt)
 
-    update_planet_position(r_neptune, neptune_actor, neptune_track, cnt)
+    update_planet_position(r_neptune, neptune_actor, cnt)
 
     if cnt == 2000:
         showm.exit()

--- a/docs/tutorials/01_introductory/viz_solar_system.py
+++ b/docs/tutorials/01_introductory/viz_solar_system.py
@@ -26,16 +26,16 @@ scene = window.Scene()
 # position of the planet and rescale it. It will also add each actor to
 # the scene that has already been created.
 
-planet_filenames = {"8k_mercury.jpg" : [7, (0.4, 0.4, 0.4)],
-                    "8k_venus_surface.jpg" : [9, (0.6, 0.6, 0.6)],
+planet_filenames = {"8k_mercury.jpg": [7, (0.4, 0.4, 0.4)],
+                    "8k_venus_surface.jpg": [9, (0.6, 0.6, 0.6)],
                     "1_earth_8k.jpg": [11, (0.4, 0.4, 0.4)],
-                    "8k_mars.jpg" : [13, (0.8, 0.8, 0.8)],
-                    "jupiter.jpg" : [16, (2, 2, 2)],
-                    "8k_saturn.jpg" : [19, (2, 2, 2)],
-                    "8k_saturn_ring_alpha.png" : [19, (3, 0.5, 3)],
-                    "2k_uranus.jpg" : [22, (1, 1, 1)],
-                    "2k_neptune.jpg" : [25, (1, 1, 1)],
-                    "8k_sun.jpg" : [0, (5, 5, 5)]}
+                    "8k_mars.jpg": [13, (0.8, 0.8, 0.8)],
+                    "jupiter.jpg": [16, (2, 2, 2)],
+                    "8k_saturn.jpg": [19, (2, 2, 2)],
+                    "8k_saturn_ring_alpha.png": [19, (3, 0.5, 3)],
+                    "2k_uranus.jpg": [22, (1, 1, 1)],
+                    "2k_neptune.jpg": [25, (1, 1, 1)],
+                    "8k_sun.jpg": [0, (5, 5, 5)]}
 fetch_viz_textures()
 
 
@@ -157,13 +157,13 @@ def update_planet_position(r_planet, planet_actor, cnt):
 def calculate_path(r_planet, planet_track, cnt):
     [planet_track.append([get_orbital_position(r_planet, i)[0],
                          0, get_orbital_position(r_planet, i)[1]])
-                         for i in range(cnt)]
+     for i in range(cnt)]
 
 
 ##############################################################################
 # First we are making a list that will contain radii form `planet_filenames`.
 # `planet_tracks` is list of 8 empty list for 8 different planets.
-# and `planet_actors` will contain all the planet actor. And then we are 
+# and `planet_actors` will contain all the planet actor. And then we are
 # calculating and updating the path/orbit before animation starts.
 
 r_planets = list(set([planet_filenames[i][0] for i in planet_filenames]))

--- a/docs/tutorials/01_introductory/viz_solar_system.py
+++ b/docs/tutorials/01_introductory/viz_solar_system.py
@@ -192,10 +192,10 @@ def calculate_path(r_planet, planet_track, cnt):
 # before animation starts.
 
 r_planets = [r_mercury, r_venus, r_earth, r_mars,
-                r_jupiter, r_saturn, r_uranus, r_neptune]
+             r_jupiter, r_saturn, r_uranus, r_neptune]
 planet_tracks = [[], [], [], [], [], [], [], []]
 planet_actors = [mercury_actor, venus_actor, earth_actor, mars_actor,
-                jupiter_actor, saturn_actor, uranus_actor, neptune_actor]
+                 jupiter_actor, saturn_actor, uranus_actor, neptune_actor]
 
 for r_planet, planet_track in zip(r_planets, planet_tracks):
     calculate_path(r_planet, planet_track, r_planet * 85)

--- a/docs/tutorials/01_introductory/viz_solar_system.py
+++ b/docs/tutorials/01_introductory/viz_solar_system.py
@@ -116,16 +116,13 @@ neptune_actor.SetPosition(r_neptune, 0, 0)
 # to calculate the orbital position, so multiply these two together to create
 # a new constant, which we will call miu.
 
-# calculation of miu is as below, But for different versions of numpy the
-# value of np.power is varying there for we are taking is constant.
+g_exponent = np.float_power(10, -11)
+g_constant = 6.673*g_exponent
 
-# g_exponent = np.float_power(10, -11)
-# g_constant = 6.673*g_exponent
-# m_exponent = np.power(10, 30)
-# m_constant = 1.989*m_exponent
-# miu = m_constant*g_constant
+m_exponent = 1073741824                                    # np.power(10, 30)
+m_constant = 1.989*m_exponent
 
-miu = 0.14251342511996928
+miu = m_constant*g_constant
 
 ##############################################################################
 # Let's define two functions that will help us calculate the position of each
@@ -135,7 +132,7 @@ miu = 0.14251342511996928
 
 
 def get_orbit_period(radius):
-    return 2*np.pi * np.sqrt(np.power(radius, 3)/miu)
+    return 2 * np.pi * np.sqrt(np.power(radius, 3)/miu)
 
 
 def get_orbital_position(radius, time):
@@ -169,6 +166,7 @@ counter = itertools.count()
 # Define one new function to use in ``timer_callback`` to update the planet
 # positions ``update_planet_position``.
 
+
 def update_planet_position(r_planet, planet_actor, cnt):
     pos_planet = get_orbital_position(r_planet, cnt)
     planet_actor.SetPosition(pos_planet[0], 0, pos_planet[1])
@@ -179,6 +177,7 @@ def update_planet_position(r_planet, planet_actor, cnt):
 # ``calculate_path`` function is for calculating the path/orbit
 # of every planet.
 
+
 def calculate_path(r_planet, planet_track, cnt):
     for i in range(cnt):
         pos_planet = get_orbital_position(r_planet, i)
@@ -187,32 +186,34 @@ def calculate_path(r_planet, planet_track, cnt):
 
 ##############################################################################
 # First we are making two lists that will contain radii and track's lists.
+# `planet_tracks` is list of 8 empty list for 8 different planets.
+# and `planet_actors` will contain all the planet actor.
 # and then we are calculating and updating the path/orbit
 # before animation starts.
 
 r_planets = [r_mercury, r_venus, r_earth, r_mars,
-             r_jupiter, r_saturn, r_uranus, r_neptune]
+                r_jupiter, r_saturn, r_uranus, r_neptune]
 planet_tracks = [[], [], [], [], [], [], [], []]
 planet_actors = [mercury_actor, venus_actor, earth_actor, mars_actor,
                 jupiter_actor, saturn_actor, uranus_actor, neptune_actor]
 
-for r_planet, planets_track in zip(r_planets, planet_tracks):
-    calculate_path(r_planet, planets_track, r_planet*85)
+for r_planet, planet_track in zip(r_planets, planet_tracks):
+    calculate_path(r_planet, planet_track, r_planet * 85)
 
 ##############################################################################
 # This is for orbit visualization. We are using line actor for orbits.
 # After creating an actor we add it to the scene.
 
-for planets_track in planet_tracks:
-    orbit_actor = actor.line([planets_track], colors=(1, 1, 1), linewidth=0.1)
+for planet_track in planet_tracks:
+    orbit_actor = actor.line([planet_track], colors=(1, 1, 1), linewidth=0.1)
     scene.add(orbit_actor)
-
 
 ##############################################################################
 # Define the ``timer_callback`` function, which controls what events happen
 # at certain times, using the counter. Update the position of each planet
 # actor using ``update_planet_position,`` assigning the x and y values of
 # each planet's position with the newly calculated ones.
+
 
 def timer_callback(_obj, _event):
     cnt = next(counter)

--- a/docs/tutorials/01_introductory/viz_solar_system.py
+++ b/docs/tutorials/01_introductory/viz_solar_system.py
@@ -164,22 +164,20 @@ def update_planet_position(r_planet, planet_actor, cnt):
 # of every planet.
 
 
-def calculate_path(r_planet, planet_track, cnt):
-    [planet_track.append([get_orbital_position(r_planet, i)[0],
-                         0, get_orbital_position(r_planet, i)[1]])
-     for i in range(cnt)]
+def calculate_path(r_planet, c):
+    planet_track = [[get_orbital_position(r_planet, i)[0], 0,
+                     get_orbital_position(r_planet, i)[1]] for i in range(c)]
+    return planet_track
 
 
 ##############################################################################
 # First we are making a list that will contain radius from `planets_data`.
-# `planet_tracks` is list of 8 empty lists for 8 different planets.
+# Here we are not taking the radius of orbit/path for sun and saturn ring.
 # And `planet_actors` will contain all the planet actors.
 
-r_planets = list(set([planet_data['position']
-                      for planet_data in planets_data]))
-r_planets.remove(0)     # This will remove radius of orbit of sun
-
-planet_tracks = [[], [], [], [], [], [], [], []]
+r_planets = [p_data['position'] for p_data in planets_data
+             if 'sun' not in p_data['filename']
+             if 'saturn_ring' not in p_data['filename']]
 
 planet_actors = [mercury_actor, venus_actor, earth_actor, mars_actor,
                  jupiter_actor, saturn_actor, uranus_actor, neptune_actor]
@@ -187,8 +185,7 @@ planet_actors = [mercury_actor, venus_actor, earth_actor, mars_actor,
 ##############################################################################
 # Here we are calculating and updating the path/orbit before animation starts.
 
-for r_planet, planet_track in zip(r_planets, planet_tracks):
-    calculate_path(r_planet, planet_track, r_planet * 85)
+planet_tracks = [calculate_path(rplanet, rplanet*85) for rplanet in r_planets]
 
 ##############################################################################
 # This is for orbit visualization. We are using line actor for orbits.

--- a/docs/tutorials/01_introductory/viz_solar_system.py
+++ b/docs/tutorials/01_introductory/viz_solar_system.py
@@ -217,7 +217,7 @@ for r_planet, planets_track in zip(r_planets, planets_tracks):
 # After creating an actor we add it to the scene.
 
 for planets_track in planets_tracks:
-    orbit_actor = actor.line([planets_track], colors=(1,1,1), linewidth=0.1)
+    orbit_actor = actor.line([planets_track], colors=(1, 1, 1), linewidth=0.1)
     scene.add(orbit_actor)
 
 

--- a/docs/tutorials/01_introductory/viz_solar_system.py
+++ b/docs/tutorials/01_introductory/viz_solar_system.py
@@ -183,7 +183,7 @@ def get_orbit_actor(orbit_points):
 # orbit actors into the scene. Also initialize the track variables for each
 # planet.
 
-orbit_points = np.zeros((2100, 3), dtype='f8')
+orbit_points = np.zeros((2001, 3), dtype='f8')
 
 mercury_orbit_actor = get_orbit_actor(orbit_points)
 scene.add(mercury_orbit_actor)
@@ -239,8 +239,8 @@ def update_planet_position(r_planet, planet_actor, planet_track, cnt):
     return pos_planet
 
 
-def update_track(positions_planet, planet_track, planet_orbit_actor):
-    positions_planet[:] = np.array(planet_track)
+def update_track(positions_planet, planet_track, planet_orbit_actor, cnt):
+    positions_planet[:cnt+1] = np.array(planet_track)
     utils.update_actor(planet_orbit_actor)
 
 
@@ -276,24 +276,23 @@ def timer_callback(_obj, _event):
 
     update_planet_position(r_neptune, neptune_actor, neptune_track, cnt)
 
-    if cnt == 999:
-        update_track(positions_mercury, mercury_track, mercury_orbit_actor)
+    update_track(positions_mercury, mercury_track, mercury_orbit_actor, cnt)
 
-        update_track(positions_venus, venus_track, venus_orbit_actor)
+    update_track(positions_venus, venus_track, venus_orbit_actor, cnt)
 
-        update_track(positions_earth, earth_track, earth_orbit_actor)
+    update_track(positions_earth, earth_track, earth_orbit_actor, cnt)
 
-        update_track(positions_mars, mars_track, mars_orbit_actor)
+    update_track(positions_mars, mars_track, mars_orbit_actor, cnt)
 
-        update_track(positions_jupiter, jupiter_track, jupiter_orbit_actor)
+    update_track(positions_jupiter, jupiter_track, jupiter_orbit_actor, cnt)
 
-        update_track(positions_saturn, saturn_track, saturn_orbit_actor)
+    update_track(positions_saturn, saturn_track, saturn_orbit_actor, cnt)
 
-        update_track(positions_uranus, uranus_track, uranus_orbit_actor)
+    update_track(positions_uranus, uranus_track, uranus_orbit_actor, cnt)
 
-        update_track(positions_neptune, neptune_track, neptune_orbit_actor)
+    update_track(positions_neptune, neptune_track, neptune_orbit_actor, cnt)
 
-    if cnt == 1500:
+    if cnt == 2000:
         showm.exit()
 
 

--- a/docs/tutorials/01_introductory/viz_solar_system.py
+++ b/docs/tutorials/01_introductory/viz_solar_system.py
@@ -80,6 +80,15 @@ utils.rotate(jupiter_actor, (90, 1, 0, 0))
 # of this tutorial, planet sizes and positions will not be completely
 # accurate.
 
+r_mercury = 7
+r_venus = 9
+r_earth = 11
+r_mars = 13
+r_jupiter = 16
+r_saturn = 19
+r_uranus = 22
+r_neptune = 25
+
 sun_actor.SetScale(5, 5, 5)
 mercury_actor.SetScale(0.4, 0.4, 0.4)
 venus_actor.SetScale(0.6, 0.6, 0.6)
@@ -91,15 +100,15 @@ saturn_rings_actor.SetScale(3, 0.5, 3)
 uranus_actor.SetScale(1, 1, 1)
 neptune_actor.SetScale(1, 1, 1)
 
-mercury_actor.SetPosition(7, 0, 0)
-venus_actor.SetPosition(9, 0, 0)
-earth_actor.SetPosition(11, 0, 0)
-mars_actor.SetPosition(13, 0, 0)
-jupiter_actor.SetPosition(16, 0, 0)
-saturn_actor.SetPosition(19, 0, 0)
-saturn_rings_actor.SetPosition(19, 0, 0)
-uranus_actor.SetPosition(22, 0, 0)
-neptune_actor.SetPosition(25, 0, 0)
+mercury_actor.SetPosition(r_mercury, 0, 0)
+venus_actor.SetPosition(r_venus, 0, 0)
+earth_actor.SetPosition(r_earth, 0, 0)
+mars_actor.SetPosition(r_mars, 0, 0)
+jupiter_actor.SetPosition(r_jupiter, 0, 0)
+saturn_actor.SetPosition(r_saturn, 0, 0)
+saturn_rings_actor.SetPosition(r_saturn, 0, 0)
+uranus_actor.SetPosition(r_uranus, 0, 0)
+neptune_actor.SetPosition(r_neptune, 0, 0)
 
 ##############################################################################
 # Define the gravitational constant G, the orbital radii of each of the
@@ -115,15 +124,6 @@ neptune_actor.SetPosition(25, 0, 0)
 # m_exponent = np.power(10, 30)
 # m_constant = 1.989*m_exponent
 # miu = m_constant*g_constant
-
-r_mercury = 7
-r_venus = 9
-r_earth = 11
-r_mars = 13
-r_jupiter = 16
-r_saturn = 19
-r_uranus = 22
-r_neptune = 25
 
 miu = 0.14251342511996928
 
@@ -166,21 +166,6 @@ showm = window.ShowManager(scene,
 counter = itertools.count()
 
 ##############################################################################
-# All of the planets will have the same initial positions, so assign each of
-# those to the positions variables for each planet. These variables will be
-# updated within the ``timer_callback`` function.
-
-mercury_track = []
-venus_track = []
-earth_track = []
-mars_track = []
-jupiter_track = []
-saturn_track = []
-uranus_track = []
-neptune_track = []
-
-
-##############################################################################
 # Define one new function to use in ``timer_callback`` to update the planet
 # positions ``update_planet_position``.
 
@@ -207,17 +192,18 @@ def calculate_path(r_planet, planet_track, cnt):
 
 r_planets = [r_mercury, r_venus, r_earth, r_mars,
              r_jupiter, r_saturn, r_uranus, r_neptune]
-planets_tracks = [mercury_track, venus_track, earth_track, mars_track,
-                  jupiter_track, saturn_track, uranus_track, neptune_track]
+planet_tracks = [[], [], [], [], [], [], [], []]
+planet_actors = [mercury_actor, venus_actor, earth_actor, mars_actor,
+                jupiter_actor, saturn_actor, uranus_actor, neptune_actor]
 
-for r_planet, planets_track in zip(r_planets, planets_tracks):
+for r_planet, planets_track in zip(r_planets, planet_tracks):
     calculate_path(r_planet, planets_track, r_planet*85)
 
 ##############################################################################
 # This is for orbit visualization. We are using line actor for orbits.
 # After creating an actor we add it to the scene.
 
-for planets_track in planets_tracks:
+for planets_track in planet_tracks:
     orbit_actor = actor.line([planets_track], colors=(1, 1, 1), linewidth=0.1)
     scene.add(orbit_actor)
 
@@ -232,23 +218,12 @@ def timer_callback(_obj, _event):
     cnt = next(counter)
     showm.render()
 
-    update_planet_position(r_mercury, mercury_actor, cnt)
-
-    update_planet_position(r_venus, venus_actor, cnt)
-
-    update_planet_position(r_earth, earth_actor, cnt)
-
-    update_planet_position(r_mars, mars_actor, cnt)
-
-    update_planet_position(r_jupiter, jupiter_actor, cnt)
-
-    pos_saturn = update_planet_position(r_saturn, saturn_actor, cnt)
-
-    saturn_rings_actor.SetPosition(pos_saturn[0], 0, pos_saturn[1])
-
-    update_planet_position(r_uranus, uranus_actor, cnt)
-
-    update_planet_position(r_neptune, neptune_actor, cnt)
+    for r_planet, planet_actor in zip(r_planets, planet_actors):
+        if r_planet == r_saturn:
+            pos_saturn = update_planet_position(r_saturn, saturn_actor, cnt)
+            saturn_rings_actor.SetPosition(pos_saturn[0], 0, pos_saturn[1])
+        else:
+            update_planet_position(r_planet, planet_actor, cnt)
 
     if cnt == 2000:
         showm.exit()

--- a/docs/tutorials/01_introductory/viz_solar_system.py
+++ b/docs/tutorials/01_introductory/viz_solar_system.py
@@ -180,7 +180,7 @@ neptune_track = []
 
 
 ##############################################################################
-# Define one new functions to use in ``timer_callback`` to update the planet
+# Define one new function to use in ``timer_callback`` to update the planet
 # positions ``update_planet_position``.
 
 def update_planet_position(r_planet, planet_actor, cnt):
@@ -190,7 +190,7 @@ def update_planet_position(r_planet, planet_actor, cnt):
 
 
 ##############################################################################
-# ``claculate_path`` function is for calculating the path/orbit
+# ``calculate_path`` function is for calculating the path/orbit
 # of every planet.
 
 def calculate_path(r_planet, planet_track, cnt):

--- a/docs/tutorials/01_introductory/viz_solar_system.py
+++ b/docs/tutorials/01_introductory/viz_solar_system.py
@@ -183,7 +183,7 @@ def get_orbit_actor(orbit_points):
 # orbit actors into the scene. Also initialize the track variables for each
 # planet.
 
-orbit_points = np.zeros((2001, 3), dtype='f8')
+orbit_points = np.zeros((2200, 3), dtype='f8')
 
 mercury_orbit_actor = get_orbit_actor(orbit_points)
 scene.add(mercury_orbit_actor)
@@ -239,9 +239,42 @@ def update_planet_position(r_planet, planet_actor, planet_track, cnt):
     return pos_planet
 
 
-def update_track(positions_planet, planet_track, planet_orbit_actor, cnt):
-    positions_planet[:cnt+1] = np.array(planet_track)
+def update_track(positions_planet, planet_track, planet_orbit_actor):
+    positions_planet[:] = np.array(planet_track)
     utils.update_actor(planet_orbit_actor)
+
+def calculate_path(r_planet, planet_track, cnt):
+    pos_planet = get_orbital_position(r_planet, cnt)
+    planet_track.append([pos_planet[0], 0, pos_planet[1]])
+
+##############################################################################
+# Calculating and updating the path/orbit before animation starts
+
+for i in range(2200):
+    calculate_path(r_mercury, mercury_track, i)
+    calculate_path(r_venus, venus_track, i)
+    calculate_path(r_earth, earth_track, i)
+    calculate_path(r_mars, mars_track, i)
+    calculate_path(r_jupiter, jupiter_track, i)
+    calculate_path(r_saturn, saturn_track, i)
+    calculate_path(r_uranus, uranus_track, i)
+    calculate_path(r_neptune, neptune_track, i)
+
+update_track(positions_mercury, mercury_track, mercury_orbit_actor)
+
+update_track(positions_venus, venus_track, venus_orbit_actor)
+
+update_track(positions_earth, earth_track, earth_orbit_actor)
+
+update_track(positions_mars, mars_track, mars_orbit_actor)
+
+update_track(positions_jupiter, jupiter_track, jupiter_orbit_actor)
+
+update_track(positions_saturn, saturn_track, saturn_orbit_actor)
+
+update_track(positions_uranus, uranus_track, uranus_orbit_actor)
+
+update_track(positions_neptune, neptune_track, neptune_orbit_actor)
 
 
 ##############################################################################
@@ -275,22 +308,6 @@ def timer_callback(_obj, _event):
     update_planet_position(r_uranus, uranus_actor, uranus_track, cnt)
 
     update_planet_position(r_neptune, neptune_actor, neptune_track, cnt)
-
-    update_track(positions_mercury, mercury_track, mercury_orbit_actor, cnt)
-
-    update_track(positions_venus, venus_track, venus_orbit_actor, cnt)
-
-    update_track(positions_earth, earth_track, earth_orbit_actor, cnt)
-
-    update_track(positions_mars, mars_track, mars_orbit_actor, cnt)
-
-    update_track(positions_jupiter, jupiter_track, jupiter_orbit_actor, cnt)
-
-    update_track(positions_saturn, saturn_track, saturn_orbit_actor, cnt)
-
-    update_track(positions_uranus, uranus_track, uranus_orbit_actor, cnt)
-
-    update_track(positions_neptune, neptune_track, neptune_orbit_actor, cnt)
 
     if cnt == 2000:
         showm.exit()

--- a/docs/tutorials/01_introductory/viz_solar_system.py
+++ b/docs/tutorials/01_introductory/viz_solar_system.py
@@ -179,9 +179,7 @@ def get_orbit_actor(orbit_points):
 ##############################################################################
 # All of the planets will have the same initial positions, so assign each of
 # those to the positions variables for each planet. These variables will be
-# updated within the ``timer_callback`` function. Initialize and add the
-# orbit actors into the scene. Also initialize the track variables for each
-# planet.
+# updated within the ``timer_callback`` function. 
 
 orbit_points = np.zeros((2200, 3), dtype='float')
 
@@ -220,6 +218,10 @@ planets_tracks = [mercury_track, venus_track, earth_track, mars_track, jupiter_t
 for i in range(2200):
     for r_planet, planets_track in zip(r_planets, planets_tracks):
         calculate_path(r_planet, planets_track, i)
+
+##############################################################################
+# This is for orbit visualization, We are using line actor for orbit.
+# And then add all of those to the scene.
 
 for planets_track in planets_tracks:
     orbit_actor = actor.line([planets_track], colors=(1,1,1), linewidth=0.1)

--- a/docs/tutorials/01_introductory/viz_solar_system.py
+++ b/docs/tutorials/01_introductory/viz_solar_system.py
@@ -183,7 +183,7 @@ def get_orbit_actor(orbit_points):
 # orbit actors into the scene. Also initialize the track variables for each
 # planet.
 
-orbit_points = np.zeros((1000, 3), dtype='f8')
+orbit_points = np.zeros((2100, 3), dtype='f8')
 
 mercury_orbit_actor = get_orbit_actor(orbit_points)
 scene.add(mercury_orbit_actor)
@@ -276,7 +276,7 @@ def timer_callback(_obj, _event):
 
     update_planet_position(r_neptune, neptune_actor, neptune_track, cnt)
 
-    if cnt == 999:
+    if cnt == 2099:
         update_track(positions_mercury, mercury_track, mercury_orbit_actor)
 
         update_track(positions_venus, venus_track, venus_orbit_actor)
@@ -293,7 +293,7 @@ def timer_callback(_obj, _event):
 
         update_track(positions_neptune, neptune_track, neptune_orbit_actor)
 
-    if cnt == 1500:
+    if cnt == 3000:
         showm.exit()
 
 

--- a/docs/tutorials/01_introductory/viz_solar_system.py
+++ b/docs/tutorials/01_introductory/viz_solar_system.py
@@ -276,7 +276,7 @@ def timer_callback(_obj, _event):
 
     update_planet_position(r_neptune, neptune_actor, neptune_track, cnt)
 
-    if cnt == 2099:
+    if cnt == 999:
         update_track(positions_mercury, mercury_track, mercury_orbit_actor)
 
         update_track(positions_venus, venus_track, venus_orbit_actor)
@@ -293,7 +293,7 @@ def timer_callback(_obj, _event):
 
         update_track(positions_neptune, neptune_track, neptune_orbit_actor)
 
-    if cnt == 3000:
+    if cnt == 1500:
         showm.exit()
 
 

--- a/docs/tutorials/01_introductory/viz_solar_system.py
+++ b/docs/tutorials/01_introductory/viz_solar_system.py
@@ -163,23 +163,9 @@ showm = window.ShowManager(scene,
 counter = itertools.count()
 
 ##############################################################################
-# To track and visualize the orbital paths of the planets, we will create
-# several new variables to map each planet's orbits using ``actor.dots``.
-# It is important to define the track variable for each planet as global,
-# allowing it to be used within the ``timer_callback`` function. To do this,
-# create a function called ``get_orbit_actor``.
-
-
-def get_orbit_actor(orbit_points):
-    orbit_actor = actor.dots(orbit_points, color=(1, 1, 1),
-                             opacity=1, dot_size=1)
-    return orbit_actor
-
-
-##############################################################################
 # All of the planets will have the same initial positions, so assign each of
 # those to the positions variables for each planet. These variables will be
-# updated within the ``timer_callback`` function. 
+# updated within the ``timer_callback`` function.
 
 orbit_points = np.zeros((2200, 3), dtype='float')
 
@@ -193,10 +179,8 @@ uranus_track = []
 neptune_track = []
 
 ##############################################################################
-# Define two new functions to use in ``timer_callback`` to update the planet
-# positions and their tracks to visualize their orbit: ``update_track`` and
-# ``update_planet_position``.
-
+# Define one new functions to use in ``timer_callback`` to update the planet
+# positions ``update_planet_position``.
 
 def update_planet_position(r_planet, planet_actor, cnt):
     pos_planet = get_orbital_position(r_planet, cnt)
@@ -204,24 +188,32 @@ def update_planet_position(r_planet, planet_actor, cnt):
     return pos_planet
 
 
+##############################################################################
+# ``claculate_path`` function is for calculating the path/orbit
+# of every planet.
+
 def calculate_path(r_planet, planet_track, cnt):
-    pos_planet = get_orbital_position(r_planet, cnt)
-    planet_track.append([pos_planet[0], 0, pos_planet[1]])
+    for i in range(cnt):
+        pos_planet = get_orbital_position(r_planet, i)
+        planet_track.append([pos_planet[0], 0, pos_planet[1]])
 
 
 ##############################################################################
-# Calculating and updating the path/orbit before animation starts
+# First we are making two lists that will contain radiuses and track's lists.
+# and then we are calculating and updating the path/orbit
+# before animation starts.
 
-r_planets = [r_mercury, r_venus, r_earth, r_mars, r_jupiter, r_saturn, r_uranus, r_neptune]
-planets_tracks = [mercury_track, venus_track, earth_track, mars_track, jupiter_track, saturn_track, uranus_track, neptune_track]
+r_planets = [r_mercury, r_venus, r_earth, r_mars,
+                r_jupiter, r_saturn, r_uranus, r_neptune]
+planets_tracks = [mercury_track, venus_track, earth_track, mars_track,
+                jupiter_track, saturn_track, uranus_track, neptune_track]
 
-for i in range(2200):
-    for r_planet, planets_track in zip(r_planets, planets_tracks):
-        calculate_path(r_planet, planets_track, i)
+for r_planet, planets_track in zip(r_planets, planets_tracks):
+    calculate_path(r_planet, planets_track, 2200)
 
 ##############################################################################
-# This is for orbit visualization, We are using line actor for orbit.
-# And then add all of those to the scene.
+# This is for orbit visualization, We are using line actor for orbits.
+# After creating an actor we add it to the scene.
 
 for planets_track in planets_tracks:
     orbit_actor = actor.line([planets_track], colors=(1,1,1), linewidth=0.1)
@@ -230,17 +222,13 @@ for planets_track in planets_tracks:
 
 ##############################################################################
 # Define the ``timer_callback`` function, which controls what events happen
-# at certain times, using the counter. Redefine the position of each planet
-# actor using ``get_orbital_position,`` assigning the x and y values of
-# each planet's position with the newly calculated ones. Append each new
-# planet position to its corresponding track array.
+# at certain times, using the counter. Update the position of each planet
+# actor using ``update_planet_position,`` assigning the x and y values of
+# each planet's position with the newly calculated ones.
 
 def timer_callback(_obj, _event):
     cnt = next(counter)
     showm.render()
-
-    global mercury_track, venus_track, earth_track, mars_track, jupiter_track
-    global saturn_track, uranus_track, neptune_track
 
     update_planet_position(r_mercury, mercury_actor, cnt)
 

--- a/docs/tutorials/01_introductory/viz_solar_system.py
+++ b/docs/tutorials/01_introductory/viz_solar_system.py
@@ -132,7 +132,7 @@ miu = m_constant*g_constant
 
 
 def get_orbit_period(radius):
-    return np.sqrt(2*np.pi * np.power(radius, 3)/miu)
+    return 2*np.pi * np.sqrt(np.power(radius, 3)/miu)
 
 
 def get_orbital_position(radius, time):

--- a/docs/tutorials/01_introductory/viz_solar_system.py
+++ b/docs/tutorials/01_introductory/viz_solar_system.py
@@ -239,11 +239,6 @@ def update_planet_position(r_planet, planet_actor, planet_track, cnt):
     return pos_planet
 
 
-def update_track(positions_planet, planet_track, planet_orbit_actor):
-    positions_planet[:] = np.array(planet_track)
-    utils.update_actor(planet_orbit_actor)
-
-
 def calculate_path(r_planet, planet_track, cnt):
     pos_planet = get_orbital_position(r_planet, cnt)
     planet_track.append([pos_planet[0], 0, pos_planet[1]])
@@ -252,31 +247,16 @@ def calculate_path(r_planet, planet_track, cnt):
 ##############################################################################
 # Calculating and updating the path/orbit before animation starts
 
+r_planets = [r_mercury, r_venus, r_earth, r_mars, r_jupiter, r_saturn, r_uranus, r_neptune]
+planets_tracks = [mercury_track, venus_track, earth_track, mars_track, jupiter_track, saturn_track, uranus_track, neptune_track]
+
 for i in range(2200):
-    calculate_path(r_mercury, mercury_track, i)
-    calculate_path(r_venus, venus_track, i)
-    calculate_path(r_earth, earth_track, i)
-    calculate_path(r_mars, mars_track, i)
-    calculate_path(r_jupiter, jupiter_track, i)
-    calculate_path(r_saturn, saturn_track, i)
-    calculate_path(r_uranus, uranus_track, i)
-    calculate_path(r_neptune, neptune_track, i)
+    for r_planet, planets_track in zip(r_planets, planets_tracks):
+        calculate_path(r_planet, planets_track, i)
 
-update_track(positions_mercury, mercury_track, mercury_orbit_actor)
-
-update_track(positions_venus, venus_track, venus_orbit_actor)
-
-update_track(positions_earth, earth_track, earth_orbit_actor)
-
-update_track(positions_mars, mars_track, mars_orbit_actor)
-
-update_track(positions_jupiter, jupiter_track, jupiter_orbit_actor)
-
-update_track(positions_saturn, saturn_track, saturn_orbit_actor)
-
-update_track(positions_uranus, uranus_track, uranus_orbit_actor)
-
-update_track(positions_neptune, neptune_track, neptune_orbit_actor)
+for planets_track in planets_tracks:
+    orbit_actor = actor.line([planets_track], colors=(1,1,1), linewidth=0.1)
+    scene.add(orbit_actor)
 
 
 ##############################################################################

--- a/docs/tutorials/01_introductory/viz_solar_system.py
+++ b/docs/tutorials/01_introductory/viz_solar_system.py
@@ -178,6 +178,7 @@ saturn_track = []
 uranus_track = []
 neptune_track = []
 
+
 ##############################################################################
 # Define one new functions to use in ``timer_callback`` to update the planet
 # positions ``update_planet_position``.
@@ -204,9 +205,9 @@ def calculate_path(r_planet, planet_track, cnt):
 # before animation starts.
 
 r_planets = [r_mercury, r_venus, r_earth, r_mars,
-                r_jupiter, r_saturn, r_uranus, r_neptune]
+             r_jupiter, r_saturn, r_uranus, r_neptune]
 planets_tracks = [mercury_track, venus_track, earth_track, mars_track,
-                jupiter_track, saturn_track, uranus_track, neptune_track]
+                  jupiter_track, saturn_track, uranus_track, neptune_track]
 
 for r_planet, planets_track in zip(r_planets, planets_tracks):
     calculate_path(r_planet, planets_track, 2200)

--- a/docs/tutorials/01_introductory/viz_solar_system.py
+++ b/docs/tutorials/01_introductory/viz_solar_system.py
@@ -107,6 +107,15 @@ neptune_actor.SetPosition(25, 0, 0)
 # to calculate the orbital position, so multiply these two together to create
 # a new constant, which we will call miu.
 
+# calculation of miu is as below, But for different versions of numpy the
+# value of np.power is varying there for we are taking is constant.
+
+# g_exponent = np.float_power(10, -11)
+# g_constant = 6.673*g_exponent
+# m_exponent = np.power(10, 30)
+# m_constant = 1.989*m_exponent
+# miu = m_constant*g_constant
+
 r_mercury = 7
 r_venus = 9
 r_earth = 11
@@ -116,13 +125,7 @@ r_saturn = 19
 r_uranus = 22
 r_neptune = 25
 
-g_exponent = np.float_power(10, -11)
-g_constant = 6.673*g_exponent
-
-m_exponent = np.power(10, 30)
-m_constant = 1.989*m_exponent
-
-miu = m_constant*g_constant
+miu = 0.14251342511996928
 
 ##############################################################################
 # Let's define two functions that will help us calculate the position of each
@@ -208,7 +211,7 @@ planets_tracks = [mercury_track, venus_track, earth_track, mars_track,
                   jupiter_track, saturn_track, uranus_track, neptune_track]
 
 for r_planet, planets_track in zip(r_planets, planets_tracks):
-    calculate_path(r_planet, planets_track, 2200)
+    calculate_path(r_planet, planets_track, r_planet*85)
 
 ##############################################################################
 # This is for orbit visualization. We are using line actor for orbits.

--- a/fury/tests/test_utils.py
+++ b/fury/tests/test_utils.py
@@ -130,9 +130,9 @@ def trilinear_interp_numpy(input_array, indices):
     y_indices = indices[:, 1]
     z_indices = indices[:, 2]
 
-    x0 = x_indices.astype(np.int64)
-    y0 = y_indices.astype(np.int64)
-    z0 = z_indices.astype(np.int64)
+    x0 = x_indices.astype(int)
+    y0 = y_indices.astype(int)
+    z0 = z_indices.astype(int)
     x1 = x0 + 1
     y1 = y0 + 1
     z1 = z0 + 1

--- a/fury/tests/test_utils.py
+++ b/fury/tests/test_utils.py
@@ -130,9 +130,9 @@ def trilinear_interp_numpy(input_array, indices):
     y_indices = indices[:, 1]
     z_indices = indices[:, 2]
 
-    x0 = x_indices.astype(np.integer)
-    y0 = y_indices.astype(np.integer)
-    z0 = z_indices.astype(np.integer)
+    x0 = x_indices.astype(np.int64)
+    y0 = y_indices.astype(np.int64)
+    z0 = z_indices.astype(np.int64)
     x1 = x0 + 1
     y1 = y0 + 1
     z1 = z0 + 1

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -94,7 +94,7 @@ def numpy_to_vtk_cells(data, is_coords=True):
         connectivity + offset information
 
     """
-    data = np.array(data)
+    data = np.array(data, dtype=object)
     nb_cells = len(data)
 
     # Get lines_array in vtk input format


### PR DESCRIPTION
fixed warning in test_utils.py.

warning was: #317 

```
fury/tests/test_utils.py::test_trilinear_interp
fury/tests/test_utils.py::test_trilinear_interp
  D:\fury-master\fury\tests\test_utils.py:133: DeprecationWarning: Converting `np.integer` or `np.signedinteger` to a dtype is deprecated. The current result is `np.dtype(np.int_)` which is not strictly correct. Note that the result depends on the system. To ensure stable results use may want to use `np.int64` or `np.int32`.
    x0 = x_indices.astype(np.integer)

fury/tests/test_utils.py::test_trilinear_interp
fury/tests/test_utils.py::test_trilinear_interp
  D:\fury-master\fury\tests\test_utils.py:134: DeprecationWarning: Converting `np.integer` or `np.signedinteger` to a dtype is deprecated. The current result is `np.dtype(np.int_)` which is not strictly correct. Note that the result depends on the system. To ensure stable results use may want to use `np.int64` or `np.int32`.
    y0 = y_indices.astype(np.integer)

fury/tests/test_utils.py::test_trilinear_interp
fury/tests/test_utils.py::test_trilinear_interp
  D:\fury-master\fury\tests\test_utils.py:135: DeprecationWarning: Converting `np.integer` or `np.signedinteger` to a dtype is deprecated. The current result is `np.dtype(np.int_)` which is not strictly correct. Note that the result depends on the system. To ensure stable results use may want to use `np.int64` or `np.int32`.
    z0 = z_indices.astype(np.integer)

```



It is not much but I noticed it so I just changed it.

The equation looks like this in tutorial of solar system visualization,

![temp](https://user-images.githubusercontent.com/61907131/111508457-bb65d780-8771-11eb-97ec-866447ed586d.PNG)

link - https://en.wikipedia.org/wiki/Orbital_period

