### PR TITLE
Updating the Missing Parenthesis

### DIFF
--- a/.github/ISSUE_TEMPLATE/generic-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/generic-issue-template.md
@@ -18,4 +18,4 @@ assignees: ''
 [If reporting a bug, please include the following important information:]
 - [ ] Code example
 - [ ] Relevant images (if any)
-- [ ] Operating system and versions (run `python -c "from fury import get_info; print(get_info()"`)
+- [ ] Operating system and versions (run `python -c "from fury import get_info; print(get_info())"`)


### PR DESCRIPTION
For the Operating System and Version Info on Line 21, the command `print`  didn't had the closing parenthesis, so adding that as without that it throws an error while executing.