### PR TITLE
Fine-tuning of the OpenGL state

### DIFF
--- a/docs/examples/viz_fine_tuning_gl_context.py
+++ b/docs/examples/viz_fine_tuning_gl_context.py
@@ -132,14 +132,13 @@ shader_apply_effects(
     effect=window.gl_set_additive_blending)
 
 ###############################################################################
-# It's also possible to pass a list of effects which will applied in the
-# specific order. The final opengl state it'll be just the composition of the
-# effects
+# It's also possible to pass a list of effects. The final opengl state it'll 
+# be the composition of each effect that each function has in the opengl state
 
 shader_apply_effects(
     showm, actorNoDepthTest2,
     effects=[
-        window.gl_resset_blend_func, window.gl_disable_blend,
+        window.gl_reset_blend, window.gl_disable_blend,
         window.gl_disable_depth])
 
 

--- a/docs/examples/viz_fine_tuning_gl_context.py
+++ b/docs/examples/viz_fine_tuning_gl_context.py
@@ -4,11 +4,10 @@ Fine-tuning the OpenGL state using shader callbacks
 =======================================================
 
 VTK it’s powerfully, but sometimes we need to get more control about how
-OpenGL will render the actors.  For example, enforcing that deep-test keep
-disabled during the draw call of a specific actor.  This can be useful when
-we need to fine-tuning the performance or create specific visualization
-effects in order to understand a certain data, like to enhance the
-visualization of clusters in a network.
+OpenGL will render the actors. This example shows how to change the OpenGL state
+of one or more actors. This can be useful when
+we need to create specialized visualization
+effects.
 """
 
 ###############################################################################
@@ -23,7 +22,7 @@ import itertools
 
 
 ###############################################################################
-# We just proceeds as usual: creating the actors and initializing a scene in
+# We just proceed as usual: creating the actors and initializing a scene in
 # FURY
 
 centers = np.array([
@@ -139,6 +138,8 @@ counter = itertools.count()
 def timer_callback(obj, event):
     cnt = next(counter)
     showm.render()
+    # we will rotate the visualization just to help you to see
+    # the results of each specifc opengl-state
     showm.scene.GetActiveCamera().Azimuth(1)
     if cnt == 400:
         actor_no_depth_test.GetMapper().RemoveObserver(id_observer)

--- a/docs/examples/viz_fine_tuning_gl_context.py
+++ b/docs/examples/viz_fine_tuning_gl_context.py
@@ -4,10 +4,9 @@ Fine-tuning the OpenGL state using shader callbacks
 =======================================================
 
 VTK it’s powerfully, but sometimes we need to get more control about how
-OpenGL will render the actors. This example shows how to change the OpenGL state
-of one or more actors. This can be useful when
-we need to create specialized visualization
-effects.
+OpenGL will render the actors. This example shows how to change the OpenGL
+state of one or more actors. This can be useful when we need to create 
+specialized visualization effects.
 """
 
 ###############################################################################
@@ -150,10 +149,8 @@ def timer_callback(obj, event):
         showm.exit()
 
 
-showm.add_timer_callback(True, 5, timer_callback)
-
 interactive = True
-
+showm.add_timer_callback(interactive, 5, timer_callback)
 if interactive:
     showm.start()
 

--- a/docs/examples/viz_fine_tuning_gl_context.py
+++ b/docs/examples/viz_fine_tuning_gl_context.py
@@ -25,7 +25,7 @@ import itertools
 # We just proceeds as usual: creating the actors and initializing a scene in
 # FURY
 
-centers = 1*np.array([
+centers = np.array([
     [0, 0, 0],
     [-1, 0, 0],
     [1, 0, 0]
@@ -58,6 +58,7 @@ showm = window.ShowManager(scene,
 scene.add(actors)
 scene.add(actor_normal_blending)
 scene.add(actors_no_depth_test)
+
 ###############################################################################
 # Now, we will enter in the topic of this example. First, we need to create
 # (or use one of the pre-built gl_function of FURY) to
@@ -72,7 +73,7 @@ shader_apply_effects(
 
 id_observer = shader_apply_effects(
     showm, actor_normal_blending,
-    effect=window.gl_set_normal_blending)
+    effects=window.gl_set_normal_blending)
 
 ###############################################################################
 # It's also possible to pass a list of effects. The final opengl state it'll
@@ -106,4 +107,12 @@ def timer_callback(obj, event):
 
 
 showm.add_timer_callback(True, 5, timer_callback)
-showm.start()
+
+interactive = False
+
+if interactive:
+    showm.start()
+
+window.record(
+    scene, out_path='viz_fine_tuning_gl_context.png', size=(600, 600))
+

--- a/docs/examples/viz_fine_tuning_gl_context.py
+++ b/docs/examples/viz_fine_tuning_gl_context.py
@@ -15,12 +15,10 @@ visualization of clusters in a network.
 # First, let's import some functions
 import numpy as np
 
-from fury.shaders import add_shader_callback, shader_apply_effects
+from fury.shaders import shader_apply_effects
 
 from fury import window, actor
 import itertools
-
-from functools import partial
 
 
 ###############################################################################
@@ -34,33 +32,18 @@ centers = 1*np.array([
 ])
 centers_no_depth_test = centers - np.array([[0, -1, 0]])
 centers_additive = centers_no_depth_test - np.array([[0, -1, 0]])
-centers_no_depth_test2 = centers_additive - np.array([[0, -1, 0]])
 colors = np.array([
     [1, 0, 0],
     [0, 1, 0],
     [0, 0, 1]
 ])
 
-
-use_sdf_actors = True
-if use_sdf_actors:
-    actors = actor.sdf(
-        centers, primitives='sphere', colors=colors, scales=2)
-    actors_no_depth_test = actor.sdf(
-        centers_no_depth_test, primitives='sphere', colors=colors, scales=2)
-    actors_no_depth_test2 = actor.sdf(
-        centers_no_depth_test2, primitives='sphere', colors=colors, scales=2)
-    actorAdd = actor.sdf(
-        centers_additive, primitives='sphere', colors=colors, scales=2)
-else:
-    actors = actor.sphere(
-        centers, opacity=.5, radii=.4, colors=colors)
-    actors_no_depth_test = actor.sphere(
-        centers_no_depth_test, opacity=.5, radii=.4, colors=colors)
-    actors_no_depth_test2 = actor.sphere(
-        centers_no_depth_test2, opacity=.5, radii=.4, colors=colors)
-    actorAdd = actor.sphere(
-        centers_additive, opacity=1, radii=.4, colors=colors)
+actors = actor.sphere(
+    centers, opacity=.5, radii=.4, colors=colors)
+actors_no_depth_test = actor.sphere(
+    centers_no_depth_test, opacity=.5, radii=.4, colors=colors)
+actor_add = actor.sphere(
+    centers_additive, opacity=1, radii=.4, colors=colors)
 
 renderer = window.Scene()
 scene = window.Scene()
@@ -72,70 +55,30 @@ showm = window.ShowManager(scene,
 ###############################################################################
 # All actors must be added  in the scene
 
-scene.add(actors_no_depth_test)
 scene.add(actors)
-scene.add(actorAdd)
-scene.add(actors_no_depth_test2)
+scene.add(actor_add)
+scene.add(actors_no_depth_test)
 ###############################################################################
 # Now, we will enter in the topic of this example. First, we need to create
 # (or use one of the pre-built gl_function of FURY) to
 # change the OpenGL state of a given fury window instance (showm.window).
 #
-# The function bellow it's a simple example and can be used to disable the
-# GL_DEPTH_STATE  of the opengl context used by FURY. VTK allway's change
-# this state to True before the draw call, therefore we need to set them
-# inside of a shader callback, even if you have just one actor.
-
-glState = showm.window.GetState()
-
-
-def gl_disable_depth(glState):
-    '''this functions it's allways accessible through
-    fury.window.gl_disable_depth
-    '''
-    GL_DEPTH_TEST = 2929
-    GL_BLEND = 3042
-    glState.vtkglDisable(GL_DEPTH_TEST)
-    glState.vtkglDisable(GL_BLEND)
-
-###############################################################################
-# Next, we write a standard callback function.
-
-
-def callback(
-        _caller, _event, calldata=None,
-        gl_set_func=None, glState=None):
-    program = calldata
-    if program is not None:
-        gl_set_func(glState)
-
-
-###############################################################################
-# Then we use that callback function  as argument to the add_shader_callback
-# method from FURY. The callback function will be called in every draw call
-id_observer_depth = add_shader_callback(
-        actors_no_depth_test, partial(
-            callback,
-            gl_set_func=gl_disable_depth, glState=glState))
-
-
-###############################################################################
 # Here we're using the pre-build FURY window functions which has already a
 # set of  specific behaviors to  be applied in the OpenGL context
 
-id_observer_normal = shader_apply_effects(
+shader_apply_effects(
     showm, actors,
     effect=window.gl_set_normal_blending)
 
-shader_apply_effects(
-    showm, actorAdd,
+id_add = shader_apply_effects(
+    showm, actor_add,
     effect=window.gl_set_additive_blending)
 
 ###############################################################################
 # It's also possible to pass a list of effects. The final opengl state it'll
 # be the composition of each effect that each function has in the opengl state
 shader_apply_effects(
-    showm, actors_no_depth_test2,
+    showm, actors_no_depth_test,
     effects=[
         window.gl_reset_blend, window.gl_disable_blend,
         window.gl_disable_depth])
@@ -148,13 +91,18 @@ showm.initialize()
 # window.gl_set_additive_blending(showm.window)
 counter = itertools.count()
 
+# After one hundred of steps we will remove the additive blending effect
+# from actor_add object
+
 
 def timer_callback(obj, event):
     cnt = next(counter)
     showm.render()
+    if cnt == 100:
+        actor_add.GetMapper().RemoveObserver(id_add)
     if cnt == 1000:
         showm.exit()
 
 
-showm.add_timer_callback(True, 200, timer_callback)
+showm.add_timer_callback(True, 5, timer_callback)
 showm.start()

--- a/docs/examples/viz_fine_tuning_gl_context.py
+++ b/docs/examples/viz_fine_tuning_gl_context.py
@@ -15,7 +15,7 @@ specialized visualization effects.
 import numpy as np
 
 from fury.shaders import shader_apply_effects
-
+from fury.utils import remove_observer_from_actor
 from fury import window, actor
 import itertools
 
@@ -141,7 +141,7 @@ def timer_callback(obj, event):
     # the results of each specifc opengl-state
     showm.scene.azimuth(1)
     if cnt == 400:
-        actor_no_depth_test.GetMapper().RemoveObserver(id_observer)
+        remove_observer_from_actor(actor_no_depth_test, id_observer)
         shader_apply_effects(
              showm.window, actor_no_depth_test,
              effects=window.gl_set_additive_blending)

--- a/docs/examples/viz_fine_tuning_gl_context.py
+++ b/docs/examples/viz_fine_tuning_gl_context.py
@@ -3,7 +3,7 @@
 Fine-tuning the OpenGL state using shader callbacks
 =======================================================
 
-VTK it’s powerfully, but sometimes we need to get more control about how
+Sometimes we need to get more control about how
 OpenGL will render the actors. This example shows how to change the OpenGL
 state of one or more actors. This can be useful when we need to create 
 specialized visualization effects.

--- a/docs/examples/viz_fine_tuning_gl_context.py
+++ b/docs/examples/viz_fine_tuning_gl_context.py
@@ -104,8 +104,8 @@ shader_apply_effects(
     effects=window.gl_set_normal_blending)
 
 # ###############################################################################
-# # It's also possible to pass a list of effects. The final opengl state it'll
-# # be the composition of each effect that each function has in the opengl state
+#  It's also possible use a list of effects. The final opengl state it'll
+#  be the composition of each effect that each function has in the opengl state
 
 id_observer = shader_apply_effects(
     showm.window, actor_no_depth_test,
@@ -133,7 +133,7 @@ shader_apply_effects(
 showm.initialize()
 counter = itertools.count()
 
-# After some steps we will remove no_depth_test effect
+# After some steps we will remove the no_depth_test effect
 
 
 def timer_callback(obj, event):

--- a/docs/examples/viz_fine_tuning_gl_context.py
+++ b/docs/examples/viz_fine_tuning_gl_context.py
@@ -24,6 +24,10 @@ import itertools
 from functools import partial
 
 
+###############################################################################
+# We just proceeds as usual: creating the actors and initializing a scene in
+# fury
+
 centers = 1*np.array([
     [0, 0, 0],
     [-1, 0, 0],
@@ -56,29 +60,34 @@ showm = window.ShowManager(scene,
                            order_transparent=True)
 
 ###############################################################################
-# All actors need to be added in a scene
+# All actors must be added  in a scene
 
 scene.add(actorAdd)
 scene.add(actors)
 scene.add(actorNoDeph)
 
 ###############################################################################
-# Now we will enter in the topic of this example. 
-# First we need to create (or use one of the pre-built gl_function of fury) to 
-# change the OpenGL state of a given fury window instance (showm.window). 
-# The function bellow it's a simple example and can be used to change the GL_DEPTH_STATE
-# from the opengl context of vtk. VTK allway's change this state to True before the draw
-# call, therefore we need to set them using inside a shader callback,
+# Now we will enter in the topic of this example. First, we need to create
+# (or use one of the pre-built gl_function of fury) to
+# change the OpenGL state of a given fury window instance (showm.window).
+#
+# The function bellow it's a simple example and can be used to change the
+# GL_DEPTH_STATE from the opengl context of a vtk instance. VTK allway's change
+#  this state to True before the draw call, therefore we need to set them
+# inside of a shader callback, even if you have just one actor.
 
 
 def gl_disable_depth(window):
+    '''this functions it's allways accessible through
+    fury.window.gl_disable_depth
+    '''
     GL_DEPTH_TEST = 2929
     glState = window.GetState()
     glState.vtkglDisable(GL_DEPTH_TEST)
 
 ###############################################################################
-# Next, we write a standard callback function and uses that function 
-# in the add_shader_callback method linking the actors which will be rendered with no 
+# Next, we write a standard callback function and uses that function in the
+# add_shader_callback method linking the actors which will be rendered with no
 # depth_test.
 
 
@@ -97,8 +106,8 @@ id_observer_depth = add_shader_callback(
 
 
 ###############################################################################
-# Here we're using the pre-build fury window functions which add specific 
-# behaviors to the OpenGL context 
+# Here we're using the pre-build fury window functions which add specific
+# behaviors to the OpenGL context
 
 
 id_observer_normal = add_shader_callback(

--- a/docs/examples/viz_fine_tuning_gl_context.py
+++ b/docs/examples/viz_fine_tuning_gl_context.py
@@ -31,7 +31,7 @@ centers = 1*np.array([
     [1, 0, 0]
 ])
 centers_no_depth_test = centers - np.array([[0, -1, 0]])
-centers_additive = centers_no_depth_test - np.array([[0, -1, 0]])
+centers_normal_blending = centers_no_depth_test - np.array([[0, -1, 0]])
 colors = np.array([
     [1, 0, 0],
     [0, 1, 0],
@@ -39,24 +39,24 @@ colors = np.array([
 ])
 
 actors = actor.sphere(
-    centers, opacity=.5, radii=.4, colors=colors)
+    centers, opacity=.8, radii=.4, colors=colors)
 actors_no_depth_test = actor.sphere(
-    centers_no_depth_test, opacity=.5, radii=.4, colors=colors)
-actor_add = actor.sphere(
-    centers_additive, opacity=1, radii=.4, colors=colors)
+    centers_no_depth_test, opacity=.8, radii=.4, colors=colors)
+actor_normal_blending = actor.sphere(
+    centers_normal_blending, opacity=.8, radii=.4, colors=colors)
 
 renderer = window.Scene()
 scene = window.Scene()
 
 showm = window.ShowManager(scene,
                            size=(900, 768), reset_camera=False,
-                           order_transparent=True)
+                           order_transparent=False)
 
 ###############################################################################
 # All actors must be added  in the scene
 
 scene.add(actors)
-scene.add(actor_add)
+scene.add(actor_normal_blending)
 scene.add(actors_no_depth_test)
 ###############################################################################
 # Now, we will enter in the topic of this example. First, we need to create
@@ -68,11 +68,11 @@ scene.add(actors_no_depth_test)
 
 shader_apply_effects(
     showm, actors,
-    effect=window.gl_set_normal_blending)
+    effects=[window.gl_enable_blend, window.gl_enable_depth])
 
-id_add = shader_apply_effects(
-    showm, actor_add,
-    effect=window.gl_set_additive_blending)
+id_observer = shader_apply_effects(
+    showm, actor_normal_blending,
+    effect=window.gl_set_normal_blending)
 
 ###############################################################################
 # It's also possible to pass a list of effects. The final opengl state it'll
@@ -81,7 +81,7 @@ shader_apply_effects(
     showm, actors_no_depth_test,
     effects=[
         window.gl_reset_blend, window.gl_disable_blend,
-        window.gl_disable_depth])
+        window.gl_disable_depth, window.gl_set_additive_blending])
 
 
 ###############################################################################
@@ -92,14 +92,15 @@ showm.initialize()
 counter = itertools.count()
 
 # After one hundred of steps we will remove the additive blending effect
-# from actor_add object
+# from actor_normal_blending object
 
 
 def timer_callback(obj, event):
     cnt = next(counter)
     showm.render()
+    showm.scene.GetActiveCamera().Azimuth(1)
     if cnt == 100:
-        actor_add.GetMapper().RemoveObserver(id_add)
+        actor_normal_blending.GetMapper().RemoveObserver(id_observer)
     if cnt == 1000:
         showm.exit()
 

--- a/docs/examples/viz_fine_tuning_gl_context.py
+++ b/docs/examples/viz_fine_tuning_gl_context.py
@@ -1,0 +1,131 @@
+"""
+=======================================================
+Fine-tuning of OpenGL state using shader callbacks
+=======================================================
+
+VTK it's very powerfully, but sometimes we need to get
+more control about how the things are rendered by OpenGL.
+For example, enforcing that deep-test keep disabled during
+the draw call of a specific actor. This can be usefully
+when you want to fine-tuning the performance or create
+specific visualizaton effects in order to understand a certain
+kind of data like  networks.
+"""
+
+###############################################################################
+# First, let's import some functions
+import numpy as np
+
+from fury.shaders import add_shader_callback
+
+from fury import window, actor
+import itertools
+
+from functools import partial
+
+
+centers = 1*np.array([
+    [0, 0, 0],
+    [-1, 0, 0],
+    [1, 0, 0]
+])
+centers_no_depth_test = centers - np.array([[0, -1, 0]])
+centers_additive = centers_no_depth_test - np.array([[0, -1, 0]])
+centers_mul = centers_additive - np.array([[0, -1, 0]])
+centers_sub = centers_mul - np.array([[0, -1, 0]])
+colors = np.array([
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1]
+])
+
+actors = actor.sdf(
+    centers, primitives='sphere', colors=colors, scales=2)
+actorNoDeph = actor.sdf(
+    centers_no_depth_test, primitives='sphere', colors=colors, scales=2)
+actorAdd = actor.sdf(
+    centers_additive, primitives='sphere', colors=colors, scales=2)
+
+renderer = window.Scene()
+scene = window.Scene()
+interactive = True
+
+
+showm = window.ShowManager(scene,
+                           size=(900, 768), reset_camera=False,
+                           order_transparent=True)
+
+###############################################################################
+# All actors need to be added in a scene
+
+scene.add(actorAdd)
+scene.add(actors)
+scene.add(actorNoDeph)
+
+###############################################################################
+# Now we will enter in the topic of this example. 
+# First we need to create (or use one of the pre-built gl_function of fury) to 
+# change the OpenGL state of a given fury window instance (showm.window). 
+# The function bellow it's a simple example and can be used to change the GL_DEPTH_STATE
+# from the opengl context of vtk. VTK allway's change this state to True before the draw
+# call, therefore we need to set them using inside a shader callback,
+
+
+def gl_disable_depth(window):
+    GL_DEPTH_TEST = 2929
+    glState = window.GetState()
+    glState.vtkglDisable(GL_DEPTH_TEST)
+
+###############################################################################
+# Next, we write a standard callback function and uses that function 
+# in the add_shader_callback method linking the actors which will be rendered with no 
+# depth_test.
+
+
+def callback(
+        _caller, _event, calldata=None,
+        gl_set_func=None, window_obj=None):
+    program = calldata
+    if program is not None:
+        gl_set_func(window_obj)
+
+
+id_observer_depth = add_shader_callback(
+        actorNoDeph, partial(
+            callback,
+            gl_set_func=gl_disable_depth, window_obj=showm.window))
+
+
+###############################################################################
+# Here we're using the pre-build fury window functions which add specific 
+# behaviors to the OpenGL context 
+
+
+id_observer_normal = add_shader_callback(
+        actors, partial(
+            callback, gl_set_func=window.gl_set_normal_blending,
+            window_obj=showm.window))
+
+
+id_observer_additive = add_shader_callback(
+        actorAdd, partial(
+            callback, gl_set_func=window.gl_set_additive_blending,
+            window_obj=showm.window))
+
+
+###############################################################################
+# Finaly, just render and see the results
+
+showm.initialize()
+counter = itertools.count()
+
+
+def timer_callback(obj, event):
+    cnt = next(counter)
+    showm.render()
+    if cnt == 10000:
+        showm.exit()
+
+
+showm.add_timer_callback(True, 200, timer_callback)
+showm.start()

--- a/docs/examples/viz_fine_tuning_gl_context.py
+++ b/docs/examples/viz_fine_tuning_gl_context.py
@@ -31,9 +31,6 @@ centers = np.array([
     [-.1, 0, 0],
     [.1, 0, 0]
 ])
-centers_no_depth_test = centers
-centers_normal_blending = centers_no_depth_test - np.array([[0, -.5, 0]])
-centers_add_blending = centers_normal_blending - np.array([[0, -.5, 0]])
 colors = np.array([
     [1, 0, 0],
     [0, 1, 0],
@@ -41,30 +38,47 @@ colors = np.array([
 ])
 
 actor_no_depth_test = actor.markers(
-    centers_no_depth_test,
+    centers,
     marker='s',
     colors=colors,
     marker_opacity=.5,
     scales=.2,
 )
 actor_normal_blending = actor.markers(
-    centers_normal_blending,
+    centers - np.array([[0, -.5, 0]]),
     marker='s',
     colors=colors,
     marker_opacity=.5,
     scales=.2,
 )
 actor_add_blending = actor.markers(
-    centers_add_blending,
+    centers - np.array([[0, -1, 0]]),
     marker='s',
     colors=colors,
     marker_opacity=.5,
     scales=.2,
 )
 
-renderer = window.Scene()
+actor_sub_blending = actor.markers(
+    centers - np.array([[0, -1.5, 0]]),
+    marker='s',
+    colors=colors,
+    marker_opacity=.5,
+    scales=.2,
+)
+actor_mul_blending = actor.markers(
+    centers - np.array([[0, -2, 0]]),
+    marker='s',
+    colors=colors,
+    marker_opacity=.5,
+    scales=.2,
+)
+
+
 scene = window.Scene()
 
+
+scene.background((.5, .5, .5))
 showm = window.ShowManager(scene,
                            size=(900, 768), reset_camera=False,
                            order_transparent=False)
@@ -75,7 +89,8 @@ showm = window.ShowManager(scene,
 scene.add(actor_no_depth_test)
 scene.add(actor_normal_blending)
 scene.add(actor_add_blending)
-
+scene.add(actor_sub_blending)
+scene.add(actor_mul_blending)
 ###############################################################################
 # Now, we will enter in the topic of this example. First, we need to create
 # (or use one of the pre-built gl_function of FURY) to
@@ -104,6 +119,13 @@ shader_apply_effects(
         window.gl_reset_blend,
         window.gl_enable_depth, window.gl_set_additive_blending])
 
+shader_apply_effects(
+    showm.window, actor_sub_blending,
+    effects=window.gl_set_subtractive_blending)
+
+shader_apply_effects(
+    showm.window, actor_mul_blending,
+    effects=window.gl_set_multiplicative_blending)
 
 ###############################################################################
 # Finaly, just render and see the results

--- a/docs/examples/viz_fine_tuning_gl_context.py
+++ b/docs/examples/viz_fine_tuning_gl_context.py
@@ -25,7 +25,7 @@ from functools import partial
 
 ###############################################################################
 # We just proceeds as usual: creating the actors and initializing a scene in
-# FURY 
+# FURY
 
 centers = 1*np.array([
     [0, 0, 0],
@@ -42,22 +42,22 @@ colors = np.array([
 ])
 
 
-useSDFActors = True
-if useSDFActors:
+use_sdf_actors = True
+if use_sdf_actors:
     actors = actor.sdf(
         centers, primitives='sphere', colors=colors, scales=2)
-    actorNoDepthTest = actor.sdf(
+    actors_no_depth_test = actor.sdf(
         centers_no_depth_test, primitives='sphere', colors=colors, scales=2)
-    actorNoDepthTest2 = actor.sdf(
+    actors_no_depth_test2 = actor.sdf(
         centers_no_depth_test2, primitives='sphere', colors=colors, scales=2)
     actorAdd = actor.sdf(
         centers_additive, primitives='sphere', colors=colors, scales=2)
 else:
     actors = actor.sphere(
         centers, opacity=.5, radii=.4, colors=colors)
-    actorNoDepthTest = actor.sphere(
+    actors_no_depth_test = actor.sphere(
         centers_no_depth_test, opacity=.5, radii=.4, colors=colors)
-    actorNoDepthTest2 = actor.sphere(
+    actors_no_depth_test2 = actor.sphere(
         centers_no_depth_test2, opacity=.5, radii=.4, colors=colors)
     actorAdd = actor.sphere(
         centers_additive, opacity=1, radii=.4, colors=colors)
@@ -72,10 +72,10 @@ showm = window.ShowManager(scene,
 ###############################################################################
 # All actors must be added  in the scene
 
-scene.add(actorNoDepthTest)
+scene.add(actors_no_depth_test)
 scene.add(actors)
 scene.add(actorAdd)
-scene.add(actorNoDepthTest2)
+scene.add(actors_no_depth_test2)
 ###############################################################################
 # Now, we will enter in the topic of this example. First, we need to create
 # (or use one of the pre-built gl_function of FURY) to
@@ -114,13 +114,13 @@ def callback(
 # Then we use that callback function  as argument to the add_shader_callback
 # method from FURY. The callback function will be called in every draw call
 id_observer_depth = add_shader_callback(
-        actorNoDepthTest, partial(
+        actors_no_depth_test, partial(
             callback,
             gl_set_func=gl_disable_depth, glState=glState))
 
 
 ###############################################################################
-# Here we're using the pre-build FURY window functions which has already a 
+# Here we're using the pre-build FURY window functions which has already a
 # set of  specific behaviors to  be applied in the OpenGL context
 
 id_observer_normal = shader_apply_effects(
@@ -132,11 +132,10 @@ shader_apply_effects(
     effect=window.gl_set_additive_blending)
 
 ###############################################################################
-# It's also possible to pass a list of effects. The final opengl state it'll 
+# It's also possible to pass a list of effects. The final opengl state it'll
 # be the composition of each effect that each function has in the opengl state
-
 shader_apply_effects(
-    showm, actorNoDepthTest2,
+    showm, actors_no_depth_test2,
     effects=[
         window.gl_reset_blend, window.gl_disable_blend,
         window.gl_disable_depth])

--- a/docs/examples/viz_fine_tuning_gl_context.py
+++ b/docs/examples/viz_fine_tuning_gl_context.py
@@ -139,7 +139,7 @@ def timer_callback(obj, event):
     showm.render()
     # we will rotate the visualization just to help you to see
     # the results of each specifc opengl-state
-    showm.scene.GetActiveCamera().Azimuth(1)
+    showm.scene.azimuth(1)
     if cnt == 400:
         actor_no_depth_test.GetMapper().RemoveObserver(id_observer)
         shader_apply_effects(
@@ -149,7 +149,7 @@ def timer_callback(obj, event):
         showm.exit()
 
 
-interactive = True
+interactive = False
 showm.add_timer_callback(interactive, 5, timer_callback)
 if interactive:
     showm.start()

--- a/docs/examples/viz_fine_tuning_gl_context.py
+++ b/docs/examples/viz_fine_tuning_gl_context.py
@@ -81,8 +81,10 @@ def gl_disable_depth(window):
     fury.window.gl_disable_depth
     '''
     GL_DEPTH_TEST = 2929
+    GL_BLEND = 3042
     glState = window.GetState()
     glState.vtkglDisable(GL_DEPTH_TEST)
+    glState.vtkglDisable(GL_BLEND)
 
 ###############################################################################
 # Next, we write a standard callback function.
@@ -97,7 +99,7 @@ def callback(
 
 
 ###############################################################################
-# Then we use that callback function  as argument to the add_shader_callback 
+# Then we use that callback function  as argument to the add_shader_callback
 # method from FURY. The callback function will be called in every draw call
 id_observer_depth = add_shader_callback(
         actorNoDepthTest, partial(

--- a/docs/examples/viz_fine_tuning_gl_context.py
+++ b/docs/examples/viz_fine_tuning_gl_context.py
@@ -1,15 +1,14 @@
 """
 =======================================================
-Fine-tuning of OpenGL state using shader callbacks
+Fine-tuning the OpenGL state using shader callbacks
 =======================================================
 
-VTK it's very powerfully, but sometimes we need to get
-more control about how the things are rendered by OpenGL.
-For example, enforcing that deep-test keep disabled during
-the draw call of a specific actor. This can be usefully
-when you want to fine-tuning the performance or create
-specific visualizaton effects in order to understand a certain
-kind of data like  networks.
+VTK it’s powerfully, but sometimes we need to get more control about how
+OpenGL will render the actors.  For example, enforcing that deep-test keep
+disabled during the draw call of a specific actor.  This can be useful when
+we need to fine-tuning the performance or create specific visualization
+effects in order to understand a certain data, like to enhance the
+visualization of clusters in a network.
 """
 
 ###############################################################################
@@ -26,7 +25,7 @@ from functools import partial
 
 ###############################################################################
 # We just proceeds as usual: creating the actors and initializing a scene in
-# fury
+# FURY 
 
 centers = 1*np.array([
     [0, 0, 0],
@@ -45,7 +44,7 @@ colors = np.array([
 
 actors = actor.sdf(
     centers, primitives='sphere', colors=colors, scales=2)
-actorNoDeph = actor.sdf(
+actorNoDepthTest = actor.sdf(
     centers_no_depth_test, primitives='sphere', colors=colors, scales=2)
 actorAdd = actor.sdf(
     centers_additive, primitives='sphere', colors=colors, scales=2)
@@ -60,20 +59,20 @@ showm = window.ShowManager(scene,
                            order_transparent=True)
 
 ###############################################################################
-# All actors must be added  in a scene
+# All actors must be added  in the scene
 
 scene.add(actorAdd)
 scene.add(actors)
-scene.add(actorNoDeph)
+scene.add(actorNoDepthTest)
 
 ###############################################################################
-# Now we will enter in the topic of this example. First, we need to create
-# (or use one of the pre-built gl_function of fury) to
+# Now, we will enter in the topic of this example. First, we need to create
+# (or use one of the pre-built gl_function of FURY) to
 # change the OpenGL state of a given fury window instance (showm.window).
 #
-# The function bellow it's a simple example and can be used to change the
-# GL_DEPTH_STATE from the opengl context of a vtk instance. VTK allway's change
-#  this state to True before the draw call, therefore we need to set them
+# The function bellow it's a simple example and can be used to disable the
+# GL_DEPTH_STATE  of the opengl context used by FURY. VTK allway's change
+# this state to True before the draw call, therefore we need to set them
 # inside of a shader callback, even if you have just one actor.
 
 
@@ -86,9 +85,7 @@ def gl_disable_depth(window):
     glState.vtkglDisable(GL_DEPTH_TEST)
 
 ###############################################################################
-# Next, we write a standard callback function and uses that function in the
-# add_shader_callback method linking the actors which will be rendered with no
-# depth_test.
+# Next, we write a standard callback function.
 
 
 def callback(
@@ -99,16 +96,18 @@ def callback(
         gl_set_func(window_obj)
 
 
+###############################################################################
+# Then we use that callback function  as argument to the add_shader_callback 
+# method from FURY. The callback function will be called in every draw call
 id_observer_depth = add_shader_callback(
-        actorNoDeph, partial(
+        actorNoDepthTest, partial(
             callback,
             gl_set_func=gl_disable_depth, window_obj=showm.window))
 
 
 ###############################################################################
-# Here we're using the pre-build fury window functions which add specific
+# Here we're using the pre-build FURY window functions which add specific
 # behaviors to the OpenGL context
-
 
 id_observer_normal = add_shader_callback(
         actors, partial(

--- a/fury/shaders/__init__.py
+++ b/fury/shaders/__init__.py
@@ -2,7 +2,8 @@
 
 from os.path import join as pjoin, dirname
 from fury.shaders.base import (shader_to_actor, add_shader_callback,
-                               attribute_to_actor, replace_shader_in_actor)
+                               attribute_to_actor, replace_shader_in_actor,
+                               shader_apply_effects)
 
 SHADERS_DIR = pjoin(dirname(__file__))
 
@@ -13,4 +14,5 @@ def load(filename):
 
 
 __all__ = ['SHADERS_DIR', 'load', 'shader_to_actor', 'add_shader_callback',
-           'attribute_to_actor', 'replace_shader_in_actor']
+           'attribute_to_actor', 'replace_shader_in_actor',
+           'shader_apply_effects']

--- a/fury/shaders/base.py
+++ b/fury/shaders/base.py
@@ -206,7 +206,7 @@ def shader_apply_effects(
     """This applies a specific opengl state (effect) or a list of effects just
     before the actor's shader be executed.
 
-    Arguments:
+    Parameters
     ----------
         showm: fury.window.ShowManager
         actor: vtk actor
@@ -218,8 +218,8 @@ def shader_apply_effects(
             Effects with a higher priority are applied first and
             can be override by the others.
 
-    Returns:
-    --------
+    Returns
+    -------
         id_observer : int
             An unsigned Int tag which can be used later to remove the event
             or retrieve the vtkCommand used in the observer.

--- a/fury/shaders/base.py
+++ b/fury/shaders/base.py
@@ -25,21 +25,21 @@ SHADERS_BLOCK = {
 # See [1] for a more extensive list of OpenGL constants
 # [1] https://docs.factorcode.org/content/vocab-opengl.gl.html
 GL_NUMBERS = {
-    "GL_SRC_ALPHA": 769,
-    "GL_ONE": 0,
-    "GL_ZERO": -1,
-    "GL_BLEND": 3041,
-    "GL_ONE_MINUS_SRC_ALPHA": 770,
-    "GL_SRC_ALPHA": 769,
-    "GL_DEPTH_TEST": 2928,
-    "GL_DST_COLOR": 773,
-    "GL_FUNC_SUBTRACT": 3276,
-    "GL_CULL_FACE": 2883,
-    "GL_ALPHA_TEST": 3007,
-    "GL_CW": 2303,
-    "GL_CCW": 2304,
-    "GL_ONE_MINUS_SRC_COLOR": 768,
-    "GL_SRC_COLOR": 767
+    "GL_SRC_ALPHA": 770,
+    "GL_ONE": 1,
+    "GL_ZERO": 0,
+    "GL_BLEND": 3042,
+    "GL_ONE_MINUS_SRC_ALPHA": 771,
+    "GL_SRC_ALPHA": 770,
+    "GL_DEPTH_TEST": 2929,
+    "GL_DST_COLOR": 774,
+    "GL_FUNC_SUBTRACT": 3277,
+    "GL_CULL_FACE": 2884,
+    "GL_ALPHA_TEST": 3008,
+    "GL_CW": 2304,
+    "GL_CCW": 2305,
+    "GL_ONE_MINUS_SRC_COLOR": 769,
+    "GL_SRC_COLOR": 768
 }
 
 
@@ -222,13 +222,13 @@ def add_shader_callback(actor, callback, priority=0.):
 
 
 def shader_apply_effects(
-        showm, actor, effects=None, priority=0):
+        window, actor, effects, priority=0):
     """This applies a specific opengl state (effect) or a list of effects just
     before the actor's shader be executed.
 
     Parameters
     ----------
-    showm : fury.window.ShowManager
+    window : vtk.vtkRenderWindow
     actor : vtk actor
     effects : a function or a list of functions
     priority : float, optional
@@ -249,16 +249,17 @@ def shader_apply_effects(
 
     def callback(
             _caller, _event, calldata=None,
-            effects=None, showm=None):
+            effects=None, window=None):
         program = calldata
+        glState = window.GetState()
         if program is not None:
             for func in effects:
-                func(showm)
+                func(glState)
 
     id_observer = add_shader_callback(
         actor, partial(
             callback,
-            effects=effects, showm=showm), priority)
+            effects=effects, window=window), priority)
 
     return id_observer
 

--- a/fury/shaders/base.py
+++ b/fury/shaders/base.py
@@ -222,7 +222,7 @@ def add_shader_callback(actor, callback, priority=0.):
 
 
 def shader_apply_effects(
-        showm, actor, effect=None, effects=None, priority=0):
+        showm, actor, effects=None, priority=0):
     """This applies a specific opengl state (effect) or a list of effects just
     before the actor's shader be executed.
 
@@ -230,9 +230,7 @@ def shader_apply_effects(
     ----------
     showm : fury.window.ShowManager
     actor : vtk actor
-    effect :  function
-        a function with a glState as argument
-    effects : a list of functions, optional
+    effects : a function or a list of functions
     priority : float, optional
         Related with the shader callback command.
         Effects with a higher priority are applied first and
@@ -246,12 +244,12 @@ def shader_apply_effects(
         See more at: https://vtk.org/doc/nightly/html/classvtkObject.html
 
     """
-    if effects is None:
-        effects = [effect]
+    if not isinstance(effects, list):
+        effects = [effects]
 
     def callback(
             _caller, _event, calldata=None,
-            effects=[], showm=None):
+            effects=None, showm=None):
         program = calldata
         if program is not None:
             for func in effects:

--- a/fury/shaders/base.py
+++ b/fury/shaders/base.py
@@ -224,7 +224,7 @@ def add_shader_callback(actor, callback, priority=0.):
 def shader_apply_effects(
         window, actor, effects, priority=0):
     """This applies a specific opengl state (effect) or a list of effects just
-    before the actor's shader be executed.
+    before the actor's shader is executed.
 
     Parameters
     ----------

--- a/fury/shaders/base.py
+++ b/fury/shaders/base.py
@@ -229,7 +229,8 @@ def shader_apply_effects(
     Parameters
     ----------
     window : vtk.vtkRenderWindow
-    actor : vtk actor
+        For example, this is provided by the ShowManager.window attribute.
+    actor : actor
     effects : a function or a list of functions
     priority : float, optional
         Related with the shader callback command.

--- a/fury/shaders/base.py
+++ b/fury/shaders/base.py
@@ -22,6 +22,26 @@ SHADERS_BLOCK = {
     "output": "//VTK::Output",  # only for geometry shader
 }
 
+# See [1] for a more extensive list of OpenGL constants
+# [1] https://docs.factorcode.org/content/vocab-opengl.gl.html
+GL_NUMBERS = {
+    "GL_SRC_ALPHA": 769,
+    "GL_ONE": 0,
+    "GL_ZERO": -1,
+    "GL_BLEND": 3041,
+    "GL_ONE_MINUS_SRC_ALPHA": 770,
+    "GL_SRC_ALPHA": 769,
+    "GL_DEPTH_TEST": 2928,
+    "GL_DST_COLOR": 773,
+    "GL_FUNC_SUBTRACT": 3276,
+    "GL_CULL_FACE": 2883,
+    "GL_ALPHA_TEST": 3007,
+    "GL_CW": 2303,
+    "GL_CCW": 2304,
+    "GL_ONE_MINUS_SRC_COLOR": 768,
+    "GL_SRC_COLOR": 767
+}
+
 
 def shader_to_actor(actor, shader_type, impl_code="", decl_code="",
                     block="valuepass", keep_default=True,

--- a/fury/shaders/base.py
+++ b/fury/shaders/base.py
@@ -208,22 +208,22 @@ def shader_apply_effects(
 
     Parameters
     ----------
-        showm: fury.window.ShowManager
-        actor: vtk actor
-        effect:  function
-            a function with a glState as argument
-        effects: a list of functions, optional
-        priority: float, optional
-            Related with the shader callback command.
-            Effects with a higher priority are applied first and
-            can be override by the others.
+    showm : fury.window.ShowManager
+    actor : vtk actor
+    effect :  function
+        a function with a glState as argument
+    effects : a list of functions, optional
+    priority : float, optional
+        Related with the shader callback command.
+        Effects with a higher priority are applied first and
+        can be override by the others.
 
     Returns
     -------
-        id_observer : int
-            An unsigned Int tag which can be used later to remove the event
-            or retrieve the vtkCommand used in the observer.
-            See more at: https://vtk.org/doc/nightly/html/classvtkObject.html
+    id_observer : int
+        An unsigned Int tag which can be used later to remove the event
+        or retrieve the vtkCommand used in the observer.
+        See more at: https://vtk.org/doc/nightly/html/classvtkObject.html
 
     """
     if effects is None:

--- a/fury/shaders/base.py
+++ b/fury/shaders/base.py
@@ -201,14 +201,16 @@ def add_shader_callback(actor, callback, priority=0.):
     return id_observer
 
 
-def shader_apply_effects(glState, actor, effect=None, effects=None, priority=0):
-    """
+def shader_apply_effects(
+        showm, actor, effect=None, effects=None, priority=0):
+    """This applies a specific opengl state (effect) or a list of effects just
+    before the actor's shader be executed.
 
     Arguments:
     ----------
-        glState:
+        showm: fury.window.ShowManager
         actor: vtk actor
-        effect:  funtion
+        effect:  function
             a function with a glState as argument
         effects: a list of functions, optional
         priority: float, optional
@@ -229,16 +231,16 @@ def shader_apply_effects(glState, actor, effect=None, effects=None, priority=0):
 
     def callback(
             _caller, _event, calldata=None,
-            effects=[], glState=None):
+            effects=[], showm=None):
         program = calldata
         if program is not None:
             for func in effects:
-                func(glState)
+                func(showm)
 
     id_observer = add_shader_callback(
         actor, partial(
             callback,
-            effects=effects, glState=glState), priority)
+            effects=effects, showm=showm), priority)
 
     return id_observer
 

--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -1,3 +1,4 @@
+from fury.utils import remove_observer_from_actor
 import os
 import warnings
 from tempfile import TemporaryDirectory as InTemporaryDirectory
@@ -421,7 +422,7 @@ def test_opengl_state_add_remove_and_check():
     after_depth_test = state['GL_DEPTH_TEST']
     npt.assert_equal(after_depth_test, False)
     # removes the no_depth_test effect
-    actor_no_depth_test.GetMapper().RemoveObserver(id_observer)
+    remove_observer_from_actor(actor_no_depth_test, id_observer)
     showm.render()
     state = window.gl_get_current_state(showm.window.GetState())
     after_remove_depth_test_observer = state['GL_DEPTH_TEST']

--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -408,7 +408,7 @@ def test_opengl_state_add_remove_and_check():
     showm.render()
     state = window.gl_get_current_state(showm.window.GetState())
     before_depth_test = state['GL_DEPTH_TEST']
-    assert before_depth_test
+    npt.assert_equal(before_depth_test, True)
     id_observer = shaders.shader_apply_effects(
         showm.window, actor_no_depth_test,
         effects=[
@@ -418,10 +418,10 @@ def test_opengl_state_add_remove_and_check():
     showm.render()
     state = window.gl_get_current_state(showm.window.GetState())
     after_depth_test = state['GL_DEPTH_TEST']
-    assert after_depth_test is False
+    npt.assert_equal(after_depth_test, False)
     # removes the no_depth_test effect
     actor_no_depth_test.GetMapper().RemoveObserver(id_observer)
     showm.render()
     state = window.gl_get_current_state(showm.window.GetState())
     after_remove_depth_test_observer = state['GL_DEPTH_TEST']
-    assert after_remove_depth_test_observer
+    npt.assert_equal(after_remove_depth_test_observer, True)

--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -417,6 +417,7 @@ def test_opengl_state_add_remove_and_check():
 
     showm.render()
     state = window.gl_get_current_state(showm.window.GetState())
+    print('type', type(showm.window.GetState()))
     after_depth_test = state['GL_DEPTH_TEST']
     npt.assert_equal(after_depth_test, False)
     # removes the no_depth_test effect

--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -419,6 +419,56 @@ def test_opengl_state():
     shaders.shader_apply_effects(
         showm.window, actor_mul_blending,
         effects=window.gl_set_multiplicative_blending)
-
+    showm.render()
     # removes the no_depth_test effect
     actor_no_depth_test.GetMapper().RemoveObserver(id_observer)
+    showm.render()
+
+
+def test_opengl_state_check():
+    scene = window.Scene()
+    centers = np.array([
+        [0, 0, 0],
+        [-.1, 0, 0],
+        [.1, 0, 0]
+    ])
+    colors = np.array([
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 1]
+    ])
+
+    actor_no_depth_test = actor.markers(
+        centers,
+        marker='s',
+        colors=colors,
+        marker_opacity=.5,
+        scales=.2,
+    )
+    showm = window.ShowManager(
+        scene,
+        size=(900, 768), reset_camera=False,
+        order_transparent=False)
+
+    scene.add(actor_no_depth_test)
+
+    showm.render()
+    state = window.gl_get_current_state(showm.window.GetState())
+    before_depth_test = state['GL_DEPTH_TEST']
+    assert before_depth_test
+    id_observer = shaders.shader_apply_effects(
+        showm.window, actor_no_depth_test,
+        effects=[
+            window.gl_reset_blend, window.gl_disable_blend,
+            window.gl_disable_depth])
+
+    showm.render()
+    state = window.gl_get_current_state(showm.window.GetState())
+    after_depth_test = state['GL_DEPTH_TEST']
+    assert after_depth_test is False
+    # removes the no_depth_test effect
+    actor_no_depth_test.GetMapper().RemoveObserver(id_observer)
+    showm.render()
+    state = window.gl_get_current_state(showm.window.GetState())
+    after_remove_depth_test_observer = state['GL_DEPTH_TEST']
+    assert after_remove_depth_test_observer

--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -335,97 +335,50 @@ def test_record():
             assert_less_equal(arr.shape[1], 5000)
 
 
-def test_opengl_state():
-    scene = window.Scene()
-    centers = np.array([
-        [0, 0, 0],
-        [-.1, 0, 0],
-        [.1, 0, 0]
-    ])
-    colors = np.array([
-        [1, 0, 0],
-        [0, 1, 0],
-        [0, 0, 1]
-    ])
+def test_opengl_state_simple():
+    for gl_state in [
+        window.gl_reset_blend, window.gl_enable_depth,
+        window.gl_disable_depth, window.gl_enable_blend,
+        window.gl_disable_blend,
+        window.gl_set_additive_blending,
+        window.gl_set_normal_blending,
+        window.gl_set_multiplicative_blending,
+        window.gl_set_subtractive_blending,
+        window.gl_set_additive_blending_white_background
+    ]:
+        scene = window.Scene()
+        centers = np.array([
+            [0, 0, 0],
+            [-.1, 0, 0],
+            [.1, 0, 0]
+        ])
+        colors = np.array([
+            [1, 0, 0],
+            [0, 1, 0],
+            [0, 0, 1]
+        ])
 
-    actor_no_depth_test = actor.markers(
-        centers,
-        marker='s',
-        colors=colors,
-        marker_opacity=.5,
-        scales=.2,
-    )
-    actor_normal_blending = actor.markers(
-        centers - np.array([[0, -.5, 0]]),
-        marker='s',
-        colors=colors,
-        marker_opacity=.5,
-        scales=.2,
-    )
-    actor_add_blending = actor.markers(
-        centers - np.array([[0, -1, 0]]),
-        marker='s',
-        colors=colors,
-        marker_opacity=.5,
-        scales=.2,
-    )
+        actors = actor.markers(
+            centers,
+            marker='s',
+            colors=colors,
+            marker_opacity=.5,
+            scales=.2,
+        )
+        showm = window.ShowManager(
+            scene,
+            size=(900, 768), reset_camera=False,
+            order_transparent=False)
 
-    actor_sub_blending = actor.markers(
-        centers - np.array([[0, -1.5, 0]]),
-        marker='s',
-        colors=colors,
-        marker_opacity=.5,
-        scales=.2,
-    )
-    actor_mul_blending = actor.markers(
-        centers - np.array([[0, -2, 0]]),
-        marker='s',
-        colors=colors,
-        marker_opacity=.5,
-        scales=.2,
-    )
-    showm = window.ShowManager(
-        scene,
-        size=(900, 768), reset_camera=False,
-        order_transparent=False)
-
-    scene.add(actor_no_depth_test)
-    scene.add(actor_normal_blending)
-    scene.add(actor_add_blending)
-    scene.add(actor_sub_blending)
-    scene.add(actor_mul_blending)
-    # single effect
-    shaders.shader_apply_effects(
-        showm.window, actor_normal_blending,
-        effects=window.gl_set_normal_blending)
-
-    # list of effects
-    id_observer = shaders.shader_apply_effects(
-        showm.window, actor_no_depth_test,
-        effects=[
-            window.gl_reset_blend, window.gl_disable_blend,
-            window.gl_disable_depth])
-
-    shaders.shader_apply_effects(
-        showm.window, actor_add_blending,
-        effects=[
-            window.gl_reset_blend,
-            window.gl_enable_depth, window.gl_set_additive_blending])
-
-    shaders.shader_apply_effects(
-        showm.window, actor_sub_blending,
-        effects=window.gl_set_subtractive_blending)
-
-    shaders.shader_apply_effects(
-        showm.window, actor_mul_blending,
-        effects=window.gl_set_multiplicative_blending)
-    showm.render()
-    # removes the no_depth_test effect
-    actor_no_depth_test.GetMapper().RemoveObserver(id_observer)
-    showm.render()
+        scene.add(actors)
+        # single effect
+        shaders.shader_apply_effects(
+            showm.window, actors,
+            effects=gl_state)
+        showm.render()
 
 
-def test_opengl_state_check():
+def test_opengl_state_add_remove_and_check():
     scene = window.Scene()
     centers = np.array([
         [0, 0, 0],

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -5,6 +5,25 @@ from scipy.ndimage import map_coordinates
 from fury.colormap import line_colors
 
 
+def remove_observer_from_actor(actor, id):
+    """Remove the observer with the given id from the actor.
+
+    Parameters
+    ----------
+    actor : vtkActor
+    id : int
+        id of the observer to remove
+
+    """
+    if not hasattr(actor, "GetMapper"):
+        raise ValueError("Invalid actor")
+
+    mapper = actor.GetMapper()
+    if not hasattr(mapper, "RemoveObserver"):
+        raise ValueError("Invalid mapper")
+    mapper.RemoveObserver(id)
+
+
 def set_input(vtk_object, inp):
     """Set Generic input function which takes into account VTK 5 or 6.
 

--- a/fury/window.py
+++ b/fury/window.py
@@ -15,7 +15,7 @@ from fury.decorators import is_osx
 from fury.interactor import CustomInteractorStyle
 from fury.io import load_image, save_image
 from fury.utils import asbytes
-
+from fury.shaders.base import GL_NUMBERS as _GL
 try:
     basestring
 except NameError:
@@ -1008,28 +1008,6 @@ def enable_stereo(renwin, stereo_type):
         stereo_type = 'horizontal'
 
     renwin.SetStereoType(stereo_type_dictionary[stereo_type])
-
-# See [1] for a more extensive list of OpenGL constants
-# [1] https://docs.factorcode.org/content/vocab-opengl.gl.html
-
-
-_GL = {
-    "GL_SRC_ALPHA": 770,
-    "GL_ONE": 1,
-    "GL_ZERO": 0,
-    "GL_BLEND": 3042,
-    "GL_ONE_MINUS_SRC_ALPHA": 771,
-    "GL_SRC_ALPHA": 770,
-    "GL_DEPTH_TEST": 2929,
-    "GL_DST_COLOR": 774,
-    "GL_FUNC_SUBTRACT": 3277,
-    "GL_CULL_FACE": 2884,
-    "GL_ALPHA_TEST": 3008,
-    "GL_CW": 2304,
-    "GL_CCW": 2305,
-    "GL_ONE_MINUS_SRC_COLOR": 769,
-    "GL_SRC_COLOR": 768
-}
 
 
 def test_and_extract_gl_state(func):

--- a/fury/window.py
+++ b/fury/window.py
@@ -1056,7 +1056,8 @@ def gl_disable_blend(glState):
     See more
     --------
     [1] https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFrontFace.xhtml
-    """ # noqa
+    """  # noqa
+
     glState.vtkglDisable(_GL['GL_CULL_FACE'])
     glState.vtkglDisable(_GL['GL_BLEND'])
 

--- a/fury/window.py
+++ b/fury/window.py
@@ -1032,9 +1032,10 @@ def gl_get_current_state(window):
         print(f'{glName}: {glState.GetEnumState(glNumber)}')
 
 
-def gl_apply_all_opaque(window):
-    '''This it will disable any gl behavior which has no 
-    function for opaque objects. The aim it's to increasse the performance
+def gl_set_opaque(window):
+    '''This it will disable any gl behavior which has no
+    function for opaque objects. This has the benefit of
+    speeding up the rendering of the image.
 
     See more
     --------
@@ -1045,3 +1046,56 @@ def gl_apply_all_opaque(window):
     glState.vtkglDisable(_GL['GL_BLEND'])
     glState.vtkglDisable(_GL['GL_DEPTH_TEST'])
 
+
+def gl_set_additive_blending(window, dark_background=False):
+    glState = window.GetState()
+    glState.vtkglEnable(_GL['GL_CULL_FACE'])
+    glState.vtkglEnable(_GL['GL_BLEND'])
+    glState.vtkglEnable(_GL['GL_DEPTH_TEST'])
+    glState.ResetGLBlendEquationState()
+    glState.ResetGLBlendFuncState()
+
+    if dark_background:
+        glState.vtkglBlendFunc(_GL['GL_SRC_ALPHA'], _GL['GL_ONE'])
+    else:
+        # glState.vtkglBlendFuncSeparate(
+        #     _GL['GL_SRC_ALPHA'], _GL['GL_ONE_MINUS_SRC_ALPHA'],
+        #     _GL['GL_ONE'],  _GL['GL_ZERO'])
+        glState.vtkglBlendFuncSeparate(
+            _GL['GL_SRC_ALPHA'], _GL['GL_ONE_MINUS_SRC_ALPHA'],
+            _GL['GL_ZERO'], _GL['GL_ONE'])
+
+
+def gl_set_multiplicative_blending(window, dark_background=False):
+    glState = window.GetState()
+    glState.vtkglEnable(_GL['GL_CULL_FACE'])
+    glState.vtkglEnable(_GL['GL_BLEND'])
+    glState.vtkglEnable(_GL['GL_DEPTH_TEST'])
+    glState.ResetGLBlendEquationState()
+    glState.ResetGLBlendFuncState()
+    glState.vtkglBlendFunc(_GL['GL_DST_COLOR'], _GL['GL_ZERO'])
+
+
+def gl_set_subtractive_blending(window, dark_background=False):
+    glState = window.GetState()
+    glState.vtkglEnable(_GL['GL_CULL_FACE'])
+    glState.vtkglEnable(_GL['GL_BLEND'])
+    glState.vtkglEnable(_GL['GL_DEPTH_TEST'])
+    glState.ResetGLBlendEquationState()
+    glState.ResetGLBlendFuncState()
+    glState.vtkglBlendEquation(_GL['GL_FUNC_SUBTRACT'])
+    glState.vtkglBlendFunc(_GL['GL_ONE'], _GL['GL_ONE'])
+
+
+def gl_set_normal_blending(window, dark_background=False):
+    glState = window.GetState()
+    glState.vtkglEnable(_GL['GL_CULL_FACE'])
+    glState.vtkglEnable(_GL['GL_BLEND'])
+    glState.vtkglEnable(_GL['GL_DEPTH_TEST'])
+    glState.ResetGLBlendEquationState()
+    glState.ResetGLBlendFuncState()
+    glState.vtkglBlendEquation(_GL['GL_FUNC_SUBTRACT'])
+    glState.vtkglBlendFunc(_GL['GL_ONE'], _GL['GL_ONE'])
+    glState.vtkglBlendFuncSeparate(
+                _GL['GL_SRC_ALPHA'], _GL['GL_ONE_MINUS_SRC_ALPHA'],
+                _GL['GL_ONE'], _GL['GL_ONE_MINUS_SRC_ALPHA'])

--- a/fury/window.py
+++ b/fury/window.py
@@ -1011,15 +1011,37 @@ def enable_stereo(renwin, stereo_type):
 
 
 _GL = {
-    "SRC_ALPHA": 770,
-    "ONE": 1,
-    "ZERO": 0,
-    "BLEND": 3042,
-    "ONE_MINUS_SRC_ALPHA": 771,
-    "SRC_ALPHA": 770,
-    "DEPTH_TEST": 2929,
-    "DST_COLOR": 774,
-    "CULL_FACE": 2884,
-    "ALPHA_TEST": 3008,
+    "GL_SRC_ALPHA": 770,
+    "GL_ONE": 1,
+    "GL_ZERO": 0,
+    "GL_BLEND": 3042,
+    "GL_ONE_MINUS_SRC_ALPHA": 771,
+    "GL_SRC_ALPHA": 770,
+    "GL_DEPTH_TEST": 2929,
+    "GL_DST_COLOR": 774,
+    "GL_CULL_FACE": 2884,
+    "GL_ALPHA_TEST": 3008,
     "GL_CW": 2304,
+    " GL_CCW": 2305,
 }
+
+
+def gl_get_current_state(window):
+    glState = window.GetState()
+    for glName, glNumber in _GL.items():
+        print(f'{glName}: {glState.GetEnumState(glNumber)}')
+
+
+def gl_apply_all_opaque(window):
+    '''This it will disable any gl behavior which has no 
+    function for opaque objects. The aim it's to increasse the performance
+
+    See more
+    --------
+    [1] https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFrontFace.xhtml
+    '''
+    glState = window.GetState()
+    glState.vtkglDisable(_GL['GL_CULL_FACE'])
+    glState.vtkglDisable(_GL['GL_BLEND'])
+    glState.vtkglDisable(_GL['GL_DEPTH_TEST'])
+

--- a/fury/window.py
+++ b/fury/window.py
@@ -1035,8 +1035,9 @@ _GL = {
 def test_and_extract_gl_state(func):
     def wrapper(obj, *args, **kwargs):
         """
-        Arguments
-        ---------
+
+        Parameters
+        ----------
             obj:
                 'vtkOpenGLState' or fury.window.ShowManager
         """

--- a/fury/window.py
+++ b/fury/window.py
@@ -1035,7 +1035,7 @@ def test_and_extract_gl_state(func):
         Arguments
         ---------
             obj:
-                'vtkOpenGLState' or FURY ShowManager 
+                'vtkOpenGLState' or fury.window.ShowManager 
         '''
         if isinstance(obj, ShowManager):
             glState = obj.window.GetState()
@@ -1045,7 +1045,7 @@ def test_and_extract_gl_state(func):
 
         else:
             raise TypeError('''valid types are vtkOpenGLState
-             or FURY ShowManager''')
+             or fury.window.ShowManager''')
 
         func(glState, *args, **kwargs)
 
@@ -1054,6 +1054,9 @@ def test_and_extract_gl_state(func):
 
 @test_and_extract_gl_state
 def gl_get_current_state(glState):
+    """Returns a dict which describes the current state of the opengl
+    context
+    """
     state_description = {
         glName: glState.GetEnumState(glNumber)
         for glName, glNumber in _GL.items()
@@ -1062,7 +1065,17 @@ def gl_get_current_state(glState):
 
 
 @test_and_extract_gl_state
-def gl_resset_blend_func(glState):
+def gl_reset_blend(glState):
+    """Redefines the state of the OpenGL context related with how the RGBA
+    channels will be combined.
+
+    See more:
+    ---------
+    https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendEquation.xhtml
+    https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendFunc.xhtml
+    vtk specification
+    https://gitlab.kitware.com/vtk/vtk/-/blob/master/Rendering/OpenGL2/vtkOpenGLState.cxx#L1705
+    """
     glState.ResetGLBlendEquationState()
     glState.ResetGLBlendFuncState()
 
@@ -1092,7 +1105,6 @@ def gl_disable_blend(glState):
     --------
     [1] https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFrontFace.xhtml
     """
-
     glState.vtkglDisable(_GL['GL_CULL_FACE'])
     glState.vtkglDisable(_GL['GL_BLEND'])
 

--- a/fury/window.py
+++ b/fury/window.py
@@ -1010,20 +1010,29 @@ def enable_stereo(renwin, stereo_type):
     renwin.SetStereoType(stereo_type_dictionary[stereo_type])
 
 
-def gl_get_current_state(glState):
+def gl_get_current_state(gl_state):
     """Returns a dict which describes the current state of the opengl
     context
+
+    Parameters
+    ----------
+    gl_state : vtkOpenGLState
+
     """
     state_description = {
-        glName: glState.GetEnumState(glNumber)
+        glName: gl_state.GetEnumState(glNumber)
         for glName, glNumber in _GL.items()
     }
     return state_description
 
 
-def gl_reset_blend(glState):
+def gl_reset_blend(gl_state):
     """Redefines the state of the OpenGL context related with how the RGBA
     channels will be combined.
+
+    Parameters
+    ----------
+    gl_state : vtkOpenGLState
 
     See more
     ---------
@@ -1031,67 +1040,129 @@ def gl_reset_blend(glState):
     [2] https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendFunc.xhtml
     vtk specification:
     [3] https://gitlab.kitware.com/vtk/vtk/-/blob/master/Rendering/OpenGL2/vtkOpenGLState.cxx#L1705
+
     """  # noqa
-    glState.ResetGLBlendEquationState()
-    glState.ResetGLBlendFuncState()
+    gl_state.ResetGLBlendEquationState()
+    gl_state.ResetGLBlendFuncState()
 
 
-def gl_enable_depth(glState):
-    glState.vtkglEnable(_GL['GL_DEPTH_TEST'])
+def gl_enable_depth(gl_state):
+    """Enable OpenGl depth test
+
+    Parameters
+    ----------
+    gl_state : vtkOpenGLState
+
+    """
+    gl_state.vtkglEnable(_GL['GL_DEPTH_TEST'])
 
 
-def gl_disable_depth(glState):
-    glState.vtkglDisable(_GL['GL_DEPTH_TEST'])
+def gl_disable_depth(gl_state):
+    """Disable OpenGl depth test
+
+    Parameters
+    ----------
+    gl_state : vtkOpenGLState
+
+    """
+    gl_state.vtkglDisable(_GL['GL_DEPTH_TEST'])
 
 
-def gl_enable_blend(glState):
-    glState.vtkglEnable(_GL['GL_BLEND'])
+def gl_enable_blend(gl_state):
+    """Enable OpenGl blending
+
+    Parameters
+    ----------
+    gl_state : vtkOpenGLState
+
+    """
+    gl_state.vtkglEnable(_GL['GL_BLEND'])
 
 
-def gl_disable_blend(glState):
+def gl_disable_blend(gl_state):
     """This it will disable any gl behavior which has no
     function for opaque objects. This has the benefit of
     speeding up the rendering of the image.
 
+    Parameters
+    ----------
+    gl_state : vtkOpenGLState
+
     See more
     --------
     [1] https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFrontFace.xhtml
+
     """  # noqa
 
-    glState.vtkglDisable(_GL['GL_CULL_FACE'])
-    glState.vtkglDisable(_GL['GL_BLEND'])
+    gl_state.vtkglDisable(_GL['GL_CULL_FACE'])
+    gl_state.vtkglDisable(_GL['GL_BLEND'])
 
 
-def gl_set_additive_blending(glState):
-    gl_reset_blend(glState)
-    glState.vtkglEnable(_GL['GL_BLEND'])
-    glState.vtkglDisable(_GL['GL_DEPTH_TEST'])
-    glState.vtkglBlendFunc(_GL['GL_SRC_ALPHA'], _GL['GL_ONE'])
+def gl_set_additive_blending(gl_state):
+    """Enable additive blending
+
+    Parameters
+    ----------
+    gl_state : vtkOpenGLState
+
+    """
+    gl_reset_blend(gl_state)
+    gl_state.vtkglEnable(_GL['GL_BLEND'])
+    gl_state.vtkglDisable(_GL['GL_DEPTH_TEST'])
+    gl_state.vtkglBlendFunc(_GL['GL_SRC_ALPHA'], _GL['GL_ONE'])
 
 
-def gl_set_additive_blending_white_background(glState):
-    gl_reset_blend(glState)
-    glState.vtkglEnable(_GL['GL_BLEND'])
-    glState.vtkglDisable(_GL['GL_DEPTH_TEST'])
-    glState.vtkglBlendFuncSeparate(
+def gl_set_additive_blending_white_background(gl_state):
+    """Enable additive blending for a white background
+
+    Parameters
+    ----------
+    gl_state : vtkOpenGLState
+
+    """
+    gl_reset_blend(gl_state)
+    gl_state.vtkglEnable(_GL['GL_BLEND'])
+    gl_state.vtkglDisable(_GL['GL_DEPTH_TEST'])
+    gl_state.vtkglBlendFuncSeparate(
             _GL['GL_SRC_ALPHA'], _GL['GL_ONE_MINUS_SRC_ALPHA'],
             _GL['GL_ONE'],  _GL['GL_ZERO'])
 
 
-def gl_set_normal_blending(glState):
-    glState.vtkglEnable(_GL['GL_BLEND'])
-    glState.vtkglEnable(_GL['GL_DEPTH_TEST'])
-    glState.vtkglBlendFunc(_GL['GL_ONE'], _GL['GL_ONE'])
-    glState.vtkglBlendFuncSeparate(
+def gl_set_normal_blending(gl_state):
+    """Enable normal blending
+
+    Parameters
+    ----------
+    gl_state : vtkOpenGLState
+
+    """
+    gl_state.vtkglEnable(_GL['GL_BLEND'])
+    gl_state.vtkglEnable(_GL['GL_DEPTH_TEST'])
+    gl_state.vtkglBlendFunc(_GL['GL_ONE'], _GL['GL_ONE'])
+    gl_state.vtkglBlendFuncSeparate(
                 _GL['GL_SRC_ALPHA'], _GL['GL_ONE_MINUS_SRC_ALPHA'],
                 _GL['GL_ONE'], _GL['GL_ONE_MINUS_SRC_ALPHA'])
 
 
-def gl_set_multiplicative_blending(glState):
-    gl_reset_blend(glState)
-    glState.vtkglBlendFunc(_GL['GL_ZERO'], _GL['GL_SRC_COLOR'])
+def gl_set_multiplicative_blending(gl_state):
+    """Enable multiplicative blending
+
+    Parameters
+    ----------
+    gl_state : vtkOpenGLState
+
+    """
+    gl_reset_blend(gl_state)
+    gl_state.vtkglBlendFunc(_GL['GL_ZERO'], _GL['GL_SRC_COLOR'])
 
 
-def gl_set_subtractive_blending(glState):
-    gl_reset_blend(glState)
-    glState.vtkglBlendFunc(_GL['GL_ZERO'], _GL['GL_ONE_MINUS_SRC_COLOR'])
+def gl_set_subtractive_blending(gl_state):
+    """Enable subtractive blending
+
+    Parameters
+    ----------
+    gl_state : vtkOpenGLState
+
+    """
+    gl_reset_blend(gl_state)
+    gl_state.vtkglBlendFunc(_GL['GL_ZERO'], _GL['GL_ONE_MINUS_SRC_COLOR'])

--- a/fury/window.py
+++ b/fury/window.py
@@ -1019,10 +1019,13 @@ _GL = {
     "GL_SRC_ALPHA": 770,
     "GL_DEPTH_TEST": 2929,
     "GL_DST_COLOR": 774,
+    "GL_FUNC_SUBTRACT": 3277,
     "GL_CULL_FACE": 2884,
     "GL_ALPHA_TEST": 3008,
     "GL_CW": 2304,
-    " GL_CCW": 2305,
+    "GL_CCW": 2305,
+    "GL_ONE_MINUS_SRC_COLOR": 769,
+    "GL_SRC_COLOR": 768
 }
 
 
@@ -1042,59 +1045,53 @@ def gl_set_opaque(window):
     [1] https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFrontFace.xhtml
     '''
     glState = window.GetState()
-    glState.vtkglDisable(_GL['GL_CULL_FACE'])
+    glState.ResetGLBlendEquationState()
+    glState.ResetGLBlendFuncState()
+
+    #glState.vtkglDisable(_GL['GL_CULL_FACE'])
+    #glState.vtkglDisable(_GL['GL_BLEND'])
     glState.vtkglDisable(_GL['GL_BLEND'])
     glState.vtkglDisable(_GL['GL_DEPTH_TEST'])
+    #glState.vtkglDepthMask(False)
+    #glState.vtkglEnable(_GL['GL_DEPTH_TEST'])
 
 
-def gl_set_additive_blending(window, dark_background=False):
+def gl_set_additive_blending(window, dark_background=True):
     glState = window.GetState()
-    glState.vtkglEnable(_GL['GL_CULL_FACE'])
+    #glState.vtkglEnable(_GL['GL_CULL_FACE'])
     glState.vtkglEnable(_GL['GL_BLEND'])
-    glState.vtkglEnable(_GL['GL_DEPTH_TEST'])
+    glState.vtkglDisable(_GL['GL_DEPTH_TEST'])
     glState.ResetGLBlendEquationState()
     glState.ResetGLBlendFuncState()
 
     if dark_background:
         glState.vtkglBlendFunc(_GL['GL_SRC_ALPHA'], _GL['GL_ONE'])
     else:
+        glState.vtkglBlendFuncSeparate(
+             _GL['GL_SRC_ALPHA'], _GL['GL_ONE_MINUS_SRC_ALPHA'],
+             _GL['GL_ONE'],  _GL['GL_ZERO'])
         # glState.vtkglBlendFuncSeparate(
         #     _GL['GL_SRC_ALPHA'], _GL['GL_ONE_MINUS_SRC_ALPHA'],
-        #     _GL['GL_ONE'],  _GL['GL_ZERO'])
-        glState.vtkglBlendFuncSeparate(
-            _GL['GL_SRC_ALPHA'], _GL['GL_ONE_MINUS_SRC_ALPHA'],
-            _GL['GL_ZERO'], _GL['GL_ONE'])
+        #     _GL['GL_ZERO'], _GL['GL_ONE'])
 
 
 def gl_set_multiplicative_blending(window, dark_background=False):
     glState = window.GetState()
-    glState.vtkglEnable(_GL['GL_CULL_FACE'])
+    #glState.vtkglEnable(_GL['GL_CULL_FACE'])
     glState.vtkglEnable(_GL['GL_BLEND'])
     glState.vtkglEnable(_GL['GL_DEPTH_TEST'])
     glState.ResetGLBlendEquationState()
     glState.ResetGLBlendFuncState()
-    glState.vtkglBlendFunc(_GL['GL_DST_COLOR'], _GL['GL_ZERO'])
-
-
-def gl_set_subtractive_blending(window, dark_background=False):
-    glState = window.GetState()
-    glState.vtkglEnable(_GL['GL_CULL_FACE'])
-    glState.vtkglEnable(_GL['GL_BLEND'])
-    glState.vtkglEnable(_GL['GL_DEPTH_TEST'])
-    glState.ResetGLBlendEquationState()
-    glState.ResetGLBlendFuncState()
-    glState.vtkglBlendEquation(_GL['GL_FUNC_SUBTRACT'])
-    glState.vtkglBlendFunc(_GL['GL_ONE'], _GL['GL_ONE'])
+    glState.vtkglBlendFunc(_GL['GL_ZERO'], _GL['GL_SRC_COLOR'])
 
 
 def gl_set_normal_blending(window, dark_background=False):
     glState = window.GetState()
-    glState.vtkglEnable(_GL['GL_CULL_FACE'])
+    #glState.vtkglEnable(_GL['GL_CULL_FACE'])
     glState.vtkglEnable(_GL['GL_BLEND'])
     glState.vtkglEnable(_GL['GL_DEPTH_TEST'])
     glState.ResetGLBlendEquationState()
     glState.ResetGLBlendFuncState()
-    glState.vtkglBlendEquation(_GL['GL_FUNC_SUBTRACT'])
     glState.vtkglBlendFunc(_GL['GL_ONE'], _GL['GL_ONE'])
     glState.vtkglBlendFuncSeparate(
                 _GL['GL_SRC_ALPHA'], _GL['GL_ONE_MINUS_SRC_ALPHA'],

--- a/fury/window.py
+++ b/fury/window.py
@@ -1010,31 +1010,6 @@ def enable_stereo(renwin, stereo_type):
     renwin.SetStereoType(stereo_type_dictionary[stereo_type])
 
 
-def test_and_extract_gl_state(func):
-    def wrapper(obj, *args, **kwargs):
-        """
-
-        Parameters
-        ----------
-        obj :
-                'vtkOpenGLState' or fury.window.ShowManager
-        """
-        if isinstance(obj, ShowManager):
-            glState = obj.window.GetState()
-
-        elif not isinstance(obj, vtk.vtkOpenGLState):
-            glState = obj
-
-        else:
-            raise TypeError("""valid types are vtkOpenGLState
-             or fury.window.ShowManager """)
-
-        func(glState, *args, **kwargs)
-
-    return wrapper
-
-
-@test_and_extract_gl_state
 def gl_get_current_state(glState):
     """Returns a dict which describes the current state of the opengl
     context
@@ -1046,7 +1021,6 @@ def gl_get_current_state(glState):
     return state_description
 
 
-@test_and_extract_gl_state
 def gl_reset_blend(glState):
     """Redefines the state of the OpenGL context related with how the RGBA
     channels will be combined.
@@ -1062,22 +1036,18 @@ def gl_reset_blend(glState):
     glState.ResetGLBlendFuncState()
 
 
-@test_and_extract_gl_state
 def gl_enable_depth(glState):
     glState.vtkglEnable(_GL['GL_DEPTH_TEST'])
 
 
-@test_and_extract_gl_state
 def gl_disable_depth(glState):
     glState.vtkglDisable(_GL['GL_DEPTH_TEST'])
 
 
-@test_and_extract_gl_state
 def gl_enable_blend(glState):
     glState.vtkglEnable(_GL['GL_BLEND'])
 
 
-@test_and_extract_gl_state
 def gl_disable_blend(glState):
     """This it will disable any gl behavior which has no
     function for opaque objects. This has the benefit of
@@ -1091,11 +1061,10 @@ def gl_disable_blend(glState):
     glState.vtkglDisable(_GL['GL_BLEND'])
 
 
-@test_and_extract_gl_state
 def gl_set_additive_blending(glState, dark_background=True):
+    gl_reset_blend(glState)
     glState.vtkglEnable(_GL['GL_BLEND'])
     glState.vtkglDisable(_GL['GL_DEPTH_TEST'])
-
     if dark_background:
         glState.vtkglBlendFunc(_GL['GL_SRC_ALPHA'], _GL['GL_ONE'])
     else:
@@ -1104,7 +1073,6 @@ def gl_set_additive_blending(glState, dark_background=True):
              _GL['GL_ONE'],  _GL['GL_ZERO'])
 
 
-@test_and_extract_gl_state
 def gl_set_normal_blending(glState):
     glState.vtkglEnable(_GL['GL_BLEND'])
     glState.vtkglEnable(_GL['GL_DEPTH_TEST'])
@@ -1112,3 +1080,13 @@ def gl_set_normal_blending(glState):
     glState.vtkglBlendFuncSeparate(
                 _GL['GL_SRC_ALPHA'], _GL['GL_ONE_MINUS_SRC_ALPHA'],
                 _GL['GL_ONE'], _GL['GL_ONE_MINUS_SRC_ALPHA'])
+
+
+def gl_set_multiplicative_blending(glState):
+    gl_reset_blend(glState)
+    glState.vtkglBlendFunc(_GL['GL_ZERO'], _GL['GL_SRC_COLOR'])
+
+
+def gl_set_subtractive_blending(glState):
+    gl_reset_blend(glState)
+    glState.vtkglBlendFunc(_GL['GL_ZERO'], _GL['GL_ONE_MINUS_SRC_COLOR'])

--- a/fury/window.py
+++ b/fury/window.py
@@ -1038,7 +1038,7 @@ def test_and_extract_gl_state(func):
 
         Parameters
         ----------
-            obj:
+        obj :
                 'vtkOpenGLState' or fury.window.ShowManager
         """
         if isinstance(obj, ShowManager):
@@ -1073,7 +1073,7 @@ def gl_reset_blend(glState):
     """Redefines the state of the OpenGL context related with how the RGBA
     channels will be combined.
 
-    See more:
+    See more
     ---------
     [1] https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendEquation.xhtml
     [2] https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendFunc.xhtml
@@ -1127,7 +1127,7 @@ def gl_set_additive_blending(glState, dark_background=True):
 
 
 @test_and_extract_gl_state
-def gl_set_normal_blending(glState, dark_background=False):
+def gl_set_normal_blending(glState):
     glState.vtkglEnable(_GL['GL_BLEND'])
     glState.vtkglEnable(_GL['GL_DEPTH_TEST'])
     glState.vtkglBlendFunc(_GL['GL_ONE'], _GL['GL_ONE'])

--- a/fury/window.py
+++ b/fury/window.py
@@ -1062,16 +1062,20 @@ def gl_disable_blend(glState):
     glState.vtkglDisable(_GL['GL_BLEND'])
 
 
-def gl_set_additive_blending(glState, dark_background=True):
+def gl_set_additive_blending(glState):
     gl_reset_blend(glState)
     glState.vtkglEnable(_GL['GL_BLEND'])
     glState.vtkglDisable(_GL['GL_DEPTH_TEST'])
-    if dark_background:
-        glState.vtkglBlendFunc(_GL['GL_SRC_ALPHA'], _GL['GL_ONE'])
-    else:
-        glState.vtkglBlendFuncSeparate(
-             _GL['GL_SRC_ALPHA'], _GL['GL_ONE_MINUS_SRC_ALPHA'],
-             _GL['GL_ONE'],  _GL['GL_ZERO'])
+    glState.vtkglBlendFunc(_GL['GL_SRC_ALPHA'], _GL['GL_ONE'])
+
+
+def gl_set_additive_blending_white_background(glState):
+    gl_reset_blend(glState)
+    glState.vtkglEnable(_GL['GL_BLEND'])
+    glState.vtkglDisable(_GL['GL_DEPTH_TEST'])
+    glState.vtkglBlendFuncSeparate(
+            _GL['GL_SRC_ALPHA'], _GL['GL_ONE_MINUS_SRC_ALPHA'],
+            _GL['GL_ONE'],  _GL['GL_ZERO'])
 
 
 def gl_set_normal_blending(glState):

--- a/fury/window.py
+++ b/fury/window.py
@@ -1008,3 +1008,18 @@ def enable_stereo(renwin, stereo_type):
         stereo_type = 'horizontal'
 
     renwin.SetStereoType(stereo_type_dictionary[stereo_type])
+
+
+_GL = {
+    "SRC_ALPHA": 770,
+    "ONE": 1,
+    "ZERO": 0,
+    "BLEND": 3042,
+    "ONE_MINUS_SRC_ALPHA": 771,
+    "SRC_ALPHA": 770,
+    "DEPTH_TEST": 2929,
+    "DST_COLOR": 774,
+    "CULL_FACE": 2884,
+    "ALPHA_TEST": 3008,
+    "GL_CW": 2304,
+}

--- a/fury/window.py
+++ b/fury/window.py
@@ -1031,11 +1031,14 @@ _GL = {
 
 def gl_get_current_state(window):
     glState = window.GetState()
-    for glName, glNumber in _GL.items():
-        print(f'{glName}: {glState.GetEnumState(glNumber)}')
+    state_description = {
+        glName: glState.GetEnumState(glNumber)
+        for glName, glNumber in _GL.items()
+    }
+    return state_description
 
 
-def gl_set_opaque(window):
+def gl_disable_depth(window):
     '''This it will disable any gl behavior which has no
     function for opaque objects. This has the benefit of
     speeding up the rendering of the image.
@@ -1048,17 +1051,12 @@ def gl_set_opaque(window):
     glState.ResetGLBlendEquationState()
     glState.ResetGLBlendFuncState()
 
-    #glState.vtkglDisable(_GL['GL_CULL_FACE'])
-    #glState.vtkglDisable(_GL['GL_BLEND'])
     glState.vtkglDisable(_GL['GL_BLEND'])
     glState.vtkglDisable(_GL['GL_DEPTH_TEST'])
-    #glState.vtkglDepthMask(False)
-    #glState.vtkglEnable(_GL['GL_DEPTH_TEST'])
 
 
 def gl_set_additive_blending(window, dark_background=True):
     glState = window.GetState()
-    #glState.vtkglEnable(_GL['GL_CULL_FACE'])
     glState.vtkglEnable(_GL['GL_BLEND'])
     glState.vtkglDisable(_GL['GL_DEPTH_TEST'])
     glState.ResetGLBlendEquationState()
@@ -1070,24 +1068,10 @@ def gl_set_additive_blending(window, dark_background=True):
         glState.vtkglBlendFuncSeparate(
              _GL['GL_SRC_ALPHA'], _GL['GL_ONE_MINUS_SRC_ALPHA'],
              _GL['GL_ONE'],  _GL['GL_ZERO'])
-        # glState.vtkglBlendFuncSeparate(
-        #     _GL['GL_SRC_ALPHA'], _GL['GL_ONE_MINUS_SRC_ALPHA'],
-        #     _GL['GL_ZERO'], _GL['GL_ONE'])
-
-
-def gl_set_multiplicative_blending(window, dark_background=False):
-    glState = window.GetState()
-    #glState.vtkglEnable(_GL['GL_CULL_FACE'])
-    glState.vtkglEnable(_GL['GL_BLEND'])
-    glState.vtkglEnable(_GL['GL_DEPTH_TEST'])
-    glState.ResetGLBlendEquationState()
-    glState.ResetGLBlendFuncState()
-    glState.vtkglBlendFunc(_GL['GL_ZERO'], _GL['GL_SRC_COLOR'])
 
 
 def gl_set_normal_blending(window, dark_background=False):
     glState = window.GetState()
-    #glState.vtkglEnable(_GL['GL_CULL_FACE'])
     glState.vtkglEnable(_GL['GL_BLEND'])
     glState.vtkglEnable(_GL['GL_DEPTH_TEST'])
     glState.ResetGLBlendEquationState()

--- a/fury/window.py
+++ b/fury/window.py
@@ -1009,6 +1009,9 @@ def enable_stereo(renwin, stereo_type):
 
     renwin.SetStereoType(stereo_type_dictionary[stereo_type])
 
+# See [1] for a more extensive list of OpenGL constants
+# [1] https://docs.factorcode.org/content/vocab-opengl.gl.html
+
 
 _GL = {
     "GL_SRC_ALPHA": 770,
@@ -1031,12 +1034,12 @@ _GL = {
 
 def test_and_extract_gl_state(func):
     def wrapper(obj, *args, **kwargs):
-        '''
+        """
         Arguments
         ---------
             obj:
-                'vtkOpenGLState' or fury.window.ShowManager 
-        '''
+                'vtkOpenGLState' or fury.window.ShowManager
+        """
         if isinstance(obj, ShowManager):
             glState = obj.window.GetState()
 
@@ -1044,8 +1047,8 @@ def test_and_extract_gl_state(func):
             glState = obj
 
         else:
-            raise TypeError('''valid types are vtkOpenGLState
-             or fury.window.ShowManager''')
+            raise TypeError("""valid types are vtkOpenGLState
+             or fury.window.ShowManager """)
 
         func(glState, *args, **kwargs)
 
@@ -1071,11 +1074,11 @@ def gl_reset_blend(glState):
 
     See more:
     ---------
-    https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendEquation.xhtml
-    https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendFunc.xhtml
-    vtk specification
-    https://gitlab.kitware.com/vtk/vtk/-/blob/master/Rendering/OpenGL2/vtkOpenGLState.cxx#L1705
-    """
+    [1] https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendEquation.xhtml
+    [2] https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendFunc.xhtml
+    vtk specification:
+    [3] https://gitlab.kitware.com/vtk/vtk/-/blob/master/Rendering/OpenGL2/vtkOpenGLState.cxx#L1705
+    """  # noqa
     glState.ResetGLBlendEquationState()
     glState.ResetGLBlendFuncState()
 
@@ -1104,7 +1107,7 @@ def gl_disable_blend(glState):
     See more
     --------
     [1] https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFrontFace.xhtml
-    """
+    """ # noqa
     glState.vtkglDisable(_GL['GL_CULL_FACE'])
     glState.vtkglDisable(_GL['GL_BLEND'])
 


### PR DESCRIPTION
This it's related with  #428

Hi @Garyfallidis and @skoudoro. I didn't finish yet, but I'm sending the pull-request to get feedbacks or suggestions.

I've created a function inside of shaders/base.py (shader_apply_effects) in order to make the control of the opengl_state more  simple.

```python
id_observer = shader_apply_effects(
    showm, actorAdd,
    effect=window.gl_set_additive_blending)

###############################################################################
# It's also possible to pass a list of effects. The final opengl state it'll  be the composition of each 
# effect that each function has in the opengl state

id_observer =  shader_apply_effects(
    showm, actorNoDepthTest2,
    effects=[
        window.gl_reset_blend, window.gl_disable_blend,
        window.gl_disable_depth])
 ```
 

 
