### PR TITLE
Deprecation of the function shaders.load

### DIFF
--- a/fury/actor.py
+++ b/fury/actor.py
@@ -6,7 +6,7 @@ from functools import partial
 import numpy as np
 
 from fury.shaders import (add_shader_callback, attribute_to_actor,
-                          compose_shader, import_fury_shader, load,
+                          compose_shader, import_fury_shader,
                           replace_shader_in_actor, shader_to_actor)
 from fury import layout
 from fury.actors.odf_slicer import OdfSlicerActor
@@ -762,7 +762,8 @@ def line(lines, colors=None, opacity=1, linewidth=1,
             if program is not None:
                 program.SetUniformf("linewidth", linewidth)
 
-        replace_shader_in_actor(actor, "geometry", load("line.geom"))
+        replace_shader_in_actor(actor, 'geometry',
+                                import_fury_shader('line.geom'))
         add_shader_callback(actor, callback)
 
     if fake_tube:
@@ -2984,10 +2985,10 @@ def sdf(centers, directions=(1, 0, 0), colors=(1, 0, 0), primitives='torus',
     attribute_to_actor(box_actor, rep_scales, 'scale')
     attribute_to_actor(box_actor, rep_directions, 'direction')
 
-    vs_dec_code = load("sdf_dec.vert")
-    vs_impl_code = load("sdf_impl.vert")
-    fs_dec_code = load("sdf_dec.frag")
-    fs_impl_code = load("sdf_impl.frag")
+    vs_dec_code = import_fury_shader('sdf_dec.vert')
+    vs_impl_code = import_fury_shader('sdf_impl.vert')
+    fs_dec_code = import_fury_shader('sdf_dec.frag')
+    fs_impl_code = import_fury_shader('sdf_impl.frag')
 
     shader_to_actor(box_actor, "vertex", impl_code=vs_impl_code,
                     decl_code=vs_dec_code)
@@ -3043,19 +3044,19 @@ def markers(
         'o': 0, 's': 1, 'd': 2, '^': 3, 'p': 4,
         'h': 5, 's6': 6, 'x': 7, '+': 8, '3d': 0}
 
-    vs_dec_code = load("billboard_dec.vert")
-    vs_dec_code += f'\n{load("marker_billboard_dec.vert")}'
-    vs_impl_code = load("billboard_impl.vert")
-    vs_impl_code += f'\n{load("marker_billboard_impl.vert")}'
+    vs_dec_code = import_fury_shader('billboard_dec.vert')
+    vs_dec_code += f'\n{import_fury_shader("marker_billboard_dec.vert")}'
+    vs_impl_code = import_fury_shader('billboard_impl.vert')
+    vs_impl_code += f'\n{import_fury_shader("marker_billboard_impl.vert")}'
 
-    fs_dec_code = load('billboard_dec.frag')
-    fs_dec_code += f'\n{load("marker_billboard_dec.frag")}'
-    fs_impl_code = load('billboard_impl.frag')
+    fs_dec_code = import_fury_shader('billboard_dec.frag')
+    fs_dec_code += f'\n{import_fury_shader("marker_billboard_dec.frag")}'
+    fs_impl_code = import_fury_shader('billboard_impl.frag')
 
     if marker == '3d':
-        fs_impl_code += f'{load("billboard_spheres_impl.frag")}'
+        fs_impl_code += f'{import_fury_shader("billboard_spheres_impl.frag")}'
     else:
-        fs_impl_code += f'{load("marker_billboard_impl.frag")}'
+        fs_impl_code += f'{import_fury_shader("marker_billboard_impl.frag")}'
         if isinstance(marker, str):
             list_of_markers = np.ones(n_markers)*marker2id[marker]
         else:

--- a/fury/actors/peak.py
+++ b/fury/actors/peak.py
@@ -1,7 +1,8 @@
 import numpy as np
 
 from fury.colormap import boys2rgb, colormap_lookup_table, orient2rgb
-from fury.shaders import attribute_to_actor, load, shader_to_actor
+from fury.shaders import (attribute_to_actor, import_fury_shader,
+                          shader_to_actor)
 from fury.utils import (apply_affine, numpy_to_vtk_colors, numpy_to_vtk_points)
 from fury.lib import (numpy_support, Actor, Command, CellArray,
                       PolyDataMapper, PolyData, VTK_OBJECT, calldata_type)
@@ -116,10 +117,10 @@ class PeakActor(Actor):
         attribute_to_actor(self, centers_array, 'center')
         attribute_to_actor(self, diffs_array, 'diff')
 
-        vs_dec_code = load('peak_dec.vert')
-        vs_impl_code = load('peak_impl.vert')
-        fs_dec_code = load('peak_dec.frag')
-        fs_impl_code = load('peak_impl.frag')
+        vs_dec_code = import_fury_shader('peak_dec.vert')
+        vs_impl_code = import_fury_shader('peak_impl.vert')
+        fs_dec_code = import_fury_shader('peak_dec.frag')
+        fs_impl_code = import_fury_shader('peak_impl.frag')
 
         shader_to_actor(self, 'vertex', decl_code=vs_dec_code,
                         impl_code=vs_impl_code)

--- a/fury/material.py
+++ b/fury/material.py
@@ -1,7 +1,8 @@
 import warnings
 
 
-from fury.shaders import add_shader_callback, load, shader_to_actor
+from fury.shaders import (add_shader_callback, import_fury_shader,
+                          shader_to_actor)
 from fury.lib import VTK_OBJECT, calldata_type
 
 
@@ -277,8 +278,8 @@ def manifest_principled(actor, subsurface=0, subsurface_color=[0, 0, 0],
 
         add_shader_callback(actor, uniforms_callback)
 
-        fs_dec_code = load('bxdf_dec.frag')
-        fs_impl_code = load('bxdf_impl.frag')
+        fs_dec_code = import_fury_shader('bxdf_dec.frag')
+        fs_impl_code = import_fury_shader('bxdf_impl.frag')
 
         shader_to_actor(actor, 'fragment', decl_code=fs_dec_code)
         shader_to_actor(actor, 'fragment', impl_code=fs_impl_code,

--- a/fury/shaders/base.py
+++ b/fury/shaders/base.py
@@ -2,6 +2,7 @@ import os
 
 from functools import partial
 from fury import enable_warnings
+from fury.deprecator import deprecate_with_version
 from fury.io import load_text
 from fury.lib import (VTK_OBJECT, Command, DataObject, Shader, calldata_type,
                       numpy_support)
@@ -9,7 +10,7 @@ from fury.lib import (VTK_OBJECT, Command, DataObject, Shader, calldata_type,
 
 SHADERS_DIR = os.path.join(os.path.dirname(__file__))
 
-SHADERS_EXTS = ['.vert', '.tesc', '.tese', '.geom', '.frag', '.comp']
+SHADERS_EXTS = ['.glsl', '.vert', '.tesc', '.tese', '.geom', '.frag', '.comp']
 
 SHADERS_TYPE = {"vertex": Shader.Vertex, "geometry": Shader.Geometry,
                 "fragment": Shader.Fragment}
@@ -126,6 +127,7 @@ def load_shader(shader_file):
     return load_text(shader_file)
 
 
+'''
 def load(filename):
     """Load a Fury shader file.
 
@@ -142,6 +144,10 @@ def load(filename):
     """
     with open(os.path.join(SHADERS_DIR, filename)) as shader_file:
         return shader_file.read()
+'''
+load = deprecate_with_version(
+    message='Load function has been reimplemented as import_fury_shader.',
+    since='0.8.1', until='0.9.0')(import_fury_shader)
 
 
 def shader_to_actor(actor, shader_type, impl_code="", decl_code="",

--- a/fury/shaders/base.py
+++ b/fury/shaders/base.py
@@ -127,7 +127,9 @@ def load_shader(shader_file):
     return load_text(shader_file)
 
 
-'''
+@deprecate_with_version(
+    message='Load function has been reimplemented as import_fury_shader.',
+    since='0.8.1', until='0.9.0')
 def load(filename):
     """Load a Fury shader file.
 
@@ -144,10 +146,6 @@ def load(filename):
     """
     with open(os.path.join(SHADERS_DIR, filename)) as shader_file:
         return shader_file.read()
-'''
-load = deprecate_with_version(
-    message='Load function has been reimplemented as import_fury_shader.',
-    since='0.8.1', until='0.9.0')(import_fury_shader)
 
 
 def shader_to_actor(actor, shader_type, impl_code="", decl_code="",

--- a/fury/shaders/tests/test_base.py
+++ b/fury/shaders/tests/test_base.py
@@ -339,6 +339,7 @@ def test_load_shader():
         npt.assert_string_equal(load_shader(fname_test), str_test)
 
 
+"""
 def test_load():
     dummy_file_name = 'dummy.txt'
     dummy_file_contents = 'This is some dummy text.'
@@ -350,6 +351,7 @@ def test_load():
     npt.assert_string_equal(load(dummy_file_name), dummy_file_contents)
 
     os.remove(os.path.join(SHADERS_DIR, dummy_file_name))
+"""
 
 
 def test_replace_shader_in_actor(interactive=False):

--- a/fury/shaders/tests/test_base.py
+++ b/fury/shaders/tests/test_base.py
@@ -339,7 +339,6 @@ def test_load_shader():
         npt.assert_string_equal(load_shader(fname_test), str_test)
 
 
-"""
 def test_load():
     dummy_file_name = 'dummy.txt'
     dummy_file_contents = 'This is some dummy text.'
@@ -348,10 +347,11 @@ def test_load():
     dummy_file.write(dummy_file_contents)
     dummy_file.close()
 
+    npt.assert_warns(DeprecationWarning, load, dummy_file_name)
+
     npt.assert_string_equal(load(dummy_file_name), dummy_file_contents)
 
     os.remove(os.path.join(SHADERS_DIR, dummy_file_name))
-"""
 
 
 def test_replace_shader_in_actor(interactive=False):

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -339,7 +339,7 @@ def test_streamtube_and_line_actors():
 
     shader_obj = c3.GetShaderProperty()
     mapper_code = shader_obj.GetGeometryShaderCode()
-    file_code = shaders.load("line.geom")
+    file_code = shaders.import_fury_shader('line.geom')
     npt.assert_equal(mapper_code, file_code)
 
     npt.assert_equal(c3.GetProperty().GetRenderLinesAsTubes(), True)


### PR DESCRIPTION
This PR deprecates the function `shaders.load` in favor of the more explicit function `shaders.import_fury_shader`.