### PR TITLE
Keep original dtype for offsets in vtk format

### DIFF
--- a/fury/utils.py
+++ b/fury/utils.py
@@ -117,6 +117,7 @@ def numpy_to_vtk_cells(data, is_coords=True):
         connectivity + offset information
 
     """
+    offset_dtype = data._offsets.dtype
     data = np.array(data, dtype=object)
     nb_cells = len(data)
 
@@ -136,10 +137,10 @@ def numpy_to_vtk_cells(data, is_coords=True):
             connectivity += list(range(current_position, end_position))
             current_position = end_position
 
-    connectivity = np.array(connectivity, np.intp)
-    offset = np.array(offset, dtype=connectivity.dtype)
+    connectivity = np.array(connectivity, offset_dtype)
+    offset = np.array(offset, dtype=offset_dtype)
 
-    vtk_array_type = numpy_support.get_vtk_array_type(connectivity.dtype)
+    vtk_array_type = numpy_support.get_vtk_array_type(offset_dtype)
     cell_array.SetData(
         numpy_support.numpy_to_vtk(offset, deep=True,
                                    array_type=vtk_array_type),


### PR DESCRIPTION
Allows saving VTK using offsets as int32 or int64 by keeping the initial datatype rather than casting it to int64.
Since the ArraySequence as offsets as int64 for default, this does not change the current behavior of the stateful_tractogram in DiPy.

@arokem (this PR match the one I made today in Dipy, to solve limitation with VTK for Chris' Benchmarking