### PR TITLE
Added support for fetching gltf samples

### DIFF
--- a/fury/data/__init__.py
+++ b/fury/data/__init__.py
@@ -3,19 +3,21 @@
 from os.path import join as pjoin, dirname
 
 from fury.data.fetcher import (fetch_viz_cubemaps, read_viz_cubemap,
-                               fetch_viz_icons, read_viz_icons,
-                               fetch_viz_wiki_nw, fetch_viz_textures,
+                               fetch_viz_icons, fetch_viz_new_icons,
+                               read_viz_icons, fetch_viz_wiki_nw,
+                               fetch_viz_textures, read_viz_textures,
+                               fetch_viz_models, read_viz_models,
+                               fetch_viz_dmri, read_viz_dmri,
                                fetch_gltf, read_viz_gltf,
-                               read_viz_textures, fetch_viz_models,
-                               read_viz_models, fetch_viz_dmri,
-                               read_viz_dmri, list_gltf_sample_models)
+                               list_gltf_sample_models)
 
 DATA_DIR = pjoin(dirname(__file__), 'files')
 
 __all__ = ['DATA_DIR', 'fetch_viz_cubemaps', 'read_viz_cubemap',
-           'fetch_viz_icons', 'read_viz_icons',
-           'fetch_viz_textures', 'read_viz_textures',
-           'fetch_viz_wiki_nw', 'fetch_viz_models',
-           'read_viz_models', 'fetch_viz_dmri',
+           'fetch_viz_icons', 'fetch_viz_new_icons',
+           'read_viz_icons', 'fetch_viz_textures',
+           'read_viz_textures', 'fetch_viz_wiki_nw',
+           'fetch_viz_models', 'read_viz_models',
+           'fetch_viz_dmri', 'read_viz_dmri',
            'fetch_gltf', 'read_viz_gltf',
-           'read_viz_dmri', 'list_gltf_sample_models']
+           'list_gltf_sample_models']

--- a/fury/data/__init__.py
+++ b/fury/data/__init__.py
@@ -5,6 +5,7 @@ from os.path import join as pjoin, dirname
 from fury.data.fetcher import (fetch_viz_cubemaps, read_viz_cubemap,
                                fetch_viz_icons, read_viz_icons,
                                fetch_viz_wiki_nw, fetch_viz_textures,
+                               fetch_viz_gltf, read_viz_gltf,
                                read_viz_textures, fetch_viz_models,
                                read_viz_models, fetch_viz_dmri,
                                read_viz_dmri)
@@ -16,4 +17,5 @@ __all__ = ['DATA_DIR', 'fetch_viz_cubemaps', 'read_viz_cubemap',
            'fetch_viz_textures', 'read_viz_textures',
            'fetch_viz_wiki_nw', 'fetch_viz_models',
            'read_viz_models', 'fetch_viz_dmri',
+           'fetch_viz_gltf', 'read_viz_gltf',
            'read_viz_dmri']

--- a/fury/data/__init__.py
+++ b/fury/data/__init__.py
@@ -8,7 +8,7 @@ from fury.data.fetcher import (fetch_viz_cubemaps, read_viz_cubemap,
                                fetch_viz_gltf, read_viz_gltf,
                                read_viz_textures, fetch_viz_models,
                                read_viz_models, fetch_viz_dmri,
-                               read_viz_dmri, list_gltf_samples)
+                               read_viz_dmri, list_gltf_sample_models)
 
 DATA_DIR = pjoin(dirname(__file__), 'files')
 
@@ -18,4 +18,4 @@ __all__ = ['DATA_DIR', 'fetch_viz_cubemaps', 'read_viz_cubemap',
            'fetch_viz_wiki_nw', 'fetch_viz_models',
            'read_viz_models', 'fetch_viz_dmri',
            'fetch_viz_gltf', 'read_viz_gltf',
-           'read_viz_dmri', 'list_gltf_samples']
+           'read_viz_dmri', 'list_gltf_sample_models']

--- a/fury/data/__init__.py
+++ b/fury/data/__init__.py
@@ -5,7 +5,7 @@ from os.path import join as pjoin, dirname
 from fury.data.fetcher import (fetch_viz_cubemaps, read_viz_cubemap,
                                fetch_viz_icons, read_viz_icons,
                                fetch_viz_wiki_nw, fetch_viz_textures,
-                               fetch_viz_gltf, read_viz_gltf,
+                               fetch_gltf, read_viz_gltf,
                                read_viz_textures, fetch_viz_models,
                                read_viz_models, fetch_viz_dmri,
                                read_viz_dmri, list_gltf_sample_models)
@@ -17,5 +17,5 @@ __all__ = ['DATA_DIR', 'fetch_viz_cubemaps', 'read_viz_cubemap',
            'fetch_viz_textures', 'read_viz_textures',
            'fetch_viz_wiki_nw', 'fetch_viz_models',
            'read_viz_models', 'fetch_viz_dmri',
-           'fetch_viz_gltf', 'read_viz_gltf',
+           'fetch_gltf', 'read_viz_gltf',
            'read_viz_dmri', 'list_gltf_sample_models']

--- a/fury/data/__init__.py
+++ b/fury/data/__init__.py
@@ -8,7 +8,7 @@ from fury.data.fetcher import (fetch_viz_cubemaps, read_viz_cubemap,
                                fetch_viz_gltf, read_viz_gltf,
                                read_viz_textures, fetch_viz_models,
                                read_viz_models, fetch_viz_dmri,
-                               read_viz_dmri)
+                               read_viz_dmri, list_gltf_samples)
 
 DATA_DIR = pjoin(dirname(__file__), 'files')
 
@@ -18,4 +18,4 @@ __all__ = ['DATA_DIR', 'fetch_viz_cubemaps', 'read_viz_cubemap',
            'fetch_viz_wiki_nw', 'fetch_viz_models',
            'read_viz_models', 'fetch_viz_dmri',
            'fetch_viz_gltf', 'read_viz_gltf',
-           'read_viz_dmri']
+           'read_viz_dmri', 'list_gltf_samples']

--- a/fury/data/fetcher.py
+++ b/fury/data/fetcher.py
@@ -13,8 +13,7 @@ from shutil import copyfileobj
 import tarfile
 import zipfile
 
-from urllib.request import urlopen, urlretrieve
-from urllib.error import HTTPError
+from urllib.request import urlopen
 import asyncio
 import aiohttp
 
@@ -302,13 +301,14 @@ async def _download(session, url, filename, size=None):
 
     Parameters
     ----------
+    session : ClientSession
+        Aiohttp client session
     url : string
         The URL of the downloadable file
     filename : string
         Name of the downloaded file (e.g. BoxTextured.gltf)
-    session : ClientSession
-        Aiohttp client session
-
+    size : int, optional
+        Length of the content in bytes
     """
     if not os.path.exists(filename):
         print(f'Downloading: {filename}')

--- a/fury/data/fetcher.py
+++ b/fury/data/fetcher.py
@@ -292,7 +292,7 @@ def fetch_viz_gltf(name=None, mode='glTF'):
 
     if type(name) == list:
         for element in name:
-            fetch_gltf_models(element)
+            fetch_viz_gltf(element)
     else:
         url = GITHUB_API_URL + name + '/' + mode
         request = urlopen(url).read()

--- a/fury/data/fetcher.py
+++ b/fury/data/fetcher.py
@@ -616,7 +616,7 @@ def read_viz_gltf(fname, mode=None):
         Model type (e.g. glTF-Binary, glTF-Embedded, etc)
 
     Returns
-    --------
+    -------
     path : str
         Complete path of models.
     """
@@ -640,7 +640,7 @@ def read_viz_gltf(fname, mode=None):
 
 
 def list_gltf_sample_models():
-    """Returns all model names available in the glTF-samples repository
+    """Returns all model name from the glTF-samples repository
 
     Returns
     ---------

--- a/fury/data/fetcher.py
+++ b/fury/data/fetcher.py
@@ -300,11 +300,11 @@ def fetch_viz_gltf(name=None, mode='glTF'):
             request = urlopen(url).read()
             request = json.loads(request)
         except HTTPError as e:
-            print("Model %s does not exist, Please check name and mode" %
-                  (name))
+            print("Model {} does not exist, Please check name and mode"
+                  .format(name))
             return None
 
-        name = pjoin('glTF', name)
+        name = pjoin(* ['glTF', name, mode])
         folder = pjoin(fury_home, name)
 
         if not os.path.exists(folder):
@@ -317,7 +317,7 @@ def fetch_viz_gltf(name=None, mode='glTF'):
             fullpath = os.path.join(folder, filename)
 
             if not os.path.exists(fullpath):
-                print('Downloading file: ', filename)
+                print('Downloading file: {}'.format(filename))
                 urlretrieve(download_url, filename=fullpath)
 
 
@@ -558,7 +558,7 @@ def read_viz_dmri(fname):
     return pjoin(folder, fname)
 
 
-def read_viz_gltf(fname):
+def read_viz_gltf(fname, type='glTF'):
     """Read specific gltf sample.
 
     Parameters
@@ -573,11 +573,26 @@ def read_viz_gltf(fname):
         Complete path of models.
     """
     folder = pjoin(fury_home, 'glTF')
-    sample = pjoin(folder, fname)
+    sample = pjoin(*[folder, fname, type])
 
     if not os.path.exists(sample):
         raise ValueError('Model does not exists.')
 
     for filename in os.listdir(sample):
-        if filename.endswith('.gltf'):
+        if filename.endswith('.gltf') or filename.endswith('.glb'):
             return pjoin(sample, filename)
+
+
+def get_model_names():
+    """Get list of all model names available in glTF-samples repository
+
+    Returns
+    ---------
+    model_names : list
+        Lists the name of glTF sample from
+        https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0
+    """
+    models = urlopen(GITHUB_API_URL).read()
+    models = json.loads(models)
+    model_names = [model['name'] for model in models if model['size'] == 0]
+    return model_names

--- a/fury/data/fetcher.py
+++ b/fury/data/fetcher.py
@@ -558,7 +558,7 @@ def read_viz_dmri(fname):
     return pjoin(folder, fname)
 
 
-def read_viz_gltf(fname, type='glTF'):
+def read_viz_gltf(fname, mode=None):
     """Read specific gltf sample.
 
     Parameters
@@ -567,13 +567,24 @@ def read_viz_gltf(fname, type='glTF'):
         Name of the model.
         This should be found in folder HOME/.fury/models/glTF/.
 
+    mode : str, optional
+        Model type (e.g. glTF-Binary, glTF-Embedded, etc)
+
     Returns
     --------
     path : str
         Complete path of models.
     """
     folder = pjoin(fury_home, 'glTF')
-    sample = pjoin(*[folder, fname, type])
+    model = pjoin(folder, fname)
+
+    if mode is None:
+        types = os.listdir(model)
+        if len(types) == 0:
+            raise ValueError('Model does not exist.')
+        mode = types[-1]
+
+    sample = pjoin(model, mode)
 
     if not os.path.exists(sample):
         raise ValueError('Model does not exists.')
@@ -583,7 +594,7 @@ def read_viz_gltf(fname, type='glTF'):
             return pjoin(sample, filename)
 
 
-def get_model_names():
+def list_gltf_samples():
     """Get list of all model names available in glTF-samples repository
 
     Returns

--- a/fury/data/tests/test_fetcher.py
+++ b/fury/data/tests/test_fetcher.py
@@ -1,14 +1,18 @@
 import os
 from os.path import join as pjoin
 import json
+from urllib.request import urlopen
 import numpy.testing as npt
 from aiohttp import InvalidURL
-from fury.data import (fetch_gltf, read_viz_gltf)
+from fury.data import (fetch_gltf, read_viz_gltf, list_gltf_sample_models)
 
 if 'FURY_HOME' in os.environ:
     fury_home = os.environ['FURY_HOME']
 else:
     fury_home = pjoin(os.path.expanduser('~'), '.fury')
+
+GLTF_DATA_URL = \
+    "https://api.github.com/repos/KhronosGroup/glTF-Sample-Models/contents/2.0/"  # noqa
 
 
 def tests_fetch_gltf():
@@ -34,8 +38,6 @@ def tests_fetch_gltf():
 
     filenames, path = fetch_gltf('Box', 'glTF-Binary')
     npt.assert_equal(len(filenames), 1)
-    print(filenames)
-    print(os.listdir(path))
     npt.assert_equal(os.listdir(path), filenames)
 
     filename = read_viz_gltf('Box', 'glTF-Binary')
@@ -46,3 +48,23 @@ def tests_fetch_gltf():
         gltf = json.loads(f.read())
     validate_gltf = gltf.get('asset')
     npt.assert_equal(validate_gltf['version'], str(2.0))
+
+
+def test_list_gltf_sample_models():
+    gltf_path = pjoin(fury_home, 'glTF')
+    list_json = pjoin(gltf_path, 'list.json')
+    if not os.path.exists(list_json):
+        json_data = urlopen(f'{GLTF_DATA_URL}').read()
+        with open(list_json, 'wb') as f:
+            f.write(json_data)
+
+    with open(list_json, 'r') as r:
+        data = json.load(r)
+    model_names = [model['name'] for model in data if model['size'] == 0]
+    fetch_names = list_gltf_sample_models()
+    npt.assert_equal(len(fetch_names), len(model_names))
+    npt.assert_array_equal(model_names, fetch_names)
+
+    default_list = ['BoxTextured', 'Duck', 'CesiumMilkTruck', 'CesiumMan']
+    result = [model in fetch_names for model in default_list]
+    npt.assert_equal(result, [True, True, True, True])

--- a/fury/data/tests/test_fetcher.py
+++ b/fury/data/tests/test_fetcher.py
@@ -1,11 +1,9 @@
-from fury.data import *
-import numpy as np
-import numpy.testing as npt
 import os
 from os.path import join as pjoin
-from aiohttp import InvalidURL
 import json
-
+import numpy.testing as npt
+from aiohttp import InvalidURL
+from fury.data import (fetch_gltf, read_viz_gltf)
 
 if 'FURY_HOME' in os.environ:
     fury_home = os.environ['FURY_HOME']

--- a/fury/data/tests/test_fetcher.py
+++ b/fury/data/tests/test_fetcher.py
@@ -1,0 +1,50 @@
+from fury.data import *
+import numpy as np
+import numpy.testing as npt
+import os
+from os.path import join as pjoin
+from aiohttp import InvalidURL
+import json
+
+
+if 'FURY_HOME' in os.environ:
+    fury_home = os.environ['FURY_HOME']
+else:
+    fury_home = pjoin(os.path.expanduser('~'), '.fury')
+
+
+def tests_fetch_gltf():
+    folder = pjoin(fury_home, 'glTF')
+    boxtex = pjoin(folder, 'BoxTextured')
+    boxtex = pjoin(boxtex, 'glTF')
+    models_list = ['BoxTextured', 'Box']
+    if os.path.exists(boxtex):
+        for path in os.listdir(boxtex):
+            os.remove(pjoin(boxtex, path))
+        os.rmdir(boxtex)
+
+    fetch_gltf(models_list)
+    list_gltf = os.listdir(folder)
+    results = [model in list_gltf for model in models_list]
+
+    npt.assert_equal(results, [True, True])
+    npt.assert_raises(InvalidURL, fetch_gltf, ['duck'])
+    npt.assert_raises(InvalidURL, fetch_gltf, ['Duck'], 'GLTF')
+
+    items = os.listdir(boxtex)
+    npt.assert_array_equal(len(items), 3)
+
+    filenames, path = fetch_gltf('Box', 'glTF-Binary')
+    npt.assert_equal(len(filenames), 1)
+    print(filenames)
+    print(os.listdir(path))
+    npt.assert_equal(os.listdir(path), filenames)
+
+    filename = read_viz_gltf('Box', 'glTF-Binary')
+    npt.assert_equal(filename, pjoin(path, filenames[0]))
+
+    gltf = pjoin(boxtex, 'BoxTextured.gltf')
+    with open(gltf, 'r') as f:
+        gltf = json.loads(f.read())
+    validate_gltf = gltf.get('asset')
+    npt.assert_equal(validate_gltf['version'], str(2.0))


### PR DESCRIPTION
This PR allows us to fetch and save glTF models directly from [Khronos gltf-samples](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0) repository.

Demo:
```py

from fury.data import fetch_viz_gltf, read_viz_gltf

fetch_viz_gltf(['BoxTextured', 'Fox'])

fname = read_viz_gltf('Fox')
print(fname)

```