### PR TITLE
Fixed the rotation matrix in repeat_primitive.

### DIFF
--- a/fury/actor.py
+++ b/fury/actor.py
@@ -22,7 +22,7 @@ from fury.lib import (numpy_support, Transform, ImageData, PolyData, Matrix4x4,
                       PolyDataNormals, Assembly, LODActor, VTK_UNSIGNED_CHAR,
                       PolyDataMapper2D, ScalarBarActor, PolyVertex, CellArray,
                       UnstructuredGrid, DataSetMapper, ConeSource, ArrowSource,
-                      SphereSource, CylinderSource, TexturedSphereSource,
+                      SphereSource, CylinderSource, DiskSource, TexturedSphereSource,
                       Texture, FloatArray, VTK_TEXT_LEFT, VTK_TEXT_RIGHT,
                       VTK_TEXT_BOTTOM, VTK_TEXT_TOP, VTK_TEXT_CENTERED,
                       TexturedActor2D, TextureMapToPlane, TextActor3D,
@@ -1609,19 +1609,91 @@ def cylinder(centers, directions, colors, radius=0.05, heights=1,
     >>> # window.show(scene)
 
     """
-    src = CylinderSource() if faces is None else None
-
-    if src is not None:
+    if faces is None:
+        src = CylinderSource()
         src.SetCapping(capped)
         src.SetResolution(resolution)
         src.SetRadius(radius)
+        rotate = np.array([[0, 1, 0, 0],
+                           [-1, 0, 0, 0],
+                           [0, 0, 1, 0],
+                           [0, 0, 0, 1]])
+    else:
+        src = None
+        rotate = None
 
     cylinder_actor = repeat_sources(centers=centers, colors=colors,
                                     directions=directions,
                                     active_scalars=heights, source=src,
-                                    vertices=vertices, faces=faces)
+                                    vertices=vertices, faces=faces,
+                                    orientation=rotate)
 
     return cylinder_actor
+
+
+def disk(centers, directions, colors, rinner=0.3,
+         router=0.7, cresolution=6, rresolution=2, vertices=None, faces=None):
+    """Visualize one or many disks with different features.
+
+    Parameters
+    ----------
+    centers : ndarray, shape (N, 3)
+        Disk positions
+    directions : ndarray, shape (N, 3)
+        The orientation vector of the disk.
+    colors : ndarray (N,3) or (N, 4) or tuple (3,) or tuple (4,)
+        RGB or RGBA (for opacity) R, G, B and A should be at the range [0, 1]
+    rinner : float
+        disk inner radius, default: 0.3
+    router : float
+        disk outer radius, default: 0.5
+    cresolution: int, optional
+        Number of facets used to define perimeter of disk, default: 6
+    rresolution: int, optional
+        Number of facets used radially, default: 2
+    vertices : ndarray, shape (N, 3)
+        The point cloud defining the disk.
+    faces : ndarray, shape (M, 3)
+        If faces is None then a disk is created based on theta and phi angles
+        If not then a disk is created with the provided vertices and faces.
+
+    Returns
+    -------
+    disk_actor: Actor
+
+    Examples
+    --------
+    >>> from fury import window, actor
+    >>> import numpy as np
+    >>> scene = window.Scene()
+    >>> centers = np.random.rand(5, 3)
+    >>> dirs = np.random.rand(5, 3)
+    >>> colors = np.random.rand(5, 4)
+    >>> actor = actor.disk(centers, dirs, colors,
+    >>>                    rinner=.1, router=.8, cresolution=30)
+    >>> scene.add(actor)
+    >>> window.show(scene)
+    """
+    if faces is None:
+        src = DiskSource()
+        src.SetCircumferentialResolution(cresolution)
+        src.SetRadialResolution(rresolution)
+        src.SetInnerRadius(rinner)
+        src.SetOuterRadius(router)
+        rotate = np.array([[0, 0, -1, 0],
+                           [0, 1, 0, 0],
+                           [1, 0, 0, 0],
+                           [0, 0, 0, 1]])
+    else:
+        src = None
+        rotate = None
+
+    disk_actor = repeat_sources(centers=centers, colors=colors,
+                                directions=directions, source=src,
+                                vertices=vertices, faces=faces,
+                                orientation=rotate)
+
+    return disk_actor
 
 
 def square(centers, directions=(1, 0, 0), colors=(1, 0, 0), scales=1):

--- a/fury/lib.py
+++ b/fury/lib.py
@@ -124,6 +124,7 @@ Glyph3D = fcvtk.vtkGlyph3D
 ##############################################################
 #  vtkFiltersGeneral Module
 SplineFilter = fgvtk.vtkSplineFilter
+TransformPolyDataFilter = fgvtk.vtkTransformPolyDataFilter
 
 ##############################################################
 #  vtkFiltersHybrid Module

--- a/fury/primitive.py
+++ b/fury/primitive.py
@@ -186,7 +186,6 @@ def repeat_primitive(vertices, faces, centers, directions=None,
         dir_abs = np.linalg.norm(dirs)
         if dir_abs:
             normal = np.array([1., 0., 0.])
-            normal = normal / np.linalg.norm(normal)
             dirs = dirs / dir_abs
             v = np.cross(normal, dirs)
             c = np.dot(normal, dirs)

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -919,20 +919,22 @@ def test_basic_geometry_actor(interactive=False):
 
 def test_advanced_geometry_actor(interactive=False):
     xyz = np.array([[0, 0, 0], [50, 0, 0], [100, 0, 0]])
-    dirs = np.array([[0, 1, 0], [1, 0, 0], [0, 0.5, 0.5]])
+    dirs = np.array([[0.5, 0.5, 0.5], [0.5, 0, 0.5], [0, 0.5, 0.5]])
 
-    actor_list = [[actor.cone, {'directions': dirs, 'resolution': 8}],
-                  [actor.arrow, {'directions': dirs, 'resolution': 9}],
-                  [actor.cylinder, {'directions': dirs}]]
+    heights = np.array([5, 7, 10])
+
+    actor_list = [[actor.cone, {'heights': heights, 'resolution': 8}],
+                  [actor.arrow, {'heights': heights, 'resolution': 9}],
+                  [actor.cylinder, {'heights': heights, 'resolution': 10}],
+                  [actor.disk, {'rinner': 4, 'router': 8, 'rresolution': 2,
+                                'cresolution': 2}]]
 
     scene = window.Scene()
 
     for act_func, extra_args in actor_list:
         colors = np.array([[1, 0, 0, 0.3], [0, 1, 0, 0.4], [1, 1, 0, 1]])
-        heights = np.array([5, 7, 10])
 
-        geom_actor = act_func(centers=xyz, heights=heights, colors=colors[:],
-                              **extra_args)
+        geom_actor = act_func(xyz, dirs, colors, **extra_args)
         scene.add(geom_actor)
 
         if interactive:
@@ -941,12 +943,11 @@ def test_advanced_geometry_actor(interactive=False):
         report = window.analyze_snapshot(arr, colors=colors)
         npt.assert_equal(report.objects, 3)
 
-        colors = np.array([1.0, 1.0, 1.0, 1.0])
-        heights = 10
-
         scene.clear()
-        geom_actor = act_func(centers=xyz[:, :3], heights=10, colors=colors[:],
-                              **extra_args)
+
+        colors = np.array([1.0, 1.0, 1.0, 1.0])
+
+        geom_actor = act_func(xyz, dirs, colors, **extra_args)
         scene.add(geom_actor)
 
         if interactive:

--- a/fury/tests/test_primitive.py
+++ b/fury/tests/test_primitive.py
@@ -166,7 +166,23 @@ def test_repeat_primitive():
     npt.assert_equal(big_colors.shape[0], verts.shape[0] * centers.shape[0])
     npt.assert_equal(big_centers.shape[0], verts.shape[0] * centers.shape[0])
 
-    # TODO: Check the array content
+    npt.assert_equal(np.unique(np.concatenate(big_faces, axis=None)).tolist(),
+                     list(range(len(big_verts))))
+
+    # translate the squares primitives centers to be the origin
+    big_vert_origin = big_verts - np.repeat(centers, 4, axis=0)
+
+    # three repeated primitives
+    sq1, sq2, sq3 = big_vert_origin.reshape([3, 12])
+
+    #  primitives directed toward different directions must not be the same
+    np.testing.assert_equal(np.any(np.not_equal(sq1, sq2)), True)
+    np.testing.assert_equal(np.any(np.not_equal(sq1, sq3)), True)
+    np.testing.assert_equal(np.any(np.not_equal(sq2, sq3)), True)
+
+    np.testing.assert_equal(big_vert_origin.min(), -0.5)
+    np.testing.assert_equal(big_vert_origin.max(), 0.5)
+    np.testing.assert_equal(np.mean(big_vert_origin), 0)
 
 
 def test_repeat_primitive_function():

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -6,7 +6,7 @@ from fury.lib import (numpy_support, PolyData, ImageData, Points,
                       CellArray, PolyDataNormals, Actor, PolyDataMapper,
                       Matrix4x4, Matrix3x3, Glyph3D, VTK_DOUBLE, VTK_FLOAT,
                       Transform, AlgorithmOutput, VTK_INT, VTK_UNSIGNED_CHAR,
-                      IdTypeArray)
+                      TransformPolyDataFilter, IdTypeArray)
 
 
 def remove_observer_from_actor(actor, id):
@@ -706,7 +706,7 @@ def get_actor_from_primitive(vertices, triangles, colors=None,
 
 
 def repeat_sources(centers, colors, active_scalars=1., directions=None,
-                   source=None, vertices=None, faces=None):
+                   source=None, vertices=None, faces=None, orientation=None):
     """Transform a vtksource to glyph."""
     if source is None and faces is None:
         raise IOError("A source or faces should be defined")
@@ -749,10 +749,16 @@ def repeat_sources(centers, colors, active_scalars=1., directions=None,
 
     glyph = Glyph3D()
     if faces is None:
+        if orientation is not None:
+            transform = Transform()
+            transform.SetMatrix(numpy_to_vtk_matrix(orientation))
+            rtrans = TransformPolyDataFilter()
+            rtrans.SetInputConnection(source.GetOutputPort())
+            rtrans.SetTransform(transform)
+            source = rtrans
         glyph.SetSourceConnection(source.GetOutputPort())
     else:
         glyph.SetSourceData(polydata_geom)
-
     glyph.SetInputData(polydata_centers)
     glyph.SetOrient(True)
     glyph.SetScaleModeToScaleByScalar()


### PR DESCRIPTION
Fixed the issue of the rotation matrix that I mentioned in issue #554. 
What I did was assume all primitives have a normal vector pointing in X-axis (1, 0, 0), then the matrix to align this normal vector of the primitives to the direction vector specified.
I tested the matrix on my arrow using **repeat_primitive** and **repeat_source** and got a match.
```
import numpy as np
from fury import window, actor

scene = window.Scene()

centers = np.zeros([3, 3])
dirs = np.identity(3)
colors = np.identity(3)
scales = np.array([2.1, 2.6, 2.5])

rpactor = actor.arrow(centers, dirs, colors=colors, scales=1.5)
rsactor = actor.arrow(centers, dirs, colors=colors, repeat_primitive=False)

cen2 = np.random.rand(5, 3)
dir2 = np.random.rand(5, 3)
cols2 = np.random.rand(5, 3)

rpactor2 = actor.arrow(cen2, dir2, colors=cols2, scales=1.5)
rsactor2 = actor.arrow(cen2, dir2, colors=cols2, repeat_primitive=False)

scene.add(rpactor)
scene.add(rpactor2)
scene.add(rsactor)
scene.add(rsactor2)

window.show(scene, size=(600, 600), reset_camera=False, title='Comparing')
```

![image](https://user-images.githubusercontent.com/63170874/157861645-c5216e57-8c33-4f85-826b-f8a4b989f608.png)

As shown in the figure above, they align perfectly now.