### PR TITLE
Check to see if file exists before opening

### DIFF
--- a/fury/io.py
+++ b/fury/io.py
@@ -262,6 +262,11 @@ def load_polydata(file_name):
     output : vtkPolyData
 
     """
+
+    # Check if file actually exists
+    if not os.path.isfile(file_name):
+        raise FileNotFoundError(file_name)
+
     file_extension = file_name.split(".")[-1].lower()
 
     poly_reader = {"vtk": PolyDataReader,

--- a/fury/tests/test_io.py
+++ b/fury/tests/test_io.py
@@ -38,6 +38,7 @@ def test_save_and_load_polydata():
     npt.assert_raises(IOError, save_polydata, PolyData(), "test.vti")
     npt.assert_raises(IOError, save_polydata, PolyData(), "test.obj")
     npt.assert_raises(IOError, load_polydata, "test.vti")
+    npt.assert_raises(FileNotFoundError, load_polydata, "does-not-exist.obj")
 
 
 def test_save_and_load_options():


### PR DESCRIPTION
Currently, io.load_cubemap_texture() checks for existence of the files
it is asked to open, and raises FileNotFoundError if needed. Added
checks to io.load_polydata() and io.load_image().