### PR TITLE
Allows fury to deal with Uniforms in shaders and change them dynamically

### DIFF
--- a/fury/shaders/__init__.py
+++ b/fury/shaders/__init__.py
@@ -2,7 +2,8 @@
 
 from os.path import join as pjoin, dirname
 from fury.shaders.base import (shader_to_actor, add_shader_callback,
-                               attribute_to_actor, replace_shader_in_actor)
+                               attribute_to_actor, replace_shader_in_actor, 
+                               Uniform, Uniforms)
 
 SHADERS_DIR = pjoin(dirname(__file__))
 
@@ -13,4 +14,5 @@ def load(filename):
 
 
 __all__ = ['SHADERS_DIR', 'load', 'shader_to_actor', 'add_shader_callback',
-           'attribute_to_actor', 'replace_shader_in_actor']
+           'attribute_to_actor', 'replace_shader_in_actor',
+           'Uniform', 'Uniforms']

--- a/fury/shaders/base.py
+++ b/fury/shaders/base.py
@@ -231,6 +231,9 @@ class Uniforms:
         """
         self.uniforms = uniforms
         for obj in self.uniforms:
+            if isinstance(obj, Uniform) is False:
+                raise ValueError(f"""{obj} it's not an Uniform object""")
+
             setattr(self, obj.name, obj)
 
     def __call__(self, _caller, _event, calldata=None,):

--- a/fury/shaders/base.py
+++ b/fury/shaders/base.py
@@ -174,20 +174,23 @@ def attribute_to_actor(actor, arr, attr_name, deep=True):
 
 class Uniform:
     def __init__(self, name, uniform_type, value):
-        """
+        """This is used for Uniforms. It's responsible to
+        store the value of a given uniform variable and call
+        the related vtk_program
+
         Parameters:
         -----------
             name: str
                 name of the uniform variable
             uniform_type: str
-                Uniform variable type to be used inside the shader.
+                Uniform variable type which will be used inside the shader.
                 Any of this are valid: 1fv, 1iv, 2f, 2fv, 2i, 3f, 3fv,
                     3uc, 4f, 4fv, 4uc, GroupUpdateTime, Matrix,
                     Matrix3x3, Matrix4x4, Matrix4x4v, f, i
                     value: float or ndarray
             value: type(uniform_type)
                 should be a value which represent's the shader uniform
-                equivalent. For example, if uniform_type is 'f' then value
+                variable. For example, if uniform_type is 'f' then value
                 should be a float; if uniform_type is '3f' then value
                 should be a 1x3 array.
         """
@@ -208,8 +211,8 @@ class Uniform:
 
     def execute_program(self, program):
         """ Given a shader program, this method
-        updates the value of a given uniform variable during
-        a draw call
+        will update the value with the associated uniform variable
+        in a draw call
 
         Parameters:
         -----------
@@ -221,13 +224,26 @@ class Uniform:
 
 class Uniforms:
     def __init__(self, uniforms):
-        """This object creates a object which can store and
+        """This  creates an object which can store and
         execute all the changes in uniforms variables associated
         with a shader.
 
         Parameters:
         -----------
             uniforms: list of Uniform's
+
+        Example
+        ```python
+        uniforms = [
+            Uniform(name='edgeWidth', uniform_type='f', value=edgeWidth)...
+        ]
+        CustomUniforms = Uniforms(markerUniforms)
+        add_shader_callback(
+                sq_actor, CustomUniforms)
+        sq_actor.CustomUniforms = CustomUniforms
+        sq_actor.CustomUniforms.edgeWidth = 0.5
+        ```
+
         """
         self.uniforms = uniforms
         for obj in self.uniforms:
@@ -238,7 +254,7 @@ class Uniforms:
 
     def __call__(self, _caller, _event, calldata=None,):
         """
-        This method should be used during as a callback of a vtk Observer
+        This method should be used as a callback for a vtk Observer
         """
         program = calldata
         if program is None:

--- a/fury/shaders/base.py
+++ b/fury/shaders/base.py
@@ -170,3 +170,54 @@ def attribute_to_actor(actor, arr, attr_name, deep=True):
     mapper = actor.GetMapper()
     mapper.MapDataArrayToVertexAttribute(
         attr_name, attr_name, vtk.vtkDataObject.FIELD_ASSOCIATION_POINTS, -1)
+
+
+class Uniform:
+    def __init__(self, name, type, value):
+        '''
+        Args:
+        -----
+            name: str
+            type: str
+            value: 
+        '''
+        self.name = name
+        self.value = value
+        self.type = type
+        self.vtk_func_uniform = ''
+        self.setType()
+
+    def setType(self, ):
+        validTypes = [
+            '1fv', '1iv', '2f', '2fv', '2i', '3f', '3fv',
+            '3uc', '4f', '4fv', '4uc', 'GroupUpdateTime', 'Matrix',
+            'Matrix3x3', 'Matrix4x4', 'Matrix4x4v', 'f', 'i']
+        if self.type not in validTypes:
+            raise ValueError(
+                f"""Uniform type {self.type} not valid. 
+                Choose one of this values: {validTypes}""")
+
+        self.vtk_func_uniform = f'SetUniform{self.type}'
+
+    def executeProgram(self, program):
+        '''
+        Args:
+        -----
+            program: vtkmodules.vtkRenderingOpenGL2.vtkShaderProgram
+        '''
+        program.__getattribute__(self.vtk_func_uniform)(
+                self.name, self.value)
+
+
+class Uniforms:
+    def __init__(self, uniforms):
+        self.uniforms = uniforms
+        for obj in self.uniforms:
+            setattr(self, obj.name, obj)
+
+    def __call__(self, _caller, _event, calldata=None,):
+        program = calldata
+        if program is None:
+            return
+        for uniform in self.uniforms:
+            uniform.executeProgram(program)

--- a/fury/shaders/base.py
+++ b/fury/shaders/base.py
@@ -174,7 +174,7 @@ def attribute_to_actor(actor, arr, attr_name, deep=True):
 
 class Uniform:
     def __init__(self, name, uniform_type, value):
-        """ 
+        """
         Parameters:
         -----------
             name: str
@@ -199,7 +199,7 @@ class Uniform:
             '1fv', '1iv', '2f', '2fv', '2i', '3f', '3fv',
             '3uc', '4f', '4fv', '4uc', 'GroupUpdateTime', 'Matrix',
             'Matrix3x3', 'Matrix4x4', 'Matrix4x4v', 'f', 'i']
-        if self.uniform_type not in self.validTypes:
+        if self.uniform_type not in self.valid_types:
             raise ValueError(
                 f"""Uniform type {self.uniform_type} not valid. 
                 Choose one of this values: {self.valid_types}""")

--- a/fury/shaders/base.py
+++ b/fury/shaders/base.py
@@ -174,43 +174,49 @@ def attribute_to_actor(actor, arr, attr_name, deep=True):
 
 class Uniform:
     def __init__(self, name, type, value):
-        '''
-        Args:
-        -----
+        """
+        Parameters:
+        -----------
             name: str
             type: str
-            value: 
-        '''
+            value: float or ndarray
+        """
         self.name = name
         self.value = value
         self.type = type
         self.vtk_func_uniform = ''
         self.setType()
 
-    def setType(self, ):
+    def setType(self):
         validTypes = [
             '1fv', '1iv', '2f', '2fv', '2i', '3f', '3fv',
             '3uc', '4f', '4fv', '4uc', 'GroupUpdateTime', 'Matrix',
             'Matrix3x3', 'Matrix4x4', 'Matrix4x4v', 'f', 'i']
         if self.type not in validTypes:
             raise ValueError(
-                f"""Uniform type {self.type} not valid. 
+                f"""Uniform type { self.type} not valid. 
                 Choose one of this values: {validTypes}""")
 
         self.vtk_func_uniform = f'SetUniform{self.type}'
 
     def executeProgram(self, program):
-        '''
-        Args:
-        -----
+        """
+        Parameters:
+        -----------
             program: vtkmodules.vtkRenderingOpenGL2.vtkShaderProgram
-        '''
+        """
         program.__getattribute__(self.vtk_func_uniform)(
                 self.name, self.value)
 
 
 class Uniforms:
     def __init__(self, uniforms):
+        """
+
+        Parameters:
+        -----------
+            uniforms: list of Uniform
+        """
         self.uniforms = uniforms
         for obj in self.uniforms:
             setattr(self, obj.name, obj)

--- a/fury/tests/test_shaders.py
+++ b/fury/tests/test_shaders.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 
 import numpy.testing as npt
 
@@ -16,3 +17,36 @@ def test_load():
     npt.assert_string_equal(fs.load(dummy_file_name), dummy_file_contents)
 
     os.remove(os.path.join(fs.SHADERS_DIR, dummy_file_name))
+
+
+def test_uniform_tools():
+    # print('\nTest: Uniform tools')
+    # print('\t...creating a Uniform obj')
+    uniform = fs.Uniform('uniform_name', 'f', 1.)
+    assert uniform.vtk_func_uniform == 'SetUniformf'
+    assert uniform.value == 1.
+
+    class Dummy_Program:
+        def SetUniformf(self, name, value):
+            """camel case because we need to simulate the
+            program used in vtk with the same attr name
+            """
+            assert name == 'uniform_name'
+            assert value == 1.
+            # print(f'\t...uniform set for {name} and value {value}')
+
+    dummy_program = Dummy_Program()
+    uniform.execute_program(dummy_program)
+
+    # print('\t...invalid uniform type should create an exception')
+    with pytest.raises(Exception):
+        fs.Uniform('uniform_name', 'invalid_type', 1.)
+
+    # print('\t...creating an Uniforms object')
+    uniforms = fs.Uniforms([uniform])
+    # print('\t...invalid uniform list  should create an exception')
+    with pytest.raises(Exception):
+        fs.Uniforms([1, '--'])
+
+    # print('\t... test __call__ method used in callback')
+    uniforms(None, None)


### PR DESCRIPTION
An uniform variable should be chosen when we have any kind
of information which act as constants, at least during the  draw call.

This commit implements the following behaviors:
1 - avoids creating an observable-vtk for each uniform variable
2 - allows the update of an uniform variable dynamically

Here it's a simple example

```python

markerUniforms = [
        Uniform(name='edgeColor', type='3f', value=edgeColor),
        Uniform(name='edgeWidth', type='f', value=edgeWidth),
        Uniform(name='edgeOpacity', type='f', value=edgeOpacity),
        Uniform(name='markerOpacity', type='f', value=markerOpacity),
    ]
CustomUniforms = Uniforms(markerUniforms)
observerId = add_shader_callback(
            sq_actor, CustomUniforms)
CustomUniforms.observerId = observerId
sq_actor.CustomUniforms = CustomUniforms

sq_actor.CustomUniforms.edgeWidth = 0.5

```