### PR TITLE
Snapshot flipping bug fix

### DIFF
--- a/fury/io.py
+++ b/fury/io.py
@@ -77,12 +77,11 @@ def load_image(filename, as_vtktype=False, use_pillow=True):
                                 0, 0)
             vtk_image.SetSpacing(1.0, 1.0, 1.0)
             vtk_image.SetOrigin(0.0, 0.0, 0.0)
-            arr_tmp = np.flipud(image)
-            arr_tmp = image
-            arr_tmp = arr_tmp.reshape(image.shape[1] * image.shape[0], depth)
-            arr_tmp = np.ascontiguousarray(arr_tmp, dtype=image.dtype)
+
+            image = image.reshape(image.shape[1] * image.shape[0], depth)
+            image = np.ascontiguousarray(image, dtype=image.dtype)
             vtk_array_type = numpy_support.get_vtk_array_type(image.dtype)
-            uchar_array = numpy_support.numpy_to_vtk(arr_tmp, deep=True,
+            uchar_array = numpy_support.numpy_to_vtk(image, deep=True,
                                                      array_type=vtk_array_type)
             vtk_image.GetPointData().SetScalars(uchar_array)
             image = vtk_image

--- a/fury/io.py
+++ b/fury/io.py
@@ -61,6 +61,7 @@ def load_image(filename, as_vtktype=False, use_pillow=True):
                     raise RuntimeError('Unknown image mode {}'
                                        .format(pil_image.mode))
                 image = np.asarray(pil_image)
+            image = np.flipud(image)
 
         if as_vtktype:
             if image.ndim not in [2, 3]:
@@ -77,6 +78,7 @@ def load_image(filename, as_vtktype=False, use_pillow=True):
             vtk_image.SetSpacing(1.0, 1.0, 1.0)
             vtk_image.SetOrigin(0.0, 0.0, 0.0)
             arr_tmp = np.flipud(image)
+            arr_tmp = image
             arr_tmp = arr_tmp.reshape(image.shape[1] * image.shape[0], depth)
             arr_tmp = np.ascontiguousarray(arr_tmp, dtype=image.dtype)
             vtk_array_type = numpy_support.get_vtk_array_type(image.dtype)
@@ -113,7 +115,7 @@ def load_image(filename, as_vtktype=False, use_pillow=True):
 
         components = vtk_array.GetNumberOfComponents()
         image = numpy_support.vtk_to_numpy(vtk_array).reshape(h, w, components)
-        image = np.flipud(image)
+        # image = np.flipud(image)
 
     if is_url:
         os.remove(filename)
@@ -161,6 +163,7 @@ def save_image(arr, filename, compression_quality=75,
                       format(filename, extension))
 
     if use_pillow:
+        arr = np.flipud(arr)    
         im = Image.fromarray(arr)
         im.save(filename, quality=compression_quality)
         return
@@ -169,7 +172,7 @@ def save_image(arr, filename, compression_quality=75,
         arr = arr[..., None]
 
     shape = arr.shape
-    arr = np.flipud(arr)
+    # arr = np.flipud(arr)
     if extension.lower() in ['.png', ]:
         arr = arr.astype(np.uint8)
     arr = arr.reshape((shape[1] * shape[0], shape[2]))

--- a/fury/io.py
+++ b/fury/io.py
@@ -115,7 +115,6 @@ def load_image(filename, as_vtktype=False, use_pillow=True):
 
         components = vtk_array.GetNumberOfComponents()
         image = numpy_support.vtk_to_numpy(vtk_array).reshape(h, w, components)
-        # image = np.flipud(image)
 
     if is_url:
         os.remove(filename)
@@ -163,7 +162,7 @@ def save_image(arr, filename, compression_quality=75,
                       format(filename, extension))
 
     if use_pillow:
-        arr = np.flipud(arr)    
+        arr = np.flipud(arr)
         im = Image.fromarray(arr)
         im.save(filename, quality=compression_quality)
         return
@@ -172,7 +171,6 @@ def save_image(arr, filename, compression_quality=75,
         arr = arr[..., None]
 
     shape = arr.shape
-    # arr = np.flipud(arr)
     if extension.lower() in ['.png', ]:
         arr = arr.astype(np.uint8)
     arr = arr.reshape((shape[1] * shape[0], shape[2]))

--- a/fury/tests/test_io.py
+++ b/fury/tests/test_io.py
@@ -152,7 +152,7 @@ def test_pillow():
 
         for opt1, opt2 in [(True, True), (False, True), (True, False),
                            (False, False)]:
-
+            print(opt1, opt2)
             save_image(data, fname_path, use_pillow=opt1)
             data2 = load_image(fname_path, use_pillow=opt2)
             npt.assert_array_almost_equal(data, data2)

--- a/fury/tests/test_io.py
+++ b/fury/tests/test_io.py
@@ -152,7 +152,6 @@ def test_pillow():
 
         for opt1, opt2 in [(True, True), (False, True), (True, False),
                            (False, False)]:
-            print(opt1, opt2)
             save_image(data, fname_path, use_pillow=opt1)
             data2 = load_image(fname_path, use_pillow=opt2)
             npt.assert_array_almost_equal(data, data2)

--- a/fury/window.py
+++ b/fury/window.py
@@ -890,7 +890,6 @@ def snapshot(scene, fname=None, size=(300, 300), offscreen=True,
     vtk_array = vtk_image.GetPointData().GetScalars()
     components = vtk_array.GetNumberOfComponents()
     arr = numpy_support.vtk_to_numpy(vtk_array).reshape(w, h, components)
-    
 
     if fname is None:
         return arr

--- a/fury/window.py
+++ b/fury/window.py
@@ -767,7 +767,7 @@ def record(scene=None, cam_pos=None, cam_focal=None, cam_view=None,
                                          .GetScalars())
         w, h, _ = renderLarge.GetOutput().GetDimensions()
         components = renderLarge.GetOutput().GetNumberOfScalarComponents()
-        arr = np.flipud(arr.reshape((h, w, components)))
+        arr = arr.reshape((h, w, components))
         save_image(arr, filename)
 
         ang = +az_ang
@@ -890,6 +890,7 @@ def snapshot(scene, fname=None, size=(300, 300), offscreen=True,
     vtk_array = vtk_image.GetPointData().GetScalars()
     components = vtk_array.GetNumberOfComponents()
     arr = numpy_support.vtk_to_numpy(vtk_array).reshape(w, h, components)
+    
 
     if fname is None:
         return arr


### PR DESCRIPTION
This PR fixes the issue reported in https://github.com/fury-gl/fury/issues/467

Basically, we were not flipping the images correctly in ``save_image`` and ``load_image``. ``save_image`` was called by ``snapshot``.