### PR TITLE
Force mesa update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,6 +115,7 @@ jobs:
     - name: Start Xvfb
       if: startsWith(matrix.os,'ubuntu')
       run: |
+        sudo apt update
         if [ "ubuntu-18.04" == "${{ matrix.os }}" ]; then
           sudo apt-get install -y libgl1-mesa-dev xvfb;
         else

--- a/docs/tutorials/01_introductory/viz_picking.py
+++ b/docs/tutorials/01_introductory/viz_picking.py
@@ -43,7 +43,7 @@ label_actor = actor.label(text='Test')
 directions = np.array([[np.sqrt(2)/2, 0, np.sqrt(2)/2],
                        [np.sqrt(2)/2, np.sqrt(2)/2, 0],
                        [0, np.sqrt(2)/2, np.sqrt(2)/2]])
-fury_actor = actor.cube(centers, directions, colors, heights=radii)
+fury_actor = actor.cube(centers, directions, colors, scales=radii)
 
 ###############################################################################
 # Access the memory of the vertices of all the cubes


### PR DESCRIPTION
Our GHA Ci seems to fail on Ubuntu because they do not find a deb package. 

by doing a system update, it should refresh the package list and fix the right one.