### PR TITLE
Fixes some bugs from ShowManager Object.

### DIFF
--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -335,15 +335,15 @@ def test_record():
             assert_less_equal(arr.shape[1], 5000)
 
 
-def test_timers():
+def test_timers(interactive=False):
     centers = np.array([[1, 0, 0]])
     showm = window.ShowManager(size=(400, 400))
     # number of times that  each time call is called
-    counts_by_interval = {0: 0, 1: 0, 2: 0}
+    counts_by_interval = {0: 0, 1: 0, 2: 0, 3:0}
     # interval of each timer in miliseconds
-    ms_1 = 1
-    ms_2 = 100
-    ms_3 = 1000
+    ms_1 = 10
+    ms_2 = 10
+    ms_3 = 100
     state = {
         'first_call': True,
         # amount of milleseconds passe since the timer was started
@@ -364,7 +364,9 @@ def test_timers():
     def t3(iren, event_name_str):
         if state['current_time'] >= ms_3:
             counts_by_interval[2] += 1
-            showm.iren.TerminateApp()
+
+            showm.destroy_timers()
+            showm.exit()
 
     id1 = showm.add_timer_callback(False, ms_1, t1)
     showm.add_timer_callback(True, ms_2, t2)
@@ -378,7 +380,9 @@ def test_timers():
     showm.scene.add(sphere)
 
     state['first_time'] = time.time()
-    showm.start()
-    # callback 1 was not called
-    npt.assert_equal(counts_by_interval[0], 0)
-    npt.assert_equal(counts_by_interval[1] >= ms_3//ms_2, True)
+    if interactive:
+        showm.start()
+        # callback 1 was not called
+        npt.assert_equal(counts_by_interval[0], 0)
+        npt.assert_equal(counts_by_interval[1] >= ms_3//ms_2, True)
+

--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -337,8 +337,41 @@ def test_record():
             assert_less_equal(arr.shape[1], 5000)
 
 
+def test_timers_basic():
+    centers = np.array([[1, 0, 0]])
+    showm = window.ShowManager(size=(400, 400))
+    # interval of each timer in miliseconds
+    ms_1 = 10
+    ms_2 = 10
+    state = {
+        'first_call': True,
+        # amount of milleseconds passe since the timer was started
+        'current_time': 0,
+    }
 
-def test_timers():
+    def t1(iren, event_name_str):
+        if state['first_call']:
+            state['first_call'] = False
+
+    def t2(iren, event_name_str):
+        if state['first_call']:
+            state['first_call'] = False
+        state['current_time'] += ms_2
+
+    id1 = showm.add_timer_callback(False, ms_1, t1)
+    showm.add_timer_callback(True, ms_2, t2)
+    showm.destroy_timer(id1)
+
+    showm.initialize()
+
+    color = np.array([0, 1, 0])
+    sphere = actor.sphere(centers, color)
+    showm.scene.add(sphere)
+
+
+@pytest.mark.skipif(skip_win, reason="This test does not work on Windows."
+                                     "exit method cannot be performed inside of a timer")
+def test_timers_count():
     interactive = False
     centers = np.array([[1, 0, 0]])
     showm = window.ShowManager(size=(400, 400))
@@ -482,4 +515,3 @@ def test_opengl_state_add_remove_and_check():
     state = window.gl_get_current_state(showm.window.GetState())
     after_remove_depth_test_observer = state['GL_DEPTH_TEST']
     npt.assert_equal(after_remove_depth_test_observer, True)
-

--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -335,7 +335,8 @@ def test_record():
             assert_less_equal(arr.shape[1], 5000)
 
 
-def test_timers(interactive=False):
+def test_timers():
+    interactive = False
     centers = np.array([[1, 0, 0]])
     showm = window.ShowManager(size=(400, 400))
     # number of times that  each time call is called

--- a/fury/window.py
+++ b/fury/window.py
@@ -326,8 +326,7 @@ class ShowManager(object):
         self.order_transparent = order_transparent
         self.interactor_style = interactor_style
         self.stereo = stereo
-        self.timers = []
-        self._timer_observers_ids = []
+        self._timers = {}
 
         if self.reset_camera:
             self.scene.ResetCamera()
@@ -518,34 +517,29 @@ class ShowManager(object):
         self.window.Render()
 
     def add_timer_callback(self, repeat, duration, timer_callback):
+        id_timer = len(self._timers.keys())
         id_observer = self.iren.AddObserver(
             "TimerEvent", timer_callback)
-        self._timer_observers_ids.append(id_observer)
 
         if repeat:
             timer_id = self.iren.CreateRepeatingTimer(duration)
         else:
             timer_id = self.iren.CreateOneShotTimer(duration)
-        self.timers.append(timer_id)
+        self._timers[id_timer] = (timer_id, id_observer)
+        return id_timer
 
     def add_iren_callback(self, iren_callback, event="MouseMoveEvent"):
-        self.iren.AddObserver(event, iren_callback)
+        self. iren.AddObserver(event, iren_callback)
 
-    def destroy_timer_by_id(self, id):
-        """Destroy a timer by id.
-        """
-        self.iren.DestroyTimer(self.timers[id])
-        self.iren.RemoveObserver(self._timer_observers_ids[id])
-        del self.timers[id]
-        del self._timer_observers_ids[id]
-
-    def destroy_timer(self, timer_id):
+    def destroy_timer(self, id):
+        timer_id, observer_id = self._timers[id]
         self.iren.DestroyTimer(timer_id)
-        del self.timers[self.timers.index(timer_id)]
+        self.iren.RemoveObserver(observer_id)
+        del self._timers[id]
 
     def destroy_timers(self):
-        for timer_id in self.timers:
-            self.destroy_timer(timer_id)
+        for id in self._timers.keys():
+            self.destroy_timer(id)
 
     def exit(self):
         """Close window and terminate interactor."""

--- a/fury/window.py
+++ b/fury/window.py
@@ -513,8 +513,9 @@ class ShowManager(object):
     def add_window_callback(self, win_callback,
                             event=vtk.vtkCommand.ModifiedEvent):
         """Add window callbacks."""
-        self.window.AddObserver(event, win_callback)
+        id_observer = self.window.AddObserver(event, win_callback)
         self.window.Render()
+        return id_observer
 
     def add_timer_callback(self, repeat, duration, timer_callback):
         id_timer = len(self._timers.keys())
@@ -529,7 +530,8 @@ class ShowManager(object):
         return id_timer
 
     def add_iren_callback(self, iren_callback, event="MouseMoveEvent"):
-        self. iren.AddObserver(event, iren_callback)
+        id_observer = self.iren.AddObserver(event, iren_callback)
+        return id_observer
 
     def destroy_timer(self, id):
         timer_id, observer_id = self._timers[id]

--- a/fury/window.py
+++ b/fury/window.py
@@ -320,7 +320,6 @@ class ShowManager(object):
             scene = Scene()
         self.scene = scene
         self.title = title
-        self.size = size
         self.png_magnify = png_magnify
         self.reset_camera = reset_camera
         self.order_transparent = order_transparent
@@ -552,6 +551,10 @@ class ShowManager(object):
         self.iren.GetRenderWindow().Finalize()
         self.iren.TerminateApp()
         self.timers.clear()
+
+    @property
+    def size(self):
+        return self.scene.GetSize()
 
 
 def show(scene, title='FURY', size=(300, 300), png_magnify=1,

--- a/fury/window.py
+++ b/fury/window.py
@@ -327,6 +327,7 @@ class ShowManager(object):
         self.interactor_style = interactor_style
         self.stereo = stereo
         self.timers = []
+        self._timer_observers_ids = []
 
         if self.reset_camera:
             self.scene.ResetCamera()
@@ -517,7 +518,9 @@ class ShowManager(object):
         self.window.Render()
 
     def add_timer_callback(self, repeat, duration, timer_callback):
-        self.iren.AddObserver("TimerEvent", timer_callback)
+        id_observer = self.iren.AddObserver(
+            "TimerEvent", timer_callback)
+        self._timer_observers_ids.append(id_observer)
 
         if repeat:
             timer_id = self.iren.CreateRepeatingTimer(duration)
@@ -527,6 +530,14 @@ class ShowManager(object):
 
     def add_iren_callback(self, iren_callback, event="MouseMoveEvent"):
         self.iren.AddObserver(event, iren_callback)
+
+    def destroy_timer_by_id(self, id):
+        """Destroy a timer by id.
+        """
+        self.iren.DestroyTimer(self.timers[id])
+        self.iren.RemoveObserver(self._timer_observers_ids[id])
+        del self.timers[id]
+        del self._timer_observers_ids[id]
 
     def destroy_timer(self, timer_id):
         self.iren.DestroyTimer(timer_id)

--- a/fury/window.py
+++ b/fury/window.py
@@ -602,13 +602,12 @@ class ShowManager(object):
 
     def exit(self):
         """Close window and terminate interactor."""
-        if is_osx and self.timers:
+        if is_osx and len(self._timers) > 0:
             # OSX seems to not destroy correctly timers
             # segfault 11 appears sometimes if we do not do it manually.
             self.destroy_timers()
         self.iren.GetRenderWindow().Finalize()
         self.iren.TerminateApp()
-        self.timers.clear()
 
     @property
     def size(self):

--- a/fury/window.py
+++ b/fury/window.py
@@ -515,7 +515,7 @@ class ShowManager(object):
 
         Parameters
         ----------
-        win_callback : function
+        win_callback : callables
             A callback function to call when a window event happens.
             The callback function must accept the following arguments:
             `ren`, `iren` and `obj`.
@@ -541,8 +541,8 @@ class ShowManager(object):
             If True, the timer will repeat.
         duration : int
             Timer duration in milliseconds.
-        timer_callback : function
-            Function to call when the timer expires.
+        timer_callback : callable
+            Callable to call when the timer expires.
 
         Returns
         -------

--- a/fury/window.py
+++ b/fury/window.py
@@ -511,13 +511,46 @@ class ShowManager(object):
 
     def add_window_callback(self, win_callback,
                             event=vtk.vtkCommand.ModifiedEvent):
-        """Add window callbacks."""
+        """Add window callbacks.
+
+        Parameters
+        ----------
+        win_callback : function
+            A callback function to call when a window event happens.
+            The callback function must accept the following arguments:
+            `ren`, `iren` and `obj`.
+        event : vtk event (default: `vtkCommand::ModifiedEvent`)
+            The event to watch for.
+
+        Returns
+        -------
+        id_observer : int
+            The observer id.
+
+        """
         id_observer = self.window.AddObserver(event, win_callback)
         self.window.Render()
         return id_observer
 
     def add_timer_callback(self, repeat, duration, timer_callback):
-        id_timer = len(self._timers.keys())
+        """Add a timer callback.
+
+        Parameters
+        ----------
+        repeat : bool
+            If True, the timer will repeat.
+        duration : int
+            Timer duration in milliseconds.
+        timer_callback : function
+            Function to call when the timer expires.
+
+        Returns
+        -------
+        id_timer : int
+            The timer ID.
+
+        """
+        timer_id = len(self._timers.keys())
         id_observer = self.iren.AddObserver(
             "TimerEvent", timer_callback)
 
@@ -525,20 +558,45 @@ class ShowManager(object):
             timer_id = self.iren.CreateRepeatingTimer(duration)
         else:
             timer_id = self.iren.CreateOneShotTimer(duration)
-        self._timers[id_timer] = (timer_id, id_observer)
-        return id_timer
+        self._timers[timer_id] = (timer_id, id_observer)
+        return timer_id
 
     def add_iren_callback(self, iren_callback, event="MouseMoveEvent"):
+        """Add a callback to a specific event on the interactor.
+
+        Parameters
+        ----------
+        iren_callback : function
+            A function that will be called when the specified event happens.
+        event : str
+            The event that will trigger the callback.
+
+        Returns
+        -------
+        id_observer : int
+            The id of the observer.
+
+        """
         id_observer = self.iren.AddObserver(event, iren_callback)
         return id_observer
 
     def destroy_timer(self, id):
+        """Destroy a timer given the id.
+
+        Parameters
+        ----------
+        id : int
+            Id of the timer to destroy.
+            Cames from the `add_timer_callback` method.
+
+        """
         timer_id, observer_id = self._timers[id]
         self.iren.DestroyTimer(timer_id)
         self.iren.RemoveObserver(observer_id)
         del self._timers[id]
 
     def destroy_timers(self):
+        """Destroy all the timers."""
         for id in self._timers.keys():
             self.destroy_timer(id)
 


### PR DESCRIPTION
Related with #483 
This PR adress two minor issues with the ShowManager object

## 1.  destroy timer behavior

ShowManager destroy_timer method destroys the timer without removing the callback related with the observer. Thus,
we lost the reference for the callback. Because of that, another timer event created after that will keep calling the
callback function with the missed reference.

## 2.  Size Window attribute
This is more trickly and usually happens on Windows. The vtk creates a window instance with a slightly different size.
Therefore, the following test can fail:
```python
size = (300, 400)
showm = ShowManager(size=size)
# code goes here
assert size[0] = showm.size[0] and size[1] == showm.size[1]
I noticed that bug running the tests of PR #437 on windows github actions.
```


This is an example which shows the bug solved by this PR. 

```python
from fury.window import ShowManager
from fury.actor import sphere
import numpy as np

centers = np.array([[1, 0,0]])
showm = ShowManager(size=(400, 400))
i1 = 0
i2 = 0

#check_bug = False  

def t1(_, __):
    global i1
    i1 += 1
    print(f'timer 1 event {i1}')

def t2(_, __):
    global i2
    i2 += 1
    print(f'timer 2 event {i2}')

id1 = showm.add_timer_callback(False, 1, t1)
print(id1, showm._timers)
id2 = showm.add_timer_callback(False, 2, t2)

print(id2, showm._timers)
showm.destroy_timer(id1)

showm.initialize()

color = np.array([0, 1, 0])
actor = sphere(centers, color)
showm.scene.add(actor)

showm.start()
#showm.render()
assert i1 == 0 # the code will fail here
```
After this PR, the above code should work whithout problems 

