### PR TITLE
Replace theme in requirements/docs.txt

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -5,7 +5,7 @@ matplotlib
 sphinx-copybutton
 sphinx-gallery>=0.10.0
 pillow
-sphinx_rtd_theme
+pydata-sphinx-theme
 networkx
 ablog >= 0.10.5
 pybullet>=2.7.0


### PR DESCRIPTION
I was unable to build the docs, and I found that `requirements/docs.txt` wasn't updated when the theme was changed. Replaced `sphinx_rtd_theme` with `pydata-sphinx-theme`.