### PR TITLE
Fixed the static path in configuration file for docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -176,7 +176,7 @@ html_additional_pages = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static/css']
+html_static_path = ['_static']
 
 html_css_files = [
     'css/custom.css',


### PR DESCRIPTION
Fixed static path as the previous path restricted static content to the css folder only