### PR TITLE
Remove VTK_9_PLUS flag

### DIFF
--- a/fury/actors/peak.py
+++ b/fury/actors/peak.py
@@ -3,7 +3,7 @@ import numpy as np
 from fury.colormap import boys2rgb, colormap_lookup_table, orient2rgb
 from fury.shaders import attribute_to_actor, load, shader_to_actor
 from fury.utils import (apply_affine, numpy_to_vtk_colors, numpy_to_vtk_points)
-from fury.lib import (VTK_9_PLUS, numpy_support, Actor, Command, CellArray,
+from fury.lib import (numpy_support, Actor, Command, CellArray,
                       PolyDataMapper, PolyData, VTK_OBJECT, calldata_type)
 
 
@@ -328,42 +328,26 @@ def _points_to_vtk_cells(points, points_per_line=2):
 
     cell_array = CellArray()
 
-    if VTK_9_PLUS:
-        """
-        Connectivity is an array that contains the indices of the points that
-        need to be connected in the visualization. The indices start from 0.
-        """
-        connectivity = np.asarray(list(range(0, num_pnts)), dtype=int)
-        """
-        Offset is an array that contains the indices of the first point of
-        each line. The indices start from 0 and given the known geometry of
-        this actor the creation of this array requires a 2 points padding
-        between indices.
-        """
-        offset = np.asarray(list(range(0, num_pnts + 1, points_per_line)),
-                            dtype=int)
+    """
+    Connectivity is an array that contains the indices of the points that
+    need to be connected in the visualization. The indices start from 0.
+    """
+    connectivity = np.asarray(list(range(0, num_pnts)), dtype=int)
+    """
+    Offset is an array that contains the indices of the first point of
+    each line. The indices start from 0 and given the known geometry of
+    this actor the creation of this array requires a 2 points padding
+    between indices.
+    """
+    offset = np.asarray(list(range(0, num_pnts + 1, points_per_line)),
+                        dtype=int)
 
-        vtk_array_type = numpy_support.get_vtk_array_type(connectivity.dtype)
-        cell_array.SetData(
-            numpy_support.numpy_to_vtk(offset, deep=True,
-                                       array_type=vtk_array_type),
-            numpy_support.numpy_to_vtk(connectivity, deep=True,
-                                       array_type=vtk_array_type))
-    else:
-        connectivity = np.array([], dtype=int)
-        i_pos = 0
-        while i_pos < num_pnts:
-            e_pos = i_pos + points_per_line
-            """
-            In old versions of VTK (<9.0) the connectivity array should include
-            the length of each line and immediately after the indices of the
-            points in each line.
-            """
-            connectivity = np.append(connectivity, [points_per_line, i_pos,
-                                                    e_pos - 1])
-            i_pos = e_pos
-
-        cell_array.GetData().DeepCopy(numpy_support.numpy_to_vtk(connectivity))
+    vtk_array_type = numpy_support.get_vtk_array_type(connectivity.dtype)
+    cell_array.SetData(
+        numpy_support.numpy_to_vtk(offset, deep=True,
+                                    array_type=vtk_array_type),
+        numpy_support.numpy_to_vtk(connectivity, deep=True,
+                                    array_type=vtk_array_type))
 
     cell_array.SetNumberOfCells(num_cells)
     return cell_array

--- a/fury/actors/peak.py
+++ b/fury/actors/peak.py
@@ -345,9 +345,9 @@ def _points_to_vtk_cells(points, points_per_line=2):
     vtk_array_type = numpy_support.get_vtk_array_type(connectivity.dtype)
     cell_array.SetData(
         numpy_support.numpy_to_vtk(offset, deep=True,
-                                    array_type=vtk_array_type),
+                                   array_type=vtk_array_type),
         numpy_support.numpy_to_vtk(connectivity, deep=True,
-                                    array_type=vtk_array_type))
+                                   array_type=vtk_array_type))
 
     cell_array.SetNumberOfCells(num_cells)
     return cell_array

--- a/fury/lib.py
+++ b/fury/lib.py
@@ -30,7 +30,6 @@ from vtkmodules.util import numpy_support, colors
 from vtkmodules.util.misc import calldata_type
 
 
-VTK_9_PLUS = ccvtk.vtkVersion.GetVTKMajorVersion() >= 9
 VTK_VERSION = ccvtk.vtkVersion.GetVTKVersion()
 
 ##############################################################

--- a/fury/material.py
+++ b/fury/material.py
@@ -2,7 +2,7 @@ import warnings
 
 
 from fury.shaders import add_shader_callback, load, shader_to_actor
-from fury.lib import VTK_9_PLUS, VTK_OBJECT, calldata_type
+from fury.lib import VTK_OBJECT, calldata_type
 
 
 def manifest_pbr(actor, metallicity=0, roughness=.5):
@@ -19,11 +19,6 @@ def manifest_pbr(actor, metallicity=0, roughness=.5):
         be between 0.0 and 1.0.
 
     """
-    if not VTK_9_PLUS:
-        warnings.warn('Your PBR effect cannot be apply due to VTK version. '
-                      'Please upgrade your VTK version (should be >= 9.0.0).')
-        return
-
     try:
         prop = actor.GetProperty()
         try:

--- a/fury/shaders/base.py
+++ b/fury/shaders/base.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 from fury import enable_warnings
-from fury.lib import (VTK_9_PLUS, numpy_support, Command, VTK_OBJECT,
+from fury.lib import (numpy_support, Command, VTK_OBJECT,
                       calldata_type, DataObject, Shader)
 
 SHADERS_TYPE = {"vertex": Shader.Vertex,
@@ -109,7 +109,7 @@ def shader_to_actor(actor, shader_type, impl_code="", decl_code="",
         error_msg = "\n\n--- DEBUG: THIS LINE GENERATES AN ERROR ---\n\n"
         impl_code += error_msg
 
-    sp = actor.GetShaderProperty() if VTK_9_PLUS else actor.GetMapper()
+    sp = actor.GetShaderProperty()
 
     sp.AddShaderReplacement(shader_type, block_dec, replace_first,
                             decl_code, replace_all)
@@ -142,7 +142,7 @@ def replace_shader_in_actor(actor, shader_type, code):
         msg += ', '.join(function_name.keys())
         raise ValueError(msg)
 
-    sp = actor.GetShaderProperty() if VTK_9_PLUS else actor.GetMapper()
+    sp = actor.GetShaderProperty()
     getattr(sp, function)(code)
 
 

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -12,7 +12,7 @@ from fury import shaders
 from fury import actor, window, primitive as fp
 from fury.actor import grid
 from fury.decorators import skip_osx, skip_win
-from fury.utils import shallow_copy, rotate, VTK_9_PLUS
+from fury.utils import shallow_copy, rotate
 from fury.testing import assert_greater, assert_greater_equal
 from fury.primitive import prim_sphere
 
@@ -337,7 +337,7 @@ def test_streamtube_and_line_actors():
 
     c3 = actor.line(lines, colors, depth_cue=True, fake_tube=True)
 
-    shader_obj = c3.GetShaderProperty() if VTK_9_PLUS else c3.GetMapper()
+    shader_obj = c3.GetShaderProperty()
     mapper_code = shader_obj.GetGeometryShaderCode()
     file_code = shaders.load("line.geom")
     npt.assert_equal(mapper_code, file_code)

--- a/fury/tests/test_deprecator.py
+++ b/fury/tests/test_deprecator.py
@@ -267,7 +267,8 @@ def test_deprecated_argument_multi_deprecation():
         npt.assert_equal(test2(x=1, y=2, z=3), (1, 2, 3))
     npt.assert_equal(len(w), 6)
 
-    npt.assert_raises(TypeError, test, x=1, y=2, z=3, b=3)
+    with pytest.warns(ArgsDeprecationWarning) as w:
+        npt.assert_raises(TypeError, test, x=1, y=2, z=3, b=3)
     npt.assert_raises(TypeError, test, x=1, y=2, z=3, a=3)
 
 

--- a/fury/tests/test_material.py
+++ b/fury/tests/test_material.py
@@ -3,7 +3,6 @@ from tempfile import TemporaryDirectory
 from fury import actor, material, window
 from fury.io import load_image
 from fury.optpkg import optional_package
-from fury.lib import VTK_9_PLUS
 
 
 import numpy as np
@@ -19,16 +18,6 @@ def test_fake():
     pass
 
 
-@pytest.mark.skipif(VTK_9_PLUS, reason="Requires VTK < 9.0.0")
-def test_manifest_pbr_vtk_less_than_9():
-    center = np.array([[0, 0, 0]])
-
-    # Test non-supported material
-    test_actor = actor.square(center, directions=(1, 1, 1), colors=(0, 0, 1))
-    npt.assert_warns(UserWarning, material.manifest_pbr, test_actor)
-
-
-# @pytest.mark.skipif(not VTK_9_PLUS, reason="Requires VTK >= 9.0.0")
 @pytest.mark.skipif(True, reason="Under investigation")
 def test_manifest_pbr_vtk_great_than_9():
     # Test non-supported property

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -141,9 +141,9 @@ def numpy_to_vtk_cells(data, is_coords=True):
     vtk_array_type = numpy_support.get_vtk_array_type(connectivity.dtype)
     cell_array.SetData(
         numpy_support.numpy_to_vtk(offset, deep=True,
-                                    array_type=vtk_array_type),
+                                   array_type=vtk_array_type),
         numpy_support.numpy_to_vtk(connectivity, deep=True,
-                                    array_type=vtk_array_type))
+                                   array_type=vtk_array_type))
 
     cell_array.SetNumberOfCells(nb_cells)
     return cell_array


### PR DESCRIPTION
Currently, we are depending only on VTK 9.1.0 so this flag is not necessary anymore.