### PR TITLE
added support for URL image in ImageContainer2D

### DIFF
--- a/fury/io.py
+++ b/fury/io.py
@@ -25,10 +25,15 @@ def load_image(filename, as_vtktype=False, use_pillow=True):
         desired image array
 
     """
-    is_url = filename.startswith('http://') or filename.startswith('https://')
+    is_url = filename.lower().startswith('http://') \
+        or filename.lower().startswith('https://')
 
     if is_url:
         image_name = os.path.basename(filename)
+
+        if len(image_name.split('.')) < 2:
+            raise IOError(f'{filename} is not a valid image URL')
+
         urlretrieve(filename, image_name)
         filename = image_name
 

--- a/fury/io.py
+++ b/fury/io.py
@@ -14,8 +14,6 @@ def load_image(filename, as_vtktype=False, use_pillow=True):
     ----------
     filename: str
         should be png, bmp, jpeg or jpg files
-    is_url: bool, optional
-        Is the filename a URL
     as_vtktype: bool, optional
         if True, return vtk output otherwise an ndarray. Default False.
     use_pillow: bool, optional

--- a/fury/io.py
+++ b/fury/io.py
@@ -7,7 +7,7 @@ from fury.utils import set_input
 from urllib.request import urlretrieve
 
 
-def load_image(filename, is_url=False, as_vtktype=False, use_pillow=True):
+def load_image(filename, as_vtktype=False, use_pillow=True):
     """Load an image.
 
     Parameters
@@ -27,6 +27,8 @@ def load_image(filename, is_url=False, as_vtktype=False, use_pillow=True):
         desired image array
 
     """
+    is_url = filename.startswith('http://') or filename.startswith('https://')
+
     if is_url:
         image_name = os.path.basename(filename)
         urlretrieve(filename, image_name)
@@ -72,7 +74,8 @@ def load_image(filename, is_url=False, as_vtktype=False, use_pillow=True):
             vtk_image.GetPointData().SetScalars(uchar_array)
             image = vtk_image
 
-        os.remove(filename)
+        if is_url:
+            os.remove(filename)
         return image
 
     d_reader = {".png": vtk.vtkPNGReader,
@@ -101,7 +104,8 @@ def load_image(filename, is_url=False, as_vtktype=False, use_pillow=True):
         image = numpy_support.vtk_to_numpy(vtk_array).reshape(h, w, components)
         image = np.flipud(image)
 
-    os.remove(filename)
+    if is_url:
+        os.remove(filename)
     return reader.GetOutput() if as_vtktype else image
 
 

--- a/fury/io.py
+++ b/fury/io.py
@@ -4,15 +4,17 @@ import numpy as np
 from PIL import Image
 from vtk.util import numpy_support
 from fury.utils import set_input
+from urllib.request import urlretrieve
 
-
-def load_image(filename, as_vtktype=False, use_pillow=True):
+def load_image(filename, is_url=False, as_vtktype=False, use_pillow=True):
     """Load an image.
 
     Parameters
     ----------
     filename: str
         should be png, bmp, jpeg or jpg files
+    is_url: bool, optional
+        Is the filename a URL
     as_vtktype: bool, optional
         if True, return vtk output otherwise an ndarray. Default False.
     use_pillow: bool, optional
@@ -24,6 +26,11 @@ def load_image(filename, as_vtktype=False, use_pillow=True):
         desired image array
 
     """
+    if is_url:
+        image_name = os.path.basename(filename)
+        urlretrieve(filename, image_name)
+        filename = image_name
+
     if use_pillow:
         with Image.open(filename) as pil_image:
             if pil_image.mode in ['RGBA', 'RGB', 'L']:
@@ -64,6 +71,7 @@ def load_image(filename, as_vtktype=False, use_pillow=True):
             vtk_image.GetPointData().SetScalars(uchar_array)
             image = vtk_image
 
+        os.remove(filename)
         return image
 
     d_reader = {".png": vtk.vtkPNGReader,
@@ -92,6 +100,7 @@ def load_image(filename, as_vtktype=False, use_pillow=True):
         image = numpy_support.vtk_to_numpy(vtk_array).reshape(h, w, components)
         image = np.flipud(image)
 
+    os.remove(filename)
     return reader.GetOutput() if as_vtktype else image
 
 

--- a/fury/io.py
+++ b/fury/io.py
@@ -6,6 +6,7 @@ from vtk.util import numpy_support
 from fury.utils import set_input
 from urllib.request import urlretrieve
 
+
 def load_image(filename, is_url=False, as_vtktype=False, use_pillow=True):
     """Load an image.
 

--- a/fury/tests/test_io.py
+++ b/fury/tests/test_io.py
@@ -81,7 +81,7 @@ def test_save_load_image():
     l_ext = ["png", "jpeg", "jpg", "bmp", "tiff"]
     fury_logo_link = 'https://raw.githubusercontent.com/fury-gl/'\
                      'fury-communication-assets/main/fury-logo.png'
-                     
+         
     invalid_link = 'https://picsum.photos/200'
     fname = "temp-io"
 

--- a/fury/tests/test_io.py
+++ b/fury/tests/test_io.py
@@ -79,17 +79,28 @@ def test_save_and_load_options():
 
 def test_save_load_image():
     l_ext = ["png", "jpeg", "jpg", "bmp", "tiff"]
+    fury_logo_link = 'https://raw.githubusercontent.com/fury-gl/'\
+                     'fury-communication-assets/main/fury-logo.png'
+                     
+    invalid_link = 'https://picsum.photos/200'
     fname = "temp-io"
 
     for ext in l_ext:
         with InTemporaryDirectory() as odir:
             data = np.random.randint(0, 255, size=(50, 3), dtype=np.uint8)
+            url_image = load_image(fury_logo_link)
+
+            url_fname_path = pjoin(odir, f'fury_logo.{ext}')
             fname_path = pjoin(odir, "{0}.{1}".format(fname, ext))
 
             save_image(data, fname_path, compression_quality=100)
+            save_image(url_image, url_fname_path, compression_quality=100)
 
             npt.assert_equal(os.path.isfile(fname_path), True)
+            npt.assert_equal(os.path.isfile(url_fname_path), True)
+
             assert_greater(os.stat(fname_path).st_size, 0)
+            assert_greater(os.stat(url_fname_path).st_size, 0)
 
             out_image = load_image(fname_path)
             if ext not in ["jpeg", "jpg", "tiff"]:
@@ -99,6 +110,7 @@ def test_save_load_image():
                 npt.assert_array_almost_equal(data[..., 0], out_image[..., 0],
                                               decimal=0)
 
+    npt.assert_raises(IOError, load_image, invalid_link)
     npt.assert_raises(IOError, load_image, "test.vtk")
     npt.assert_raises(IOError, load_image, "test.vtk", use_pillow=False)
     npt.assert_raises(IOError, save_image,

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -3197,8 +3197,7 @@ class ImageContainer2D(UI):
 
     """
 
-    def __init__(self, img_path, is_url=False, position=(0, 0),
-                 size=(100, 100)):
+    def __init__(self, img_path, position=(0, 0), size=(100, 100)):
         """
         Parameters
         ----------
@@ -3212,7 +3211,7 @@ class ImageContainer2D(UI):
             Width and height in pixels of the image.
         """
         super(ImageContainer2D, self).__init__(position)
-        self.img = load_image(img_path, is_url, as_vtktype=True)
+        self.img = load_image(img_path, as_vtktype=True)
         self.set_img(self.img)
         self.resize(size)
 

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -3203,8 +3203,6 @@ class ImageContainer2D(UI):
         ----------
         img_path : string
             Path of the image
-        is_url: bool, optional
-            Is the image path a URL
         position : (float, float), optional
             Absolute coordinates (x, y) of the lower-left corner of the image.
         size : (int, int), optional

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -3197,19 +3197,22 @@ class ImageContainer2D(UI):
 
     """
 
-    def __init__(self, img_path, position=(0, 0), size=(100, 100)):
+    def __init__(self, img_path, is_url=False, position=(0, 0),
+                 size=(100, 100)):
         """
         Parameters
         ----------
         img_path : string
             Path of the image
+        is_url: bool, optional
+            Is the image path a URL
         position : (float, float), optional
             Absolute coordinates (x, y) of the lower-left corner of the image.
         size : (int, int), optional
             Width and height in pixels of the image.
         """
         super(ImageContainer2D, self).__init__(position)
-        self.img = load_image(img_path, as_vtktype=True)
+        self.img = load_image(img_path, is_url, as_vtktype=True)
         self.set_img(self.img)
         self.resize(size)
 

--- a/fury/ui.py
+++ b/fury/ui.py
@@ -3202,7 +3202,7 @@ class ImageContainer2D(UI):
         Parameters
         ----------
         img_path : string
-            Path of the image
+            URL or local path of the image
         position : (float, float), optional
             Absolute coordinates (x, y) of the lower-left corner of the image.
         size : (int, int), optional


### PR DESCRIPTION
This adds support for fetching the image from a URL. The image is stored in the directory temporarily until the image has been processed, then it is removed from the directory. I'll try to look at other approaches that may be more flexible than this in the meantime and update this if necessary. 