### PR TITLE
Timer id is returned after creating the timer.

### DIFF
--- a/docs/tutorials/01_introductory/viz_timers.py
+++ b/docs/tutorials/01_introductory/viz_timers.py
@@ -43,19 +43,28 @@ counter = itertools.count()
 
 
 def timer_callback(_obj, _event):
+    global timer_id
     cnt = next(counter)
     tb.message = "Let's count up to 100 and exit :" + str(cnt)
     showm.scene.azimuth(0.05 * cnt)
     sphere_actor.GetProperty().SetOpacity(cnt/100.)
     showm.render()
-    if cnt == 100:
+
+    if cnt == 10:
+        # destroy the first timer and replace it with another faster timer
+        showm.destroy_timer(timer_id)
+        timer_id = showm.add_timer_callback(True, 10, timer_callback)
+
+    if cnt == 300:
+        # destroy the second timer and exit
+        showm.destroy_timer(timer_id)
         showm.exit()
 
 
 scene.add(tb)
 
 # Run every 200 milliseconds
-showm.add_timer_callback(True, 200, timer_callback)
+timer_id = showm.add_timer_callback(True, 200, timer_callback)
 
 showm.start()
 

--- a/docs/tutorials/01_introductory/viz_timers.py
+++ b/docs/tutorials/01_introductory/viz_timers.py
@@ -45,7 +45,7 @@ counter = itertools.count()
 def timer_callback(_obj, _event):
     global timer_id
     cnt = next(counter)
-    tb.message = "Let's count up to 100 and exit :" + str(cnt)
+    tb.message = "Let's count up to 300 and exit :" + str(cnt)
     showm.scene.azimuth(0.05 * cnt)
     sphere_actor.GetProperty().SetOpacity(cnt/100.)
     showm.render()

--- a/fury/window.py
+++ b/fury/window.py
@@ -570,6 +570,7 @@ class ShowManager(object):
         else:
             timer_id = self.iren.CreateOneShotTimer(duration)
         self.timers.append(timer_id)
+        return timer_id
 
     def add_iren_callback(self, iren_callback, event="MouseMoveEvent"):
         self.iren.AddObserver(event, iren_callback)


### PR DESCRIPTION
There was no way to get the id of a timer to destroy it. So I altered the "add_timer_callback" method to return the timer id so that we can use it to destroy the timer.
Also updated the tutorial viz_timers.py to show how to create/destroy timers during runtime.

