### PR TITLE
Added an accurate way to get the FPS for the showManager

### DIFF
--- a/docs/examples/physics_using_pybullet/viz_brick_wall.py
+++ b/docs/examples/physics_using_pybullet/viz_brick_wall.py
@@ -237,7 +237,7 @@ def timer_callback(_obj, _event):
     showm.render()
 
     if cnt % 1 == 0:
-        fps = scene.frame_rate
+        fps = showm.frame_rate
         fpss = np.append(fpss, fps)
         tb.message = "Avg. FPS: " + str(np.round(np.mean(fpss), 0)) + \
                      "\nSim Steps: " + str(cnt)

--- a/docs/examples/physics_using_pybullet/viz_chain.py
+++ b/docs/examples/physics_using_pybullet/viz_chain.py
@@ -208,7 +208,7 @@ def timer_callback(_obj, _event):
     t += 1. / freq_sim
 
     if cnt % 1 == 0:
-        fps = scene.frame_rate
+        fps = showm.frame_rate
         fpss = np.append(fpss, fps)
         tb.message = "Avg. FPS: " + str(np.round(np.mean(fpss), 0)) + \
                      "\nSim Steps: " + str(cnt)

--- a/docs/examples/physics_using_pybullet/viz_domino.py
+++ b/docs/examples/physics_using_pybullet/viz_domino.py
@@ -185,7 +185,7 @@ def timer_callback(_obj, _event):
     showm.render()
 
     if cnt % 1 == 0:
-        fps = scene.frame_rate
+        fps = showm.frame_rate
         fpss = np.append(fpss, fps)
         tb.message = "Avg. FPS: " + str(np.round(np.mean(fpss), 0)) + \
                      "\nSim Steps: " + str(cnt)

--- a/docs/examples/physics_using_pybullet/viz_wrecking_ball.py
+++ b/docs/examples/physics_using_pybullet/viz_wrecking_ball.py
@@ -310,7 +310,7 @@ def timer_callback(_obj, _event):
     showm.render()
 
     if cnt % 1 == 0:
-        fps = scene.frame_rate
+        fps = showm.frame_rate
         fpss = np.append(fpss, fps)
         tb.message = "Avg. FPS: " + str(np.round(np.mean(fpss), 0)) + \
                      "\nSim Steps: " + str(cnt)

--- a/docs/experimental/viz_brick_wall.py
+++ b/docs/experimental/viz_brick_wall.py
@@ -139,7 +139,7 @@ def timer_callback(_obj, _event):
     showm.render()
 
     if cnt % 1 == 0:
-        fps = scene.frame_rate
+        fps = showm.frame_rate
         fpss = np.append(fpss, fps)
         tb.message = "Avg. FPS: " + str(np.round(np.mean(fpss), 0)) +\
             "\nSim Steps: " + str(cnt)

--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -5,6 +5,7 @@ from tempfile import TemporaryDirectory as InTemporaryDirectory
 import numpy as np
 import numpy.testing as npt
 import pytest
+import itertools
 from fury import actor, window, io
 from fury.lib import ImageData, Texture, numpy_support
 from fury.testing import captured_output, assert_less_equal, assert_greater
@@ -564,6 +565,47 @@ def test_opengl_state_add_remove_and_check():
     after_remove_depth_test_observer = state['GL_DEPTH_TEST']
     npt.assert_equal(after_remove_depth_test_observer, True)
 
+
+def test_frame_rate():
+    xyz = 1000 * np.random.rand(10, 3)
+    colors = np.random.rand(10, 4)
+    radii = np.random.rand(10) * 50 + 0.5
+    scene = window.Scene()
+    sphere_actor = actor.sphere(centers=xyz,
+                                colors=colors,
+                                radii=radii)
+    scene.add(sphere_actor)
+
+    showm = window.ShowManager(scene,
+                               size=(900, 768), reset_camera=False,
+                               order_transparent=True)
+    showm.initialize()
+    counter = itertools.count()
+    frame_rates = []
+    render_times = []
+
+    def timer_callback(_obj, _event):
+        cnt = next(counter)
+        frame_rates.append(showm.frame_rate)
+
+        showm.scene.azimuth(0.05 * cnt)
+        sphere_actor.GetProperty().SetOpacity(cnt / 100.)
+
+        showm.render()
+        render_times.append(scene.last_render_time)
+
+        if cnt > 100:
+            showm.exit()
+
+    showm.add_timer_callback(True, 10, timer_callback)
+    showm.start()
+
+    actual_fps = sum(frame_rates)/len(frame_rates)
+    ideal_fps = 1 / (sum(render_times) / len(render_times))
+
+    assert_greater(actual_fps, 0)
+    assert_greater(ideal_fps, 0)
+    assert_greater(ideal_fps, actual_fps)
 
 # test_opengl_state_add_remove_and_check()
 # test_opengl_state_simple()

--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -600,6 +600,9 @@ def test_frame_rate():
     showm.add_timer_callback(True, 10, timer_callback)
     showm.start()
 
+    assert_greater(len(frame_rates), 0)
+    assert_greater(len(render_times), 0)
+
     actual_fps = sum(frame_rates)/len(frame_rates)
     ideal_fps = 1 / (sum(render_times) / len(render_times))
 

--- a/fury/ui/tests/test_elements_callback.py
+++ b/fury/ui/tests/test_elements_callback.py
@@ -77,7 +77,7 @@ def test_frame_rate_and_anti_aliasing():
     def timer_callback(_obj, _event):
         cnt = next(counter)
         if cnt % 1 == 0:
-            fps = np.round(scene.frame_rate, 0)
+            fps = np.round(showm.frame_rate, 0)
             frh.fpss.append(fps)
             msg = "FPS " + str(fps) + ' ' + str(cnt)
             tb.message = msg

--- a/fury/window.py
+++ b/fury/window.py
@@ -412,7 +412,6 @@ class ShowManager(object):
 
     def start(self):
         """Start interaction."""
-        # self._last_render_time = time.perf_counter()
         try:
             self.render()
             if self.title.upper() == "FURY":

--- a/fury/window.py
+++ b/fury/window.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import gzip
+import time
 from tempfile import TemporaryDirectory as InTemporaryDirectory
 from warnings import warn
 
@@ -362,6 +363,8 @@ class ShowManager(object):
         self.interactor_style = interactor_style
         self.stereo = stereo
         self.timers = []
+        self.fps = 0
+        self._last_render_time = 0
 
         if self.reset_camera:
             self.scene.ResetCamera()
@@ -403,10 +406,13 @@ class ShowManager(object):
 
     def render(self):
         """Render only once."""
+        self.fps = 1.0 / (time.perf_counter() - self._last_render_time)
+        self._last_render_time = time.perf_counter()
         self.window.Render()
 
     def start(self):
         """Start interaction."""
+        # self._last_render_time = time.perf_counter()
         try:
             self.render()
             if self.title.upper() == "FURY":
@@ -433,6 +439,11 @@ class ShowManager(object):
         self.window.Finalize()
         del self.iren
         del self.window
+
+    @property
+    def frame_rate(self):
+        """Returns FPS."""
+        return self.fps
 
     def record_events(self):
         """Record events during the interaction.

--- a/fury/window.py
+++ b/fury/window.py
@@ -261,10 +261,10 @@ class Scene(OpenGLRenderer):
         return self.GetActiveCamera().GetDirectionOfProjection()
 
     @property
-    def frame_rate(self):
-        rtis = self.GetLastRenderTimeInSeconds()
-        fps = 1.0 / rtis
-        return fps
+    def last_render_time(self):
+        """Returns the last render time in seconds."""
+
+        return self.GetLastRenderTimeInSeconds()
 
     def fxaa_on(self):
         self.SetUseFXAA(True)

--- a/fury/window.py
+++ b/fury/window.py
@@ -406,7 +406,7 @@ class ShowManager(object):
 
     def render(self):
         """Render only once."""
-        self.fps = 1.0 / (time.perf_counter() - self._last_render_time)
+        self._fps = 1.0 / (time.perf_counter() - self._last_render_time)
         self._last_render_time = time.perf_counter()
         self.window.Render()
 

--- a/fury/window.py
+++ b/fury/window.py
@@ -363,7 +363,7 @@ class ShowManager(object):
         self.interactor_style = interactor_style
         self.stereo = stereo
         self.timers = []
-        self.fps = 0
+        self._fps = 0
         self._last_render_time = 0
 
         if self.reset_camera:
@@ -442,8 +442,8 @@ class ShowManager(object):
 
     @property
     def frame_rate(self):
-        """Returns FPS."""
-        return self.fps
+        """Returns number of frames per second."""
+        return self._fps
 
     def record_events(self):
         """Record events during the interaction.

--- a/fury/window.py
+++ b/fury/window.py
@@ -406,9 +406,10 @@ class ShowManager(object):
 
     def render(self):
         """Render only once."""
+        self.window.Render()
+        # calculate the FPS
         self._fps = 1.0 / (time.perf_counter() - self._last_render_time)
         self._last_render_time = time.perf_counter()
-        self.window.Render()
 
     def start(self):
         """Start interaction."""


### PR DESCRIPTION
## What is wrong with the old way?
Since it basically depends on the time needed to render a single frame using the VTK' method "**GetLastRenderTimeInSeconds()**", it will be accurate with both of the two conditions below are true:
 1.  If the scene is all about rendering and no side calculations.
 2. The render method is called with an offset (delay) less than (not guaranteed) or equals the time required to render a single frame.

**For example**:
If the render method is called 32 times every second, this should give a 32 FPS as calculated by [Fraps](https://fraps.com/download.php) in yellow. This makes sense since it only depends on the render time.
```
showm.add_timer_callback(True, 1000//32 , timer_callback)
```
 ![image](https://user-images.githubusercontent.com/63170874/172705849-48f70b31-42fb-4fa3-a0c3-a923d23463bd.png)


The proposed way is to actually measure the time from rendering a frame until it renders the next frame.

## The old way vs. the new way:
For a scene with the conditions above, they are both accurate:

https://user-images.githubusercontent.com/63170874/172708989-982fff98-462e-4bf7-a1ef-781e2d42521f.mp4

### But for the other conditions, the old way is not accurate as shown below:
 
 https://user-images.githubusercontent.com/63170874/172709571-c3c6bfd8-a349-4f69-9ee5-be3e0f7ec5a7.mp4


### Code used for the last test:
```
import numpy as np  
from fury import window, actor, ui  
import itertools  
  
xyz = 1000 * np.random.rand(10, 3)  
colors = np.random.rand(10, 4)  
radii = np.random.rand(10) * 50 + 0.5  
  
scene = window.Scene()  
  
sphere_actor = actor.sphere(centers=xyz,  
  colors=colors,  
  radii=radii)  
  
scene.add(sphere_actor)  
  
showm = window.ShowManager(scene,  
  size=(900, 768), reset_camera=False,  
  order_transparent=True)  
  
showm.initialize()  
  
tb = ui.TextBlock2D(bold=True, position=(20, 720))  
  
counter = itertools.count()  
  
fps_scene = []  
fps_showm = []  
  
def timer_callback(_obj, _event):  
    global counter, fps_scene, fps_showm  
  
    cnt = next(counter)  
  
    if not (cnt % 5):  
        fps_scene.append(scene.frame_rate)  
        fps_showm.append(showm.frame_rate)  
        tb.message = f"Avg. FPS (old): {sum(fps_scene) // len(fps_scene)}" \  
                     f"\nAvg. FPS (new): {sum(fps_showm) // len(fps_showm)}"  
  fps_scene = []  
        fps_showm = []  
  
    showm.scene.azimuth(0.05 * cnt)  
    sphere_actor.GetProperty().SetOpacity(cnt / 100.)  
    showm.render()  
  
scene.add(tb)  
  
showm.add_timer_callback(True, 1000//32, timer_callback)  
showm.start()
```