### PR TITLE
Fix vertex order in prim_tetrahedron

### DIFF
--- a/fury/primitive.py
+++ b/fury/primitive.py
@@ -374,9 +374,9 @@ def prim_tetrahedron():
                              [-0.5, -0.5, 0.5]])
 
     pyramid_triag = np.array([[2, 0, 1],
-                              [0, 3, 2],
+                              [0, 2, 3],
                               [0, 3, 1],
-                              [1, 2, 3]], dtype='i8')
+                              [1, 3, 2]], dtype='i8')
 
     return pyramid_vert, pyramid_triag
 


### PR DESCRIPTION
Currently, 2 of the faces returned by `primitive.prim_tetrahedron()` have the vertices in incorrect order. This leads to incorrect normals being calculated, and the two faces in question appear invisible from the outside.

Current version: Note the missing faces!
![Screenshot from 2022-04-12 20-58-20](https://user-images.githubusercontent.com/72246047/163001190-fcf93bb1-597d-4518-aa79-0fbe1c0b497a.png)

Fixed version: All faces are now visible from the outside.
![Screenshot from 2022-04-12 20-57-33](https://user-images.githubusercontent.com/72246047/163001270-02fb3a82-4cdc-49b2-9644-f7e14655d538.png)

Minimal reproducible example:
```python
from fury import utils, window, primitive

v, f = primitive.prim_tetrahedron()

# Uncomment to see the fix
# f[1][1], f[1][2] = f[1][2], f[1][1]
# f[3][1], f[3][2] = f[3][2], f[3][1]

a = utils.get_actor_from_primitive(v, f)

scene = window.Scene()
scene.add(a)
window.show(scene)
```