### PR TITLE
WIP: added tests for layout module

### DIFF
--- a/fury/tests/test_layout.py
+++ b/fury/tests/test_layout.py
@@ -8,7 +8,7 @@ def get_default_cubes(centers=np.asarray([[[0, 0, 0]], [[5, 5, 5]]]),
                       directions=np.asarray([[[0, 0, 0]], [[0, 0, 0]]]),
                       colors=np.random.rand(2, 3), scales=[1, 1.5]):
     """Provides cube actors with default parameters
-    
+
     Parameters
     ----------
     centers: ndarray, shape (2, 3)
@@ -65,10 +65,13 @@ def test_grid_layout_get_cell_shape():
     grid = GridLayout()
     grid_square = GridLayout(cell_shape="square")
     grid_diagonal = GridLayout(cell_shape="diagonal")
+    invalid_gird = GridLayout(cell_shape="invalid")
 
     shape = grid.get_cells_shape([cube_first, cube_second])
     shape_square = grid_square.get_cells_shape([cube_first, cube_second])
     shape_diagonal = grid_diagonal.get_cells_shape([cube_first, cube_second])
+    with npt.assert_raises(ValueError):
+        shape_invalid = invalid_gird.get_cells_shape([cube_first, cube_second])
 
     npt.assert_array_equal(shape, [[1.5, 1.5], [1.5, 1.5]])
     npt.assert_array_equal(shape_square, [[1.5, 1.5], [1.5, 1.5]], 0)

--- a/fury/tests/test_layout.py
+++ b/fury/tests/test_layout.py
@@ -1,33 +1,108 @@
 import numpy as np
 import numpy.testing as npt
 from fury import actor
-from fury.layout import GridLayout
+from fury.layout import GridLayout, Layout
 
 
-def test_grid_layout_gets_cell_shape():
-    centers = np.asarray([[0, 0, 0], [0, 0, 0]])
-    directions = np.asarray([[0, 0, 0], [0, 0, 0]])
-    heights = np.asarray([2, 5])
-    colors = np.random.rand(2, 3)
-    cylinders = actor.cylinder(centers, directions, colors, heights=heights)
+def get_default_cubes(centers=np.asarray([[[0, 0, 0]], [[5, 5, 5]]]),
+                      directions=np.asarray([[[0, 0, 0]], [[0, 0, 0]]]),
+                      colors=np.random.rand(2, 3), scales=[1, 1.5]):
+    """Provides cube actors with default parameters
+    
+    Parameters
+    ----------
+    centers: ndarray, shape (2, 3)
+        Cube positions
+    directions: ndarray, shape (2, 3)
+        The orientation vector of the cube.
+    colors: ndarray ndarray (2,3) or (2, 4)
+        RGB or RGBA (for opacity)
+    scales: list of 2 floats
+        Cube Sizes
+    """
+    cube_first_center, cube_second_center = centers
+    cube_first_direction, cube_second_direction = directions
+    cube_first_color, cube_second_color = colors
+    cube_first_scale, cube_second_scale = scales
+
+    cube_first = actor.cube(cube_first_center, cube_first_direction,
+                            cube_first_color, cube_first_scale)
+
+    cube_second = actor.cube(cube_second_center, cube_second_direction,
+                             cube_second_color, cube_second_scale)
+
+    return (cube_first, cube_second)
+
+
+def test_layout_apply():
+
+    cube_first, cube_second = get_default_cubes()
+
+    layout = Layout()
+    layout.apply([cube_first, cube_second])
+
+    cube_first_center = cube_first.GetCenter()
+    cube_second_center = cube_second.GetCenter()
+
+    npt.assert_array_equal(cube_first_center, [0, 0, 0])
+    npt.assert_array_equal(cube_second_center, [5, 5, 5])
+
+
+def test_layout_compute_postions():
+
+    cube_first, cube_second = get_default_cubes()
+
+    layout = Layout()
+
+    positions = layout.compute_positions([cube_first, cube_second])
+    npt.assert_array_equal(positions, [])
+
+
+def test_grid_layout_get_cell_shape():
+
+    cube_first, cube_second = get_default_cubes()
+
     grid = GridLayout()
     grid_square = GridLayout(cell_shape="square")
     grid_diagonal = GridLayout(cell_shape="diagonal")
-    shape = grid.get_cells_shape([cylinders])
-    shape_square = grid_square.get_cells_shape([cylinders])
-    shape_diagonal = grid_diagonal.get_cells_shape([cylinders])
-    npt.assert_array_equal(shape, [[0.5, 5]])
-    npt.assert_array_equal(shape_square, [[5, 5]])
-    npt.assert_array_almost_equal(shape_diagonal, [[5, 5]], 0)
+
+    shape = grid.get_cells_shape([cube_first, cube_second])
+    shape_square = grid_square.get_cells_shape([cube_first, cube_second])
+    shape_diagonal = grid_diagonal.get_cells_shape([cube_first, cube_second])
+
+    npt.assert_array_equal(shape, [[1.5, 1.5], [1.5, 1.5]])
+    npt.assert_array_equal(shape_square, [[1.5, 1.5], [1.5, 1.5]], 0)
+    npt.assert_array_almost_equal(shape_diagonal,
+                                  [[2.59, 2.59], [2.59, 2.59]], 0)
 
 
 def test_grid_layout_compute_positions():
-    centers = np.asarray([[0, 0, 0], [0, 0, 0]])
-    directions = np.asarray([[0, 0, 0], [0, 0, 0]])
-    heights = np.asarray([2, 5])
-    colors = np.random.rand(2, 3)
-    cylinders = actor.cylinder(centers, directions, colors, heights=heights)
+
+    cube_first, cube_second = get_default_cubes()
+
     grid = GridLayout()
-    positions = grid.compute_positions([cylinders])
-    p = [[0, 0, 0], [0.5, 0, 0], [1, 0, 0], [1.5, 0, 0], [2, 0, 0]]
-    npt.assert_array_equal(positions, p)
+    grid_square = GridLayout(cell_shape="square")
+    grid_diagonal = GridLayout(cell_shape="diagonal")
+
+    position_rect = grid.compute_positions([cube_first, cube_second])
+    position_square = grid_square.compute_positions([cube_first, cube_second])
+    position_diagonal = grid_diagonal.compute_positions([cube_first,
+                                                        cube_second])
+
+    npt.assert_array_equal(position_rect, [[0, 0, 0], [1.5, 0, 0]])
+    npt.assert_array_equal(position_square, [[0, 0, 0], [1.5, 0, 0]])
+    npt.assert_array_almost_equal(position_diagonal,
+                                  [[0, 0, 0], [2.59, 0, 0]], 0)
+
+
+def test_grid_layout_apply():
+
+    cube_first, cube_second = get_default_cubes()
+
+    grid_diagonal = GridLayout(cell_shape="diagonal")
+    grid_diagonal.apply([cube_first, cube_second])
+
+    cube_first_center = cube_first.GetCenter()
+    cube_second_center = cube_second.GetCenter()
+    npt.assert_array_almost_equal([cube_first_center, cube_second_center],
+                                  [[0, 0, 0], [2.59, 0, 0]], 0)


### PR DESCRIPTION
This PR adds tests for the layout module. This PR extends/modifies the PR opened by @jhalak27 ( #411 ).
Along with the tests a `get_default_cubes` method is also implemented that provides default parameter cube actors to test the grid with. The `GridLayout`  as well as the `Layout` classes are tested with these default cubes as it makes the visualization of the grid behavior easier.
 
![daigonal_grid](https://user-images.githubusercontent.com/54466356/119834535-ac439880-bf1d-11eb-9fb9-24ef07db1816.png)
Diagonal Grid
![square/rect grid](https://user-images.githubusercontent.com/54466356/119834568-b36aa680-bf1d-11eb-8a72-d554a29016eb.png)
Square/Rect Grid

