### PR TITLE
Surface actor colormap fix

### DIFF
--- a/fury/actor.py
+++ b/fury/actor.py
@@ -298,7 +298,7 @@ def surface(vertices, faces=None, colors=None, smooth=None, subdivision=3):
 
     if colors is not None:
         triangle_poly_data.GetPointData().\
-            SetScalars(numpy_support.numpy_to_vtk_colors(colors))
+            SetScalars(numpy_support.numpy_to_vtk_colors(255 * colors))
 
     if faces is None:
         tri = Delaunay(vertices[:, [0, 1]])

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -298,7 +298,7 @@ def surface(vertices, faces=None, colors=None, smooth=None, subdivision=3):
 
     if colors is not None:
         triangle_poly_data.GetPointData().\
-            SetScalars(numpy_support.numpy_to_vtk_colors(255 * colors))
+            SetScalars(numpy_to_vtk_colors(colors))
 
     if faces is None:
         tri = Delaunay(vertices[:, [0, 1]])

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -15,7 +15,7 @@ from fury.utils import (lines_to_vtk_polydata, set_input, apply_affine,
                         set_polydata_vertices, set_polydata_triangles,
                         shallow_copy, rgb_to_vtk, numpy_to_vtk_matrix,
                         repeat_sources, get_actor_from_primitive,
-                        fix_winding_order)
+                        fix_winding_order, numpy_to_vtk_colors)
 from fury.io import load_image
 from fury.actors.odf_slicer import OdfSlicerActor
 import fury.primitive as fp
@@ -298,7 +298,7 @@ def surface(vertices, faces=None, colors=None, smooth=None, subdivision=3):
 
     if colors is not None:
         triangle_poly_data.GetPointData().\
-            SetScalars(numpy_support.numpy_to_vtk(colors))
+            SetScalars(numpy_support.numpy_to_vtk_colors(colors))
 
     if faces is None:
         tri = Delaunay(vertices[:, [0, 1]])

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -271,7 +271,7 @@ def surface(vertices, faces=None, colors=None, smooth=None, subdivision=3):
             It is an optional parameter, it is computed locally if None
         colors : (N, 3) array
             Specifies the colors associated with each vertex in the
-            vertices array.
+            vertices array. Range should be 0 to 1.
             Optional parameter, if not passed, all vertices
             are colored white
         smooth : string - "loop" or "butterfly"
@@ -298,7 +298,7 @@ def surface(vertices, faces=None, colors=None, smooth=None, subdivision=3):
 
     if colors is not None:
         triangle_poly_data.GetPointData().\
-            SetScalars(numpy_to_vtk_colors(colors))
+            SetScalars(numpy_to_vtk_colors(255 * colors))
 
     if faces is None:
         tri = Delaunay(vertices[:, [0, 1]])


### PR DESCRIPTION
Hi! 
This is a fix for issue #429 .
@SunTzunami and I hopped on a call and fixed it together.

### Earlier

![](https://user-images.githubusercontent.com/65067354/116779575-aaa8c100-aa94-11eb-92a1-415d23c18ff6.png)

### Now

![Screenshot 2021-05-01 at 6 42 31 PM](https://user-images.githubusercontent.com/21289530/116783707-f4ea6c00-aaad-11eb-9961-3577d6122060.png)

I think, this is exactly how It should look...
I've also changed the documentation to include the range of the Individual color values. 
In case someone else is confused due to this.