### PR TITLE
Deprecate and rename label to vector_text

### DIFF
--- a/fury/actor.py
+++ b/fury/actor.py
@@ -12,7 +12,7 @@ from fury import layout
 from fury.actors.odf_slicer import OdfSlicerActor
 from fury.actors.peak import PeakActor
 from fury.colormap import colormap_lookup_table
-from fury.deprecator import deprecated_params
+from fury.deprecator import deprecated_params, deprecate_with_version
 from fury.io import load_image
 from fury.lib import (numpy_support, Transform, ImageData, PolyData, Matrix4x4,
                       ImageReslice, ImageActor, CellPicker, OutlineFilter,
@@ -2221,8 +2221,8 @@ def billboard(centers, colors=(0, 1, 0), scales=1, vs_dec=None, vs_impl=None,
     return sq_actor
 
 
-def label(text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.2),
-          color=(1, 1, 1)):
+def vector_text(text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.2),
+                color=(1, 1, 1)):
     """Create a label actor.
 
     This actor will always face the camera
@@ -2266,6 +2266,12 @@ def label(text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.2),
     texta.SetPosition(pos)
 
     return texta
+
+
+label = deprecate_with_version(message="Label function has been renamed"
+                                       "vector_text",
+                               since="0.7.1",
+                               until="0.9.0")(vector_text)
 
 
 def text_3d(text, position=(0, 0, 0), color=(1, 1, 1),

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -226,7 +226,7 @@ def test_contour_from_roi(interactive=False):
 
     npt.assert_equal(report.objects, 1)
     npt.assert_equal(report2.objects, 2)
-   
+
 
 @pytest.mark.skipif(skip_osx, reason="This test does not work on macOS + "
                                      "Travis. It works on a local machine"
@@ -804,8 +804,8 @@ def test_points(interactive=False):
 
 
 def test_labels(interactive=False):
-    npt.assert_warns(DeprecationWarning, actor.label, "hello")
-    text_actor = actor.vector_text("Hello")
+    npt.assert_warns(DeprecationWarning, actor.label, "FURY Rocks")
+    text_actor = actor.vector_text("FURY Rocks")
 
     scene = window.Scene()
     scene.add(text_actor)

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -804,7 +804,8 @@ def test_points(interactive=False):
 
 
 def test_labels(interactive=False):
-    text_actor = actor.label("Hello")
+    npt.assert_warns(DeprecationWarning, actor.label, "hello")
+    text_actor = actor.vector_text("Hello")
 
     scene = window.Scene()
     scene.add(text_actor)


### PR DESCRIPTION
This is a follow-up of [this comment](https://github.com/fury-gl/fury/pull/489#discussion_r719525377) from #489.

The goal is to:
- rename `label(...)` to `vector_text(...)`
- deprecate `label` and warn the users of the change