### PR TITLE
Release 0.7.1 preparation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -33,6 +33,10 @@ Nasim Anousheh <nasimanousheh@gmail.com> Nasim <nasimanousheh@gmail.com>
 Kesshi Jordan <Kesshi.Jordan@ucsf.edu> kesshijordan <Kesshi.Jordan@ucsf.edu>
 Tushar <codingid6@gmail.com> Tushar <30565750+tushar5526@users.noreply.github.com>
 Sajag Swami <sun.tsunami248@gmail.com> SunTzunami <sun.tsunami248@gmail.com>
-SunTzunami <sun.tsunami248@gmail.com> Sajag Swami <65067354+SunTzunami@users.noreply.github.com>
+Sajag Swami <sun.tsunami248@gmail.com> Sajag Swami <65067354+SunTzunami@users.noreply.github.com>
 Sanjay Marreddi <sanjay.mareddi@gmail.com> SanjayMarreddi <sanjay.mareddi@gmail.com>
 haran2001 <hari.ayapps@gmail.com> haran2001 <56040092+haran2001@users.noreply.github.com>
+Bruno Messias  <messias.physics@gmail.com> devmessias <messias.physics@gmail.com>
+Antriksh Misri <antrikshmisri@gmail.com> antrikshmisri <antrikshmisri@gmail.com>
+Praneeth Shetty <praneethshetty10@gmail.com> ganimtron-10 <64432063+ganimtron-10@users.noreply.github.com>
+Hariharan Ayappane <hari.ayapps@gmail.com> haran2001 <hari.ayapps@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -37,6 +37,7 @@ Sajag Swami <sun.tsunami248@gmail.com> Sajag Swami <65067354+SunTzunami@users.no
 Sanjay Marreddi <sanjay.mareddi@gmail.com> SanjayMarreddi <sanjay.mareddi@gmail.com>
 haran2001 <hari.ayapps@gmail.com> haran2001 <56040092+haran2001@users.noreply.github.com>
 Bruno Messias  <messias.physics@gmail.com> devmessias <messias.physics@gmail.com>
+Bruno Messias  <messias.physics@gmail.com> bruno messias <messias.physics@gmail.com>
 Antriksh Misri <antrikshmisri@gmail.com> antrikshmisri <antrikshmisri@gmail.com>
 Praneeth Shetty <praneethshetty10@gmail.com> ganimtron-10 <64432063+ganimtron-10@users.noreply.github.com>
 Hariharan Ayappane <hari.ayapps@gmail.com> haran2001 <hari.ayapps@gmail.com>

--- a/docs/source/posts/2021/2021-08-03-release-announcement.rst
+++ b/docs/source/posts/2021/2021-08-03-release-announcement.rst
@@ -1,0 +1,48 @@
+FURY 0.7.0 Released
+===================
+
+.. post:: August 03 2021
+   :author: skoudoro
+   :tags: fury
+   :category: release
+
+
+The FURY project is happy to announce the release of FURY 0.7.1!
+FURY is a free and open source software library for scientific visualization and 3D animations.
+
+You can show your support by `adding a star <https://github.com/fury-gl/fury/stargazers>`_ on FURY github project.
+
+This Release is mainly a maintenance release. The **major highlights** of this release are:
+
+.. include:: ../../release_notes/releasev0.7.1.rst
+    :start-after: --------------
+    :end-before: Details
+
+.. note:: The complete release notes are available :ref:`here <releasev0.7.1>`
+
+**To upgrade or install FURY**
+
+Run the following command in your terminal::
+
+    pip install --upgrade fury
+
+or::
+
+    conda install -c conda-forge fury
+
+
+**Questions or suggestions?**
+
+For any questions go to http://fury.gl, or send an e-mail to fury@python.org
+We can also join our `discord community <https://discord.gg/6btFPPj>`_
+
+We would like to thanks to :ref:`all contributors <community>` for this release:
+
+.. include:: ../../release_notes/releasev0.7.1.rst
+    :start-after: commits.
+    :end-before: We closed
+
+
+On behalf of the :ref:`FURY developers <community>`,
+
+Serge K.

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -7,6 +7,7 @@ For a full list of the features implemented in the most recent release cycle, ch
 .. toctree::
    :maxdepth: 1
 
+   release_notes/releasev0.7.1
    release_notes/releasev0.7.0
    release_notes/releasev0.6.1
    release_notes/releasev0.6.0

--- a/docs/source/release_notes/releasev0.7.1.rst
+++ b/docs/source/release_notes/releasev0.7.1.rst
@@ -39,8 +39,7 @@ The following 15 authors contributed 211 commits.
 * Praneeth Shetty
 * Sajag Swami
 * Serge Koudoro
-* bruno messias
-* haran2001
+* Hariharan Ayappane
 
 
 We closed a total of 89 issues, 35 pull requests and 54 regular issues;

--- a/docs/source/release_notes/releasev0.7.1.rst
+++ b/docs/source/release_notes/releasev0.7.1.rst
@@ -1,0 +1,143 @@
+.. _releasev0.7.1:
+
+==============================
+ Release notes v0.7.1
+ ==============================
+
+Quick Overview
+--------------
+
+* FURY paper added.
+* Fast selection of multiple objects added.
+* UI refactored.
+* Tests coverage increased.
+* New actor (Marker) added.
+* New primitive (Triangular Prism) added.
+* Demos added and updated.
+* Large Documentation Update.
+
+
+Details
+-------
+
+GitHub stats for 2021/03/13 - 2021/08/03 (tag: v0.7.0)
+
+These lists are automatically generated, and may be incomplete or contain duplicates.
+
+The following 15 authors contributed 211 commits.
+
+* Amit Chaudhari
+* Antriksh Misri
+* Bruno Messias
+* Daniel S. Katz
+* Eleftherios Garyfallidis
+* Gurdit Siyan
+* Javier Guaje
+* Jhalak Gupta
+* LoopThrough-i-j
+* MIHIR
+* Praneeth Shetty
+* Sajag Swami
+* Serge Koudoro
+* bruno messias
+* haran2001
+
+
+We closed a total of 89 issues, 35 pull requests and 54 regular issues;
+this is the full list (generated with the script
+:file:`tools/github_stats.py`):
+
+Pull Requests (35):
+
+* :ghpull:`475`: Gsoc blog 2021
+* :ghpull:`476`: Google Summer of Code blog posts
+* :ghpull:`477`: added blog posts for GSoC'21
+* :ghpull:`442`: added method to wrap overflowing text
+* :ghpull:`441`: Added border support in Panel2D
+* :ghpull:`466`: two more small bib changes
+* :ghpull:`464`: Paper Dan's Comments
+* :ghpull:`459`: extracted Button2D class from `elements` to `core`
+* :ghpull:`430`: Surface actor colormap fix
+* :ghpull:`456`: Updated about documentation
+* :ghpull:`455`: Fixed bibtex
+* :ghpull:`454`: Added missing DOIs and URLs
+* :ghpull:`451`: Typo fix
+* :ghpull:`447`: UI refactoring
+* :ghpull:`438`: Fast selection of multiple objects in 3D using GPU acceleration
+* :ghpull:`420`: added an example about graph-tool  and nested stochastic block model
+* :ghpull:`422`: This allow to draw markers using shaders
+* :ghpull:`444`: Remove deprecated functions
+* :ghpull:`440`: added support for URL image in ImageContainer2D
+* :ghpull:`356`: Render a video on an actor.
+* :ghpull:`436`: [Fix] Update Azure pipeline for windows
+* :ghpull:`434`: WIP: added tests for layout module
+* :ghpull:`426`: Allows to define the priority of a shader_callback and obtain the vtkEventId
+* :ghpull:`394`: Fixed warnings in test_utils.py
+* :ghpull:`415`: update sk orcid
+* :ghpull:`413`: add nanohub doi
+* :ghpull:`412`: fix paper doi
+* :ghpull:`386`: FURY paper for Journal of Open Source Software (JOSS)
+* :ghpull:`371`: Textbox2d  special character support
+* :ghpull:`408`: Updating the Missing Parenthesis
+* :ghpull:`406`: Removed unused library in FURY tutorial
+* :ghpull:`405`: Updating Redirecting Issues in Readme
+* :ghpull:`399`: Resolve warnings #317 & and Fix Issue: #355
+* :ghpull:`393`: added primitive and actor for triangular prism, added tests too
+* :ghpull:`396`: #317 Fixing Warnings during test : test_actors.py
+
+Issues (54):
+
+* :ghissue:`407`: UI Textbox background doesn't resize according to text in it.
+* :ghissue:`421`: Implementing the Resizing of Listbox
+* :ghissue:`416`: Fixing the Resizing Background issue of TextBox2D UI.
+* :ghissue:`475`: Gsoc blog 2021
+* :ghissue:`476`: Google Summer of Code blog posts
+* :ghissue:`477`: added blog posts for GSoC'21
+* :ghissue:`442`: added method to wrap overflowing text
+* :ghissue:`441`: Added border support in Panel2D
+* :ghissue:`466`: two more small bib changes
+* :ghissue:`464`: Paper Dan's Comments
+* :ghissue:`445`: [WIP] Example to show how to render multiple bonds
+* :ghissue:`410`: added BulletList to UI
+* :ghissue:`459`: extracted Button2D class from `elements` to `core`
+* :ghissue:`429`: Colormap not working as intended with surface actor
+* :ghissue:`430`: Surface actor colormap fix
+* :ghissue:`450`: Issue with references related to JOSS review
+* :ghissue:`456`: Updated about documentation
+* :ghissue:`455`: Fixed bibtex
+* :ghissue:`454`: Added missing DOIs and URLs
+* :ghissue:`453`: Add missing DOIs and URLs
+* :ghissue:`451`: Typo fix
+* :ghissue:`439`: [WIP] Space filling model
+* :ghissue:`447`: UI refactoring
+* :ghissue:`438`: Fast selection of multiple objects in 3D using GPU acceleration
+* :ghissue:`420`: added an example about graph-tool  and nested stochastic block model
+* :ghissue:`422`: This allow to draw markers using shaders
+* :ghissue:`444`: Remove deprecated functions
+* :ghissue:`440`: added support for URL image in ImageContainer2D
+* :ghissue:`356`: Render a video on an actor.
+* :ghissue:`436`: [Fix] Update Azure pipeline for windows
+* :ghissue:`434`: WIP: added tests for layout module
+* :ghissue:`403`: Creating test for layout module
+* :ghissue:`411`: Added Layout test file
+* :ghissue:`426`: Allows to define the priority of a shader_callback and obtain the vtkEventId
+* :ghissue:`417`: Fixing pep issues
+* :ghissue:`394`: Fixed warnings in test_utils.py
+* :ghissue:`415`: update sk orcid
+* :ghissue:`414`: Duplicate ORCIDs in the JOSS paper
+* :ghissue:`413`: add nanohub doi
+* :ghissue:`412`: fix paper doi
+* :ghissue:`386`: FURY paper for Journal of Open Source Software (JOSS)
+* :ghissue:`371`: Textbox2d  special character support
+* :ghissue:`409`: Segmentation Fault When Running Fury Tests
+* :ghissue:`408`: Updating the Missing Parenthesis
+* :ghissue:`406`: Removed unused library in FURY tutorial
+* :ghissue:`405`: Updating Redirecting Issues in Readme
+* :ghissue:`375`: Visuals for some parametric 2D functions
+* :ghissue:`317`: Track and fix warnings during tests.
+* :ghissue:`355`: [Vulnerability Bug] Used blacklisted dangerous function call that can lead to RCE
+* :ghissue:`399`: Resolve warnings #317 & and Fix Issue: #355
+* :ghissue:`393`: added primitive and actor for triangular prism, added tests too
+* :ghissue:`395`: FURY installation conflict
+* :ghissue:`396`: #317 Fixing Warnings during test : test_actors.py
+* :ghissue:`358`: Updated io.py


### PR DESCRIPTION
# Summary

Preparation for 0.7.1 release, targeting, August 3rd. 

Just a note that any PR can block the release. If they are not in, it will be for the next release in
September.

# Release checklist
- [x] add release_notes 0.7.1 and update release-history.rst
- [x] Update .mailmap
- [x] Check the copyright years in LICENSE
- [x] Check documentation
- [x] Check Tutorial
- [x] Update index.rst
- [x] Add a blog post
- [ ] Update website
- [x] Update deprecation cycle : delete if expired since 3 releases.