### PR TITLE
Fixed #550 : Added necessary allignment between glyph creation and ac…

### DIFF
--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1690,7 +1690,7 @@ def disk(centers, directions, colors, rinner=0.3,
 
     disk_actor = repeat_sources(centers=centers, colors=colors,
                                 directions=directions, source=src,
-                                vertices=vertices, faces=None,
+                                vertices=vertices, faces=faces,
                                 orientation=rotate)
 
     return disk_actor

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1627,7 +1627,7 @@ def cylinder(centers, directions, colors, radius=0.05, heights=1,
 
 
 def disk(centers, directions, colors, rinner=0.3,
-         router=0.7, cresolution=6, rresolution=2, vertices=None, faces=None):
+         router=0.7, cresolution=6, rresolution=2, vertices=None):
     """Visualize one or many disks with different features.
 
     Parameters
@@ -1641,14 +1641,11 @@ def disk(centers, directions, colors, rinner=0.3,
     rinner : float or ndarray (N,) or tuple (N,)
         disk inner radius, default: 0.3
     router : float or ndarray (N,) or tuple (N,)
-        disk inner radius, default: 0.5
+        disk outer radius, default: 0.5
     cresolution: int, default: 6
         Number of facets used to define perimeter of disk.
     rresolution: int, default: 2
         Number of facets used radially.
-    faces : ndarray, shape (M, 3)
-        If faces is None then a disk is created based on theta and phi angles
-        If not then an actor is created with the provided vertices and faces.
 
     Returns
     -------
@@ -1663,23 +1660,20 @@ def disk(centers, directions, colors, rinner=0.3,
     >>> dirs = np.random.rand(5, 3)
     >>> colors = np.random.rand(5, 4)
     >>> actor = actor.disk(centers, dirs, colors, 
-    >>>                    rinner=.1, router=.8, cresolution=10)
+    >>>                    rinner=.1, router=.8, cresolution=30)
     >>> scene.add(actor)
     >>> window.show(scene)
     """
-    if faces is None:
-        src = DiskSource()
-        src.SetCircumferentialResolution(cresolution)
-        src.SetRadialResolution(rresolution)
-        src.SetInnerRadius(rinner)
-        src.SetOuterRadius(router)
-        rotate = np.array([[0,0,-1,0],[0,1,0,0],[1,0,0,0],[0,0,0,1]])
-    else:
-        src = rotate = None
+    src = DiskSource()
+    src.SetCircumferentialResolution(cresolution)
+    src.SetRadialResolution(rresolution)
+    src.SetInnerRadius(rinner)
+    src.SetOuterRadius(router)
+    rotate = np.array([[0,0,-1,0],[0,1,0,0],[1,0,0,0],[0,0,0,1]])
 
     disk_actor = repeat_sources(centers=centers, colors=colors,
                                     directions=directions, source=src,
-                                    vertices=vertices, faces=faces, orientation=rotate)
+                                    vertices=vertices, faces=None, orientation=rotate)
 
     return disk_actor
 

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1619,18 +1619,20 @@ def cylinder(centers, directions, colors, radius=0.05, heights=1,
                            [0, 0, 1, 0],
                            [0, 0, 0, 1]])
     else:
-        src = rotate = None
+        src = None
+        rotate = None
 
     cylinder_actor = repeat_sources(centers=centers, colors=colors,
                                     directions=directions,
                                     active_scalars=heights, source=src,
-                                    vertices=vertices, faces=faces, orientation=rotate)
+                                    vertices=vertices, faces=faces,
+                                    orientation=rotate)
 
     return cylinder_actor
 
 
 def disk(centers, directions, colors, rinner=0.3,
-         router=0.7, cresolution=6, rresolution=2, vertices=None):
+         router=0.7, cresolution=6, rresolution=2, vertices=None, faces=None):
     """Visualize one or many disks with different features.
 
     Parameters
@@ -1649,10 +1651,15 @@ def disk(centers, directions, colors, rinner=0.3,
         Number of facets used to define perimeter of disk.
     rresolution: int, default: 2
         Number of facets used radially.
+    vertices : ndarray, shape (N, 3)
+        The point cloud defining the disk.
+    faces : ndarray, shape (M, 3)
+        If faces is None then a disk is created based on theta and phi angles
+        If not then a disk is created with the provided vertices and faces.
 
     Returns
     -------
-    cylinder_actor: Actor
+    disk_actor: Actor
 
     Examples
     --------
@@ -1667,19 +1674,24 @@ def disk(centers, directions, colors, rinner=0.3,
     >>> scene.add(actor)
     >>> window.show(scene)
     """
-    src = DiskSource()
-    src.SetCircumferentialResolution(cresolution)
-    src.SetRadialResolution(rresolution)
-    src.SetInnerRadius(rinner)
-    src.SetOuterRadius(router)
-    rotate = np.array([[0, 0, -1, 0],
-                       [0, 1, 0, 0],
-                       [1, 0, 0, 0],
-                       [0, 0, 0, 1]])
+    if faces is None:
+        src = DiskSource()
+        src.SetCircumferentialResolution(cresolution)
+        src.SetRadialResolution(rresolution)
+        src.SetInnerRadius(rinner)
+        src.SetOuterRadius(router)
+        rotate = np.array([[0, 0, -1, 0],
+                           [0, 1, 0, 0],
+                           [1, 0, 0, 0],
+                           [0, 0, 0, 1]])
+    else:
+        src = None
+        rotate = None
 
     disk_actor = repeat_sources(centers=centers, colors=colors,
                                 directions=directions, source=src,
-                                vertices=vertices, faces=None, orientation=rotate)
+                                vertices=vertices, faces=None,
+                                orientation=rotate)
 
     return disk_actor
 

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1643,9 +1643,9 @@ def disk(centers, directions, colors, rinner=0.3,
         The orientation vector of the disk.
     colors : ndarray (N,3) or (N, 4) or tuple (3,) or tuple (4,)
         RGB or RGBA (for opacity) R, G, B and A should be at the range [0, 1]
-    rinner : float or ndarray (N,) or tuple (N,)
+    rinner : float
         disk inner radius, default: 0.3
-    router : float or ndarray (N,) or tuple (N,)
+    router : float
         disk outer radius, default: 0.5
     cresolution: int, default: 6
         Number of facets used to define perimeter of disk.

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1614,7 +1614,10 @@ def cylinder(centers, directions, colors, radius=0.05, heights=1,
         src.SetCapping(capped)
         src.SetResolution(resolution)
         src.SetRadius(radius)
-        rotate = np.array([[0,1,0,0],[-1,0,0,0],[0,0,1,0],[0,0,0,1]])
+        rotate = np.array([[0, 1, 0, 0],
+                           [-1, 0, 0, 0],
+                           [0, 0, 1, 0],
+                           [0, 0, 0, 1]])
     else:
         src = rotate = None
 
@@ -1659,7 +1662,7 @@ def disk(centers, directions, colors, rinner=0.3,
     >>> centers = np.random.rand(5, 3)
     >>> dirs = np.random.rand(5, 3)
     >>> colors = np.random.rand(5, 4)
-    >>> actor = actor.disk(centers, dirs, colors, 
+    >>> actor = actor.disk(centers, dirs, colors,
     >>>                    rinner=.1, router=.8, cresolution=30)
     >>> scene.add(actor)
     >>> window.show(scene)
@@ -1669,11 +1672,14 @@ def disk(centers, directions, colors, rinner=0.3,
     src.SetRadialResolution(rresolution)
     src.SetInnerRadius(rinner)
     src.SetOuterRadius(router)
-    rotate = np.array([[0,0,-1,0],[0,1,0,0],[1,0,0,0],[0,0,0,1]])
+    rotate = np.array([[0, 0, -1, 0],
+                       [0, 1, 0, 0],
+                       [1, 0, 0, 0],
+                       [0, 0, 0, 1]])
 
     disk_actor = repeat_sources(centers=centers, colors=colors,
-                                    directions=directions, source=src,
-                                    vertices=vertices, faces=None, orientation=rotate)
+                                directions=directions, source=src,
+                                vertices=vertices, faces=None, orientation=rotate)
 
     return disk_actor
 

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -22,7 +22,7 @@ from fury.lib import (numpy_support, Transform, ImageData, PolyData, Matrix4x4,
                       PolyDataNormals, Assembly, LODActor, VTK_UNSIGNED_CHAR,
                       PolyDataMapper2D, ScalarBarActor, PolyVertex, CellArray,
                       UnstructuredGrid, DataSetMapper, ConeSource, ArrowSource,
-                      SphereSource, CylinderSource, TexturedSphereSource,
+                      SphereSource, CylinderSource, DiskSource, TexturedSphereSource,
                       Texture, FloatArray, VTK_TEXT_LEFT, VTK_TEXT_RIGHT,
                       VTK_TEXT_BOTTOM, VTK_TEXT_TOP, VTK_TEXT_CENTERED,
                       TexturedActor2D, TextureMapToPlane, TextActor3D,
@@ -1609,19 +1609,79 @@ def cylinder(centers, directions, colors, radius=0.05, heights=1,
     >>> # window.show(scene)
 
     """
-    src = CylinderSource() if faces is None else None
-
-    if src is not None:
+    if faces is None:
+        src = CylinderSource()
         src.SetCapping(capped)
         src.SetResolution(resolution)
         src.SetRadius(radius)
+        rotate = np.array([[0,1,0,0],[-1,0,0,0],[0,0,1,0],[0,0,0,1]])
+    else:
+        src = rotate = None
 
     cylinder_actor = repeat_sources(centers=centers, colors=colors,
                                     directions=directions,
                                     active_scalars=heights, source=src,
-                                    vertices=vertices, faces=faces)
+                                    vertices=vertices, faces=faces, orientation=rotate)
 
     return cylinder_actor
+
+
+def disk(centers, directions, colors, rinner=0.3,
+         router=0.7, cresolution=6, rresolution=2, vertices=None, faces=None):
+    """Visualize one or many disks with different features.
+
+    Parameters
+    ----------
+    centers : ndarray, shape (N, 3)
+        Disk positions
+    directions : ndarray, shape (N, 3)
+        The orientation vector of the disk.
+    colors : ndarray (N,3) or (N, 4) or tuple (3,) or tuple (4,)
+        RGB or RGBA (for opacity) R, G, B and A should be at the range [0, 1]
+    rinner : float or ndarray (N,) or tuple (N,)
+        disk inner radius, default: 0.3
+    router : float or ndarray (N,) or tuple (N,)
+        disk inner radius, default: 0.5
+    cresolution: int, default: 6
+        Number of facets used to define perimeter of disk.
+    rresolution: int, default: 2
+        Number of facets used radially.
+    faces : ndarray, shape (M, 3)
+        If faces is None then a disk is created based on theta and phi angles
+        If not then an actor is created with the provided vertices and faces.
+
+    Returns
+    -------
+    cylinder_actor: Actor
+
+    Examples
+    --------
+    >>> from fury import window, actor
+    >>> import numpy as np
+    >>> scene = window.Scene()
+    >>> centers = np.random.rand(5, 3)
+    >>> dirs = np.random.rand(5, 3)
+    >>> colors = np.random.rand(5, 4)
+    >>> actor = actor.disk(centers, dirs, colors, 
+    >>>                    rinner=.1, router=.8, cresolution=10)
+    >>> scene.add(actor)
+    >>> window.show(scene)
+    """
+    if faces is None:
+        src = DiskSource()
+        src.SetCircumferentialResolution(cresolution)
+        src.SetRadialResolution(rresolution)
+        src.SetInnerRadius(rinner)
+        src.SetOuterRadius(router)
+        rotate = np.array([[0,0,-1,0],[0,1,0,0],[1,0,0,0],[0,0,0,1]])
+    else:
+        src = rotate = None
+
+    disk_actor = repeat_sources(centers=centers, colors=colors,
+                                    directions=directions, source=src,
+                                    vertices=vertices, faces=faces, orientation=rotate)
+
+    return disk_actor
 
 
 def square(centers, directions=(1, 0, 0), colors=(1, 0, 0), scales=1):

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1647,10 +1647,10 @@ def disk(centers, directions, colors, rinner=0.3,
         disk inner radius, default: 0.3
     router : float
         disk outer radius, default: 0.5
-    cresolution: int, default: 6
-        Number of facets used to define perimeter of disk.
-    rresolution: int, default: 2
-        Number of facets used radially.
+    cresolution: int, optional
+        Number of facets used to define perimeter of disk, default: 6
+    rresolution: int, optional
+        Number of facets used radially, default: 2
     vertices : ndarray, shape (N, 3)
         The point cloud defining the disk.
     faces : ndarray, shape (M, 3)

--- a/fury/lib.py
+++ b/fury/lib.py
@@ -124,6 +124,7 @@ Glyph3D = fcvtk.vtkGlyph3D
 ##############################################################
 #  vtkFiltersGeneral Module
 SplineFilter = fgvtk.vtkSplineFilter
+TransformPolyDataFilter = fgvtk.vtkTransformPolyDataFilter
 
 ##############################################################
 #  vtkFiltersHybrid Module

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -921,9 +921,18 @@ def test_advanced_geometry_actor(interactive=False):
     xyz = np.array([[0, 0, 0], [50, 0, 0], [100, 0, 0]])
     dirs = np.array([[0, 1, 0], [1, 0, 0], [0, 0.5, 0.5]])
 
+    rot_Y = np.array([[0, 0, -1, 0],
+                      [0, 1, 0, 0],
+                      [1, 0, 0, 0],
+                      [0, 0, 0, 1]])
+    rot_Z = np.array([[0, 1, 0, 0],
+                      [-1, 0, 0, 0],
+                      [0, 0, 1, 0],
+                      [0, 0, 0, 1]])
     actor_list = [[actor.cone, {'directions': dirs, 'resolution': 8}],
                   [actor.arrow, {'directions': dirs, 'resolution': 9}],
-                  [actor.cylinder, {'directions': dirs}]]
+                  [actor.cylinder, {'directions': dirs, 'orientation':rot_Z}],
+                  [actor.disk, {'directions': dirs, 'orientation':rot_Y}]]
 
     scene = window.Scene()
 

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -932,8 +932,12 @@ def test_advanced_geometry_actor(interactive=False):
         colors = np.array([[1, 0, 0, 0.3], [0, 1, 0, 0.4], [1, 1, 0, 1]])
         heights = np.array([5, 7, 10])
 
-        geom_actor = act_func(centers=xyz, heights=heights, colors=colors[:],
-                              **extra_args)
+        if act_func == actor.disk:
+          geom_actor = act_func(centers=xyz, colors=colors[:],
+                                **extra_args)
+        else:
+          geom_actor = act_func(centers=xyz, heights=heights, colors=colors[:],
+                                **extra_args)
         scene.add(geom_actor)
 
         if interactive:

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -919,7 +919,7 @@ def test_basic_geometry_actor(interactive=False):
 
 def test_advanced_geometry_actor(interactive=False):
     xyz = np.array([[0, 0, 0], [50, 0, 0], [100, 0, 0]])
-    dirs = np.array([[0.5, 0.5, 0], [0.5, 0, 0.5], [0, 0.5, 0.5]])
+    dirs = np.array([[0.5, 0.5, 0.5], [0.5, 0, 0.5], [0, 0.5, 0.5]])
 
     actor_list = [[actor.cone, {'directions': dirs, 'resolution': 8}],
                   [actor.arrow, {'directions': dirs, 'resolution': 9}],

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -930,14 +930,15 @@ def test_advanced_geometry_actor(interactive=False):
 
     for act_func, extra_args in actor_list:
         colors = np.array([[1, 0, 0, 0.3], [0, 1, 0, 0.4], [1, 1, 0, 1]])
-        heights = np.array([5, 7, 10])
 
         if act_func == actor.disk:
-          geom_actor = act_func(centers=xyz, colors=colors[:],
-                                **extra_args)
+            geom_actor = act_func(centers=xyz, colors=colors[:], rinner=4,
+                                  router=8, rresolution=2, cresolution=10,
+                                  **extra_args)
         else:
-          geom_actor = act_func(centers=xyz, heights=heights, colors=colors[:],
-                                **extra_args)
+            heights = np.array([5, 7, 10])
+            geom_actor = act_func(centers=xyz, heights=heights, colors=colors[:],
+                                  **extra_args)
         scene.add(geom_actor)
 
         if interactive:

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -919,7 +919,7 @@ def test_basic_geometry_actor(interactive=False):
 
 def test_advanced_geometry_actor(interactive=False):
     xyz = np.array([[0, 0, 0], [50, 0, 0], [100, 0, 0]])
-    dirs = np.array([[0, 1, 0], [1, 0, 0], [0, 0.5, 0.5]])
+    dirs = np.array([[0.5, 0.5, 0], [0.5, 0, 0.5], [0, 0.5, 0.5]])
 
     actor_list = [[actor.cone, {'directions': dirs, 'resolution': 8}],
                   [actor.arrow, {'directions': dirs, 'resolution': 9}],

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -950,8 +950,12 @@ def test_advanced_geometry_actor(interactive=False):
         heights = 10
 
         scene.clear()
-        geom_actor = act_func(centers=xyz[:, :3], heights=10, colors=colors[:],
-                              **extra_args)
+        if act_func == actor.disk:
+          geom_actor = act_func(centers=xyz[:, :3], colors=colors[:],
+                                **extra_args)
+        else:
+          geom_actor = act_func(centers=xyz[:, :3], heights=10, colors=colors[:],
+                                **extra_args)
         scene.add(geom_actor)
 
         if interactive:

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -921,24 +921,20 @@ def test_advanced_geometry_actor(interactive=False):
     xyz = np.array([[0, 0, 0], [50, 0, 0], [100, 0, 0]])
     dirs = np.array([[0.5, 0.5, 0.5], [0.5, 0, 0.5], [0, 0.5, 0.5]])
 
-    actor_list = [[actor.cone, {'directions': dirs, 'resolution': 8}],
-                  [actor.arrow, {'directions': dirs, 'resolution': 9}],
-                  [actor.cylinder, {'directions': dirs}],
-                  [actor.disk, {'directions': dirs}]]
+    heights = np.array([5, 7, 10])
+
+    actor_list = [[actor.cone, {'heights': heights, 'resolution': 8}],
+                  [actor.arrow, {'heights': heights, 'resolution': 9}],
+                  [actor.cylinder, {'heights': heights, 'resolution': 10}],
+                  [actor.disk, {'rinner': 4, 'router': 8, 'rresolution': 2,
+                                'cresolution': 2}]]
 
     scene = window.Scene()
 
     for act_func, extra_args in actor_list:
         colors = np.array([[1, 0, 0, 0.3], [0, 1, 0, 0.4], [1, 1, 0, 1]])
 
-        if act_func == actor.disk:
-            geom_actor = act_func(centers=xyz, colors=colors[:], rinner=4,
-                                  router=8, rresolution=2, cresolution=10,
-                                  **extra_args)
-        else:
-            heights = np.array([5, 7, 10])
-            geom_actor = act_func(centers=xyz, heights=heights, colors=colors[:],
-                                  **extra_args)
+        geom_actor = act_func(xyz, dirs, colors, **extra_args)
         scene.add(geom_actor)
 
         if interactive:
@@ -947,16 +943,11 @@ def test_advanced_geometry_actor(interactive=False):
         report = window.analyze_snapshot(arr, colors=colors)
         npt.assert_equal(report.objects, 3)
 
-        colors = np.array([1.0, 1.0, 1.0, 1.0])
-        heights = 10
-
         scene.clear()
-        if act_func == actor.disk:
-          geom_actor = act_func(centers=xyz[:, :3], colors=colors[:],
-                                **extra_args)
-        else:
-          geom_actor = act_func(centers=xyz[:, :3], heights=10, colors=colors[:],
-                                **extra_args)
+
+        colors = np.array([1.0, 1.0, 1.0, 1.0])
+
+        geom_actor = act_func(xyz, dirs, colors, **extra_args)
         scene.add(geom_actor)
 
         if interactive:

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -921,18 +921,10 @@ def test_advanced_geometry_actor(interactive=False):
     xyz = np.array([[0, 0, 0], [50, 0, 0], [100, 0, 0]])
     dirs = np.array([[0, 1, 0], [1, 0, 0], [0, 0.5, 0.5]])
 
-    rot_Y = np.array([[0, 0, -1, 0],
-                      [0, 1, 0, 0],
-                      [1, 0, 0, 0],
-                      [0, 0, 0, 1]])
-    rot_Z = np.array([[0, 1, 0, 0],
-                      [-1, 0, 0, 0],
-                      [0, 0, 1, 0],
-                      [0, 0, 0, 1]])
     actor_list = [[actor.cone, {'directions': dirs, 'resolution': 8}],
                   [actor.arrow, {'directions': dirs, 'resolution': 9}],
-                  [actor.cylinder, {'directions': dirs, 'orientation':rot_Z}],
-                  [actor.disk, {'directions': dirs, 'orientation':rot_Y}]]
+                  [actor.cylinder, {'directions': dirs}],
+                  [actor.disk, {'directions': dirs}]]
 
     scene = window.Scene()
 

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -750,12 +750,8 @@ def repeat_sources(centers, colors, active_scalars=1., directions=None,
     glyph = Glyph3D()
     if faces is None:
         if orientation is not None:
-            matrix = Matrix4x4()
-            for i in range(4):
-                for j in range(4):
-                    matrix.SetElement(i, j, orientation[i, j])
             transform = Transform()
-            transform.SetMatrix(matrix)
+            transform.SetMatrix(numpy_to_vtk_matrix(orientation))
             rtrans = TransformPolyDataFilter()
             rtrans.SetInputConnection(source.GetOutputPort())
             rtrans.SetTransform(transform)

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -706,7 +706,7 @@ def get_actor_from_primitive(vertices, triangles, colors=None,
 
 
 def repeat_sources(centers, colors, active_scalars=1., directions=None,
-                   source=None, vertices=None, faces=None):
+                   source=None, vertices=None, faces=None, orientation=None):
     """Transform a vtksource to glyph."""
     if source is None and faces is None:
         raise IOError("A source or faces should be defined")
@@ -752,11 +752,18 @@ def repeat_sources(centers, colors, active_scalars=1., directions=None,
         glyph.SetSourceConnection(source.GetOutputPort())
     else:
         glyph.SetSourceData(polydata_geom)
-
     glyph.SetInputData(polydata_centers)
     glyph.SetOrient(True)
     glyph.SetScaleModeToScaleByScalar()
     glyph.SetVectorModeToUseVector()
+    if orientation is not None:
+        matrix = Matrix4x4()
+        for i in range(4):
+            for j in range(4):
+                matrix.SetElement(i, j, orientation[i,j])
+        transform = Transform()
+        transform.SetMatrix(matrix)
+        glyph.SetSourceTransform(transform)
     glyph.Update()
 
     mapper = PolyDataMapper()

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -6,7 +6,7 @@ from fury.lib import (numpy_support, PolyData, ImageData, Points,
                       CellArray, PolyDataNormals, Actor, PolyDataMapper,
                       Matrix4x4, Matrix3x3, Glyph3D, VTK_DOUBLE, VTK_FLOAT,
                       Transform, AlgorithmOutput, VTK_INT, VTK_UNSIGNED_CHAR,
-                      IdTypeArray)
+                      TransformPolyDataFilter, IdTypeArray)
 
 
 def remove_observer_from_actor(actor, id):
@@ -749,6 +749,17 @@ def repeat_sources(centers, colors, active_scalars=1., directions=None,
 
     glyph = Glyph3D()
     if faces is None:
+        if orientation is not None:
+            matrix = Matrix4x4()
+            for i in range(4):
+                for j in range(4):
+                    matrix.SetElement(i, j, orientation[i, j])
+            transform = Transform()
+            transform.SetMatrix(matrix)
+            rtrans = TransformPolyDataFilter()
+            rtrans.SetInputConnection(source.GetOutputPort())
+            rtrans.SetTransform(transform)
+            source = rtrans
         glyph.SetSourceConnection(source.GetOutputPort())
     else:
         glyph.SetSourceData(polydata_geom)
@@ -756,14 +767,6 @@ def repeat_sources(centers, colors, active_scalars=1., directions=None,
     glyph.SetOrient(True)
     glyph.SetScaleModeToScaleByScalar()
     glyph.SetVectorModeToUseVector()
-    if orientation is not None:
-        matrix = Matrix4x4()
-        for i in range(4):
-            for j in range(4):
-                matrix.SetElement(i, j, orientation[i, j])
-        transform = Transform()
-        transform.SetMatrix(matrix)
-        glyph.SetSourceTransform(transform)
     glyph.Update()
 
     mapper = PolyDataMapper()

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -760,7 +760,7 @@ def repeat_sources(centers, colors, active_scalars=1., directions=None,
         matrix = Matrix4x4()
         for i in range(4):
             for j in range(4):
-                matrix.SetElement(i, j, orientation[i,j])
+                matrix.SetElement(i, j, orientation[i, j])
         transform = Transform()
         transform.SetMatrix(matrix)
         glyph.SetSourceTransform(transform)


### PR DESCRIPTION
Added necessary alignment between glyph creation and actor mapping. If a vtkSource is not aligned with the X axis, provide 4x4 orientation matrix to repeat_sources to align.

This is necessary for the Cylinder object, which is aligned to the global Y axis in vtk. Without the correct orientation of the glyph, rotation into the z plane is not possible.

Also, the DiskSource is default aligned to the Z axis in vtk.
A similar routine for plotting discs (i.e. another use case for this patch) is included in actor.py.

Cylinder's with same specified direction as Arrows, original:
<img width="687" alt="Screen Shot 2022-03-03 at 5 28 53 PM" src="https://user-images.githubusercontent.com/5353971/156684314-6c0941d6-96cc-4816-940c-f7ae7b51ec61.png">

Trivial implementation of Disks (Non-functional in a similar manner to cylinders):
<img width="803" alt="Screen Shot 2022-03-03 at 5 35 00 PM" src="https://user-images.githubusercontent.com/5353971/156684516-6cefe038-078c-4903-9c66-1a7a7129b223.png">

Correct implementation of Cylinders and Disks:
<img width="606" alt="Screen Shot 2022-03-03 at 5 26 16 PM" src="https://user-images.githubusercontent.com/5353971/156684572-99702408-9d0d-4402-a81f-66b610bb3ca9.png">

