### PR TITLE
Record should not make the window appear

### DIFF
--- a/fury/window.py
+++ b/fury/window.py
@@ -701,7 +701,10 @@ def record(scene=None, cam_pos=None, cam_focal=None, cam_view=None,
     az_ang : float, optional
         Azimuthal angle of camera rotation.
     magnification : int, optional
-        How much to magnify the saved frame. Default is 1.
+        How much to magnify the saved frame. Default is 1. A value greater
+        than 1 increases the quality of the image. However, the output
+        size will be larger. For example, 200x200 image with magnification
+        of 2 will be a 400x400 image.
     size : (int, int)
         ``(width, height)`` of the window. Default is (300, 300).
     screen_clip: bool

--- a/fury/window.py
+++ b/fury/window.py
@@ -737,9 +737,11 @@ def record(scene=None, cam_pos=None, cam_focal=None, cam_view=None,
 
     """
     if scene is None:
-        scene = Renderer()
+        scene = Scene()
 
     renWin = RenderWindow()
+
+    renWin.SetOffScreenRendering(1)
     renWin.SetBorders(screen_clip)
     renWin.AddRenderer(scene)
     renWin.SetSize(size[0], size[1])


### PR DESCRIPTION
This PR allows ``fury.window.record`` to go offscreen as it should, and not create any windows while saving images. 

This is resolving the memory issue when repeatedly calling record. And the fact that you see a black window for a few seconds.

See relevant issues here:
https://github.com/fury-gl/fury/issues/548
https://github.com/fury-gl/fury/issues/196


```
from fury import window, actor
import numpy as np

t = np.linspace(-10, 10, 100)
bundle = []
for i in np.linspace(3, 5, 1000):
    pts = np.vstack((np.cos(2 * t/np.pi), np.zeros(t.shape) + i*10, t )).T
    bundle.append(pts)

ren = window.Scene()
for time in range(200):#len(plot_params["rod0"]["time"])):
    ren.clear()
    bundle_actor = actor.streamtube(bundle, window.colors.red, linewidth=0.01)
    ren.add(bundle_actor)
    ren.SetBackground(*window.colors.white)
    # image_array = window.snapshot(
    #     ren, fname='/tmp/file%02d.png' % time, size=(1000, 1000))

    window.record(ren, out_path='/tmp/file%02d.png' % time, size=(1000, 1000))
```

A note here to say that we do not see anymore the memory leak on either snapshot or record (with this PR merged).

