### PR TITLE
Updating Redirecting Issues in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 - **Website and Documentation:** https://fury.gl
 - **Tutorials:** https://fury.gl/latest/auto_tutorials/index.html
 - **Demos:** https://fury.gl/latest/auto_examples/index.html
-- **Blog:**  https://fury.gl/dev/blog
+- **Blog:**  https://fury.gl/latest/blog.html
 - **Mailing list:** https://mail.python.org/mailman3/lists/fury.python.org
 - **Official source code repo:** https://github.com/fury-gl/fury.git
 - **Download releases:** https://pypi.org/project/fury/
@@ -100,7 +100,7 @@ Or as an ["editable" installation](https://pip.pypa.io/en/stable/reference/pip_i
 
 **Step 4:** Enjoy!
 
-For more information, see also [installation page on fury.gl](https://fury.gl/stable/installation.html)
+For more information, see also [installation page on fury.gl](https://fury.gl/latest/installation.html)
 
 ## Testing
 


### PR DESCRIPTION
Some links in the readme redirect to wrong links so changing them to correct links:
Blogs refer to https://fury.gl/dev/blog but the working link is https://fury.gl/latest/blog.html
Similarly, More Installation Info refers to https://fury.gl/stable/installation.html but the working link is https://fury.gl/latest/installation.html
Thank You.