### PR TITLE
Fixing API limits reached issue in gltf fetcher

### DIFF
--- a/fury/data/fetcher.py
+++ b/fury/data/fetcher.py
@@ -705,9 +705,18 @@ def list_gltf_sample_models():
         Lists the name of glTF sample from
         https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0
     """
-    models = urlopen(GLTF_DATA_URL).read()
-    models = json.loads(models)
-    model_names = [model['name'] for model in models if model['size'] == 0]
+    DATA_DIR = pjoin(dirname(__file__), 'files')
+    with open(pjoin(DATA_DIR, 'KhronosGltfSamples.json'), 'r') as f:
+        models = json.loads(f.read())
+    models = models.keys()
+    model_modes = [model.split('/')[0] for model in models]
+
+    model_names = []
+    for name in model_modes:
+        if name not in model_names:
+            model_names.append(name)
+    model_names = model_names[1:]  # removing __comments__
+
     default_models = ['BoxTextured', 'Duck', 'CesiumMilkTruck', 'CesiumMan']
 
     if not model_names:

--- a/fury/data/fetcher.py
+++ b/fury/data/fetcher.py
@@ -338,6 +338,13 @@ async def _fetch_gltf(name, mode):
     mode: str
         Type of the glTF format.
         (e.g. glTF, glTF-Embedded, glTF-Binary, glTF-Draco)
+
+    Returns
+    -------
+    f_names : list
+        list of fetched all file names.
+    folder : str
+        Path to the fetched files.
     """
 
     if name is None:
@@ -395,6 +402,11 @@ def fetch_gltf(name=None, mode='glTF'):
         You can choose from different options
         (e.g. glTF, glTF-Embedded, glTF-Binary, glTF-Draco)
         Default: glTF, `.bin` and texture files are stored separately.
+
+    Returns
+    -------
+    filenames : tuple
+        tuple of feteched filenames (list) and folder (str) path.
     """
     filenames = asyncio.run(_fetch_gltf(name, mode))
     return filenames

--- a/fury/data/fetcher.py
+++ b/fury/data/fetcher.py
@@ -316,8 +316,8 @@ async def _download(session, url, filename, size=None):
     if not os.path.exists(filename):
         print(f'Downloading: {filename}')
         async with session.get(url) as response:
-            block = 100
             size = response.content_length if not size else size
+            block = size
             copied = 0
             with open(filename, mode='wb') as f:
                 async for chunk in response.content.iter_chunked(block):
@@ -360,6 +360,7 @@ async def _fetch_gltf(name, mode):
             raise ValueError(
                 "Model name and mode combination doesn't exist")
 
+        path = pjoin(name, mode)
         path = pjoin('glTF', path)
         folder = pjoin(fury_home, path)
         if not os.path.exists(folder):

--- a/fury/data/fetcher.py
+++ b/fury/data/fetcher.py
@@ -16,6 +16,7 @@ import zipfile
 from urllib.request import urlopen
 import asyncio
 import aiohttp
+import platform
 
 # Set a user-writeable file-system location to put files:
 if 'FURY_HOME' in os.environ:
@@ -408,6 +409,8 @@ def fetch_gltf(name=None, mode='glTF'):
     filenames : tuple
         tuple of feteched filenames (list) and folder (str) path.
     """
+    if platform.system().lower() == "windows":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     filenames = asyncio.run(_fetch_gltf(name, mode))
     return filenames
 

--- a/fury/data/files/KhronosGltfSamples.json
+++ b/fury/data/files/KhronosGltfSamples.json
@@ -1,0 +1,4333 @@
+{
+    "__comments__": "2022-06-26, url",
+    "2CylinderEngine/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/2CylinderEngine/glTF-Binary/2CylinderEngine.glb",
+            "size": 1838084
+        }
+    ],
+    "2CylinderEngine/glTF-Draco": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/2CylinderEngine/glTF-Draco/2CylinderEngine.bin",
+            "size": 155392
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/2CylinderEngine/glTF-Draco/2CylinderEngine.gltf",
+            "size": 90296
+        }
+    ],
+    "2CylinderEngine/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/2CylinderEngine/glTF-Embedded/2CylinderEngine.gltf",
+            "size": 2503896
+        }
+    ],
+    "2CylinderEngine/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/2CylinderEngine/glTF/2CylinderEngine.gltf",
+            "size": 111063
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/2CylinderEngine/glTF/2CylinderEngine0.bin",
+            "size": 1794612
+        }
+    ],
+    "2CylinderEngine/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/2CylinderEngine/screenshot/screenshot.png",
+            "size": 9325
+        }
+    ],
+    "AlphaBlendModeTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AlphaBlendModeTest/glTF-Binary/AlphaBlendModeTest.glb",
+            "size": 3017136
+        }
+    ],
+    "AlphaBlendModeTest/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AlphaBlendModeTest/glTF-Embedded/AlphaBlendModeTest.gltf",
+            "size": 4038240
+        }
+    ],
+    "AlphaBlendModeTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AlphaBlendModeTest/glTF/AlphaBlendLabels.png",
+            "size": 65522
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AlphaBlendModeTest/glTF/AlphaBlendModeTest.bin",
+            "size": 6776
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AlphaBlendModeTest/glTF/AlphaBlendModeTest.gltf",
+            "size": 31620
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AlphaBlendModeTest/glTF/MatBed_baseColor.jpg",
+            "size": 702714
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AlphaBlendModeTest/glTF/MatBed_normal.jpg",
+            "size": 1216267
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AlphaBlendModeTest/glTF/MatBed_occlusionRoughnessMetallic.jpg",
+            "size": 1013673
+        }
+    ],
+    "AlphaBlendModeTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AlphaBlendModeTest/screenshot/BlendFail.jpg",
+            "size": 101417
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AlphaBlendModeTest/screenshot/CutoffDefaultFail.jpg",
+            "size": 80944
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AlphaBlendModeTest/screenshot/CutoffTests.jpg",
+            "size": 131891
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AlphaBlendModeTest/screenshot/CutoffValueFail.jpg",
+            "size": 81180
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AlphaBlendModeTest/screenshot/MissingBorder.png",
+            "size": 169559
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AlphaBlendModeTest/screenshot/OpaqueFail.jpg",
+            "size": 72513
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AlphaBlendModeTest/screenshot/OpaqueVsBlend.jpg",
+            "size": 100761
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AlphaBlendModeTest/screenshot/screenshot.png",
+            "size": 53739
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AlphaBlendModeTest/screenshot/screenshot_large.jpg",
+            "size": 88413
+        }
+    ],
+    "AnimatedCube/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedCube/glTF/AnimatedCube.bin",
+            "size": 1860
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedCube/glTF/AnimatedCube.gltf",
+            "size": 5139
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedCube/glTF/AnimatedCube_BaseColor.png",
+            "size": 891995
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedCube/glTF/AnimatedCube_MetallicRoughness.png",
+            "size": 319
+        }
+    ],
+    "AnimatedCube/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedCube/screenshot/screenshot.gif",
+            "size": 517169
+        }
+    ],
+    "AnimatedMorphCube/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedMorphCube/glTF-Binary/AnimatedMorphCube.glb",
+            "size": 6752
+        }
+    ],
+    "AnimatedMorphCube/glTF-Quantized": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedMorphCube/glTF-Quantized/AnimatedMorphCube.bin",
+            "size": 1700
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedMorphCube/glTF-Quantized/AnimatedMorphCube.gltf",
+            "size": 4330
+        }
+    ],
+    "AnimatedMorphCube/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedMorphCube/glTF/AnimatedMorphCube.bin",
+            "size": 4284
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedMorphCube/glTF/AnimatedMorphCube.gltf",
+            "size": 4621
+        }
+    ],
+    "AnimatedMorphCube/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedMorphCube/screenshot/screenshot.gif",
+            "size": 99054
+        }
+    ],
+    "AnimatedMorphSphere/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedMorphSphere/glTF-Binary/AnimatedMorphSphere.glb",
+            "size": 221004
+        }
+    ],
+    "AnimatedMorphSphere/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedMorphSphere/glTF/AnimatedMorphSphere.bin",
+            "size": 218476
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedMorphSphere/glTF/AnimatedMorphSphere.gltf",
+            "size": 4622
+        }
+    ],
+    "AnimatedMorphSphere/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedMorphSphere/screenshot/screenshot.gif",
+            "size": 955024
+        }
+    ],
+    "AnimatedTriangle/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedTriangle/glTF-Embedded/AnimatedTriangle.gltf",
+            "size": 2300
+        }
+    ],
+    "AnimatedTriangle/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedTriangle/glTF/AnimatedTriangle.gltf",
+            "size": 2061
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedTriangle/glTF/animation.bin",
+            "size": 100
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedTriangle/glTF/simpleTriangle.bin",
+            "size": 44
+        }
+    ],
+    "AnimatedTriangle/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedTriangle/screenshot/animation.png",
+            "size": 52152
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedTriangle/screenshot/screenshot.gif",
+            "size": 12731
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AnimatedTriangle/screenshot/simpleTriangle.png",
+            "size": 43858
+        }
+    ],
+    "AntiqueCamera/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueCamera/glTF-Binary/AntiqueCamera.glb",
+            "size": 20199648
+        }
+    ],
+    "AntiqueCamera/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueCamera/glTF/AntiqueCamera.bin",
+            "size": 798092
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueCamera/glTF/AntiqueCamera.gltf",
+            "size": 7947
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueCamera/glTF/camera_camera_BaseColor.png",
+            "size": 1849905
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueCamera/glTF/camera_camera_Normal.png",
+            "size": 4993139
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueCamera/glTF/camera_camera_Roughness.png",
+            "size": 2880076
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueCamera/glTF/camera_tripod_BaseColor.png",
+            "size": 4563165
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueCamera/glTF/camera_tripod_Normal.png",
+            "size": 2774785
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueCamera/glTF/camera_tripod_Roughness.png",
+            "size": 2336802
+        }
+    ],
+    "AntiqueCamera/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueCamera/screenshot/screenshot.png",
+            "size": 14513
+        }
+    ],
+    "AttenuationTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AttenuationTest/glTF-Binary/AttenuationTest.glb",
+            "size": 57532
+        }
+    ],
+    "AttenuationTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AttenuationTest/glTF/AttenuationLabels.png",
+            "size": 24933
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AttenuationTest/glTF/AttenuationTest.bin",
+            "size": 10584
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AttenuationTest/glTF/AttenuationTest.gltf",
+            "size": 34579
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AttenuationTest/glTF/PlainGrid.png",
+            "size": 618
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AttenuationTest/glTF/ThicknessTexture.png",
+            "size": 8370
+        }
+    ],
+    "AttenuationTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AttenuationTest/screenshot/screenshot-large.jpg",
+            "size": 555848
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AttenuationTest/screenshot/screenshot.jpg",
+            "size": 64621
+        }
+    ],
+    "Avocado/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Avocado/glTF-Binary/Avocado.glb",
+            "size": 8328156
+        }
+    ],
+    "Avocado/glTF-Draco": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Avocado/glTF-Draco/Avocado.bin",
+            "size": 8724
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Avocado/glTF-Draco/Avocado.gltf",
+            "size": 3083
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Avocado/glTF-Draco/Avocado_baseColor.png",
+            "size": 3158729
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Avocado/glTF-Draco/Avocado_normal.png",
+            "size": 3489232
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Avocado/glTF-Draco/Avocado_roughnessMetallic.png",
+            "size": 1655059
+        }
+    ],
+    "Avocado/glTF-Quantized": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Avocado/glTF-Quantized/Avocado.bin",
+            "size": 12212
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Avocado/glTF-Quantized/Avocado.gltf",
+            "size": 4037
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Avocado/glTF-Quantized/Avocado_baseColor.png",
+            "size": 3158729
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Avocado/glTF-Quantized/Avocado_normal.png",
+            "size": 3489232
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Avocado/glTF-Quantized/Avocado_roughnessMetallic.png",
+            "size": 1655059
+        }
+    ],
+    "Avocado/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Avocado/glTF/Avocado.bin",
+            "size": 23580
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Avocado/glTF/Avocado.gltf",
+            "size": 2413
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Avocado/glTF/Avocado_baseColor.png",
+            "size": 3158729
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Avocado/glTF/Avocado_normal.png",
+            "size": 3489232
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Avocado/glTF/Avocado_roughnessMetallic.png",
+            "size": 1655059
+        }
+    ],
+    "Avocado/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Avocado/screenshot/screenshot.jpg",
+            "size": 3414
+        }
+    ],
+    "BarramundiFish/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BarramundiFish/glTF-Binary/BarramundiFish.glb",
+            "size": 12521196
+        }
+    ],
+    "BarramundiFish/glTF-Draco": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BarramundiFish/glTF-Draco/BarramundiFish.bin",
+            "size": 43300
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BarramundiFish/glTF-Draco/BarramundiFish.gltf",
+            "size": 3266
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BarramundiFish/glTF-Draco/BarramundiFish_baseColor.png",
+            "size": 4985099
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BarramundiFish/glTF-Draco/BarramundiFish_normal.png",
+            "size": 3050432
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BarramundiFish/glTF-Draco/BarramundiFish_occlusionRoughnessMetallic.png",
+            "size": 4355820
+        }
+    ],
+    "BarramundiFish/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BarramundiFish/glTF/BarramundiFish.bin",
+            "size": 128208
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BarramundiFish/glTF/BarramundiFish.gltf",
+            "size": 2554
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BarramundiFish/glTF/BarramundiFish_baseColor.png",
+            "size": 4985099
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BarramundiFish/glTF/BarramundiFish_normal.png",
+            "size": 3050432
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BarramundiFish/glTF/BarramundiFish_occlusionRoughnessMetallic.png",
+            "size": 4355820
+        }
+    ],
+    "BarramundiFish/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BarramundiFish/screenshot/screenshot.jpg",
+            "size": 2138
+        }
+    ],
+    "BoomBox/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF-Binary/BoomBox.glb",
+            "size": 10945640
+        }
+    ],
+    "BoomBox/glTF-Draco": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF-Draco/BoomBox.bin",
+            "size": 71144
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF-Draco/BoomBox.gltf",
+            "size": 3371
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF-Draco/BoomBox_baseColor.png",
+            "size": 3285844
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF-Draco/BoomBox_emissive.png",
+            "size": 132833
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF-Draco/BoomBox_normal.png",
+            "size": 2845923
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF-Draco/BoomBox_occlusionRoughnessMetallic.png",
+            "size": 4471451
+        }
+    ],
+    "BoomBox/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF/BoomBox.bin",
+            "size": 207816
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF/BoomBox.gltf",
+            "size": 2702
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF/BoomBox_baseColor.png",
+            "size": 3285844
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF/BoomBox_emissive.png",
+            "size": 132833
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF/BoomBox_normal.png",
+            "size": 2845923
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF/BoomBox_occlusionRoughnessMetallic.png",
+            "size": 4471451
+        }
+    ],
+    "BoomBox/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/screenshot/screenshot.jpg",
+            "size": 4139
+        }
+    ],
+    "BoomBoxWithAxes/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBoxWithAxes/glTF/BoomBoxWithAxes.bin",
+            "size": 591168
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBoxWithAxes/glTF/BoomBoxWithAxes.gltf",
+            "size": 9761
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBoxWithAxes/glTF/BoomBoxWithAxes_baseColor.png",
+            "size": 3285844
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBoxWithAxes/glTF/BoomBoxWithAxes_baseColor1.png",
+            "size": 130
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBoxWithAxes/glTF/BoomBoxWithAxes_emissive.png",
+            "size": 132833
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBoxWithAxes/glTF/BoomBoxWithAxes_normal.png",
+            "size": 2845923
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBoxWithAxes/glTF/BoomBoxWithAxes_roughnessMetallic.png",
+            "size": 3131213
+        }
+    ],
+    "BoomBoxWithAxes/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBoxWithAxes/screenshot/screenshot.jpg",
+            "size": 6967
+        }
+    ],
+    "Box With Spaces/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Box%20With%20Spaces/glTF/Box%20With%20Spaces.bin",
+            "size": 840
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Box%20With%20Spaces/glTF/Box%20With%20Spaces.gltf",
+            "size": 3395
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Box%20With%20Spaces/glTF/Normal%20Map.png",
+            "size": 45248
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Box%20With%20Spaces/glTF/Roughness%20Metallic.png",
+            "size": 18434
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Box%20With%20Spaces/glTF/glTF%20Logo%20With%20Spaces.png",
+            "size": 20640
+        }
+    ],
+    "Box With Spaces/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Box%20With%20Spaces/screenshot/screenshot.png",
+            "size": 9004
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Box%20With%20Spaces/screenshot/screenshot_large.png",
+            "size": 86214
+        }
+    ],
+    "Box/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Box/glTF-Binary/Box.glb",
+            "size": 1664
+        }
+    ],
+    "Box/glTF-Draco": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Box/glTF-Draco/Box.bin",
+            "size": 120
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Box/glTF-Draco/Box.gltf",
+            "size": 2427
+        }
+    ],
+    "Box/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Box/glTF-Embedded/Box.gltf",
+            "size": 3791
+        }
+    ],
+    "Box/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Box/glTF/Box.gltf",
+            "size": 2898
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Box/glTF/Box0.bin",
+            "size": 648
+        }
+    ],
+    "Box/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Box/screenshot/screenshot.png",
+            "size": 3276
+        }
+    ],
+    "BoxAnimated/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxAnimated/glTF-Binary/BoxAnimated.glb",
+            "size": 11944
+        }
+    ],
+    "BoxAnimated/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxAnimated/glTF-Embedded/BoxAnimated.gltf",
+            "size": 19713
+        }
+    ],
+    "BoxAnimated/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxAnimated/glTF/BoxAnimated.gltf",
+            "size": 7280
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxAnimated/glTF/BoxAnimated0.bin",
+            "size": 9308
+        }
+    ],
+    "BoxAnimated/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxAnimated/screenshot/BoxAnimatedBug.png",
+            "size": 15070
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxAnimated/screenshot/screenshot.gif",
+            "size": 41746
+        }
+    ],
+    "BoxInterleaved/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxInterleaved/glTF-Binary/BoxInterleaved.glb",
+            "size": 1632
+        }
+    ],
+    "BoxInterleaved/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxInterleaved/glTF-Embedded/BoxInterleaved.gltf",
+            "size": 3724
+        }
+    ],
+    "BoxInterleaved/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxInterleaved/glTF/BoxInterleaved.bin",
+            "size": 648
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxInterleaved/glTF/BoxInterleaved.gltf",
+            "size": 2877
+        }
+    ],
+    "BoxInterleaved/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxInterleaved/screenshot/screenshot.png",
+            "size": 3276
+        }
+    ],
+    "BoxTextured/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxTextured/glTF-Binary/BoxTextured.glb",
+            "size": 6540
+        }
+    ],
+    "BoxTextured/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxTextured/glTF-Embedded/BoxTextured.gltf",
+            "size": 10620
+        }
+    ],
+    "BoxTextured/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxTextured/glTF/BoxTextured.gltf",
+            "size": 3695
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxTextured/glTF/BoxTextured0.bin",
+            "size": 840
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxTextured/glTF/CesiumLogoFlat.png",
+            "size": 4333
+        }
+    ],
+    "BoxTextured/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxTextured/screenshot/screenshot.png",
+            "size": 10893
+        }
+    ],
+    "BoxTexturedNonPowerOfTwo/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxTexturedNonPowerOfTwo/glTF-Binary/BoxTexturedNonPowerOfTwo.glb",
+            "size": 4696
+        }
+    ],
+    "BoxTexturedNonPowerOfTwo/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxTexturedNonPowerOfTwo/glTF-Embedded/BoxTexturedNonPowerOfTwo.gltf",
+            "size": 8084
+        }
+    ],
+    "BoxTexturedNonPowerOfTwo/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxTexturedNonPowerOfTwo/glTF/BoxTextured0.bin",
+            "size": 840
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxTexturedNonPowerOfTwo/glTF/BoxTexturedNonPowerOfTwo.gltf",
+            "size": 3695
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxTexturedNonPowerOfTwo/glTF/CesiumLogoFlat.png",
+            "size": 2433
+        }
+    ],
+    "BoxTexturedNonPowerOfTwo/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxTexturedNonPowerOfTwo/screenshot/screenshot.png",
+            "size": 10893
+        }
+    ],
+    "BoxVertexColors/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxVertexColors/glTF-Binary/BoxVertexColors.glb",
+            "size": 2880
+        }
+    ],
+    "BoxVertexColors/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxVertexColors/glTF-Embedded/BoxVertexColors.gltf",
+            "size": 6353
+        }
+    ],
+    "BoxVertexColors/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxVertexColors/glTF/BoxVertexColors.gltf",
+            "size": 4694
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxVertexColors/glTF/buffer.bin",
+            "size": 1224
+        }
+    ],
+    "BoxVertexColors/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxVertexColors/screenshot/screenshot.png",
+            "size": 22530
+        }
+    ],
+    "BrainStem/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BrainStem/glTF-Binary/BrainStem.glb",
+            "size": 3194848
+        }
+    ],
+    "BrainStem/glTF-Draco": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BrainStem/glTF-Draco/BrainStem.gltf",
+            "size": 187357
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BrainStem/glTF-Draco/BrainStem0.bin",
+            "size": 1802012
+        }
+    ],
+    "BrainStem/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BrainStem/glTF-Embedded/BrainStem.gltf",
+            "size": 4372640
+        }
+    ],
+    "BrainStem/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BrainStem/glTF/BrainStem.gltf",
+            "size": 232477
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BrainStem/glTF/BrainStem0.bin",
+            "size": 3105104
+        }
+    ],
+    "BrainStem/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BrainStem/screenshot/screenshot.gif",
+            "size": 944494
+        }
+    ],
+    "Buggy/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Buggy/glTF-Binary/Buggy.glb",
+            "size": 7885636
+        }
+    ],
+    "Buggy/glTF-Draco": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Buggy/glTF-Draco/Buggy.bin",
+            "size": 685216
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Buggy/glTF-Draco/Buggy.gltf",
+            "size": 319098
+        }
+    ],
+    "Buggy/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Buggy/glTF-Embedded/Buggy.gltf",
+            "size": 10711909
+        }
+    ],
+    "Buggy/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Buggy/glTF/Buggy.gltf",
+            "size": 383898
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Buggy/glTF/Buggy0.bin",
+            "size": 7745988
+        }
+    ],
+    "Buggy/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Buggy/screenshot/screenshot.png",
+            "size": 18217
+        }
+    ],
+    "Cameras/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Cameras/glTF-Embedded/Cameras.gltf",
+            "size": 1790
+        }
+    ],
+    "Cameras/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Cameras/glTF/Cameras.gltf",
+            "size": 1689
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Cameras/glTF/simpleSquare.bin",
+            "size": 60
+        }
+    ],
+    "Cameras/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Cameras/screenshot/screenshot.png",
+            "size": 518
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Cameras/screenshot/simpleSquare.png",
+            "size": 48299
+        }
+    ],
+    "CesiumMan/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMan/glTF-Binary/CesiumMan.glb",
+            "size": 490956
+        }
+    ],
+    "CesiumMan/glTF-Draco": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMan/glTF-Draco/CesiumMan.gltf",
+            "size": 51891
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMan/glTF-Draco/CesiumMan_data.bin",
+            "size": 89512
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMan/glTF-Draco/CesiumMan_img0.jpg",
+            "size": 209908
+        }
+    ],
+    "CesiumMan/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMan/glTF-Embedded/CesiumMan.gltf",
+            "size": 685337
+        }
+    ],
+    "CesiumMan/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMan/glTF/CesiumMan.gltf",
+            "size": 51950
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMan/glTF/CesiumMan_data.bin",
+            "size": 252664
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMan/glTF/CesiumMan_img0.jpg",
+            "size": 209908
+        }
+    ],
+    "CesiumMan/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMan/screenshot/screenshot.gif",
+            "size": 463946
+        }
+    ],
+    "CesiumMilkTruck/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMilkTruck/glTF-Binary/CesiumMilkTruck.glb",
+            "size": 447200
+        }
+    ],
+    "CesiumMilkTruck/glTF-Draco": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMilkTruck/glTF-Draco/CesiumMilkTruck.gltf",
+            "size": 9882
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMilkTruck/glTF-Draco/CesiumMilkTruck.jpg",
+            "size": 296200
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMilkTruck/glTF-Draco/CesiumMilkTruck_data.bin",
+            "size": 11452
+        }
+    ],
+    "CesiumMilkTruck/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMilkTruck/glTF-Embedded/CesiumMilkTruck.gltf",
+            "size": 598353
+        }
+    ],
+    "CesiumMilkTruck/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMilkTruck/glTF/CesiumMilkTruck.gltf",
+            "size": 8608
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMilkTruck/glTF/CesiumMilkTruck.jpg",
+            "size": 296200
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMilkTruck/glTF/CesiumMilkTruck_data.bin",
+            "size": 146092
+        }
+    ],
+    "CesiumMilkTruck/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMilkTruck/screenshot/screenshot.gif",
+            "size": 18544
+        }
+    ],
+    "ClearCoatTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ClearCoatTest/glTF-Binary/ClearCoatTest.glb",
+            "size": 238416
+        }
+    ],
+    "ClearCoatTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ClearCoatTest/glTF/ClearCoatLabels.png",
+            "size": 10270
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ClearCoatTest/glTF/ClearCoatTest.bin",
+            "size": 50328
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ClearCoatTest/glTF/ClearCoatTest.gltf",
+            "size": 42555
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ClearCoatTest/glTF/PartialCoating.png",
+            "size": 5077
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ClearCoatTest/glTF/PartialCoating_Alpha.png",
+            "size": 5065
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ClearCoatTest/glTF/PlasticWrap_normals.jpg",
+            "size": 144210
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ClearCoatTest/glTF/RibsNormal.png",
+            "size": 1605
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ClearCoatTest/glTF/RoughnessStripes.png",
+            "size": 5033
+        }
+    ],
+    "ClearCoatTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ClearCoatTest/screenshot/FirstRow.jpg",
+            "size": 65964
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ClearCoatTest/screenshot/PartialCoat.jpg",
+            "size": 37046
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ClearCoatTest/screenshot/screenshot.jpg",
+            "size": 32519
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ClearCoatTest/screenshot/screenshot_large.jpg",
+            "size": 173820
+        }
+    ],
+    "Corset/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Corset/glTF-Binary/Corset.glb",
+            "size": 13583048
+        }
+    ],
+    "Corset/glTF-Draco": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Corset/glTF-Draco/Corset.bin",
+            "size": 230116
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Corset/glTF-Draco/Corset.gltf",
+            "size": 3179
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Corset/glTF-Draco/Corset_baseColor.png",
+            "size": 4501246
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Corset/glTF-Draco/Corset_normal.png",
+            "size": 4974340
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Corset/glTF-Draco/Corset_occlusionRoughnessMetallic.png",
+            "size": 3443675
+        }
+    ],
+    "Corset/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Corset/glTF/Corset.bin",
+            "size": 662184
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Corset/glTF/Corset.gltf",
+            "size": 2487
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Corset/glTF/Corset_baseColor.png",
+            "size": 4501246
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Corset/glTF/Corset_normal.png",
+            "size": 4974340
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Corset/glTF/Corset_occlusionRoughnessMetallic.png",
+            "size": 3443675
+        }
+    ],
+    "Corset/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Corset/screenshot/screenshot.jpg",
+            "size": 3150
+        }
+    ],
+    "Cube/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Cube/glTF/Cube.bin",
+            "size": 1800
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Cube/glTF/Cube.gltf",
+            "size": 3671
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Cube/glTF/Cube_BaseColor.png",
+            "size": 891995
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Cube/glTF/Cube_MetallicRoughness.png",
+            "size": 319
+        }
+    ],
+    "Cube/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Cube/screenshot/screenshot.jpg",
+            "size": 8597
+        }
+    ],
+    "DamagedHelmet/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF-Binary/DamagedHelmet.glb",
+            "size": 3773916
+        }
+    ],
+    "DamagedHelmet/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF-Embedded/DamagedHelmet.gltf",
+            "size": 5033556
+        }
+    ],
+    "DamagedHelmet/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF/DamagedHelmet.bin",
+            "size": 558504
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF/DamagedHelmet.gltf",
+            "size": 4537
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF/Default_AO.jpg",
+            "size": 361678
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF/Default_albedo.jpg",
+            "size": 935629
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF/Default_emissive.jpg",
+            "size": 97499
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF/Default_metalRoughness.jpg",
+            "size": 1300661
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF/Default_normal.jpg",
+            "size": 517757
+        }
+    ],
+    "DamagedHelmet/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/screenshot/screenshot.png",
+            "size": 45695
+        }
+    ],
+    "DragonAttenuation/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DragonAttenuation/glTF-Binary/DragonAttenuation.glb",
+            "size": 6566656
+        }
+    ],
+    "DragonAttenuation/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DragonAttenuation/glTF/DragonAttenuation.bin",
+            "size": 5817396
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DragonAttenuation/glTF/DragonAttenuation.gltf",
+            "size": 8403
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DragonAttenuation/glTF/Dragon_ThicknessMap.jpg",
+            "size": 578150
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DragonAttenuation/glTF/checkerboard.jpg",
+            "size": 167652
+        }
+    ],
+    "DragonAttenuation/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DragonAttenuation/screenshot/screenshot.jpg",
+            "size": 21803
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DragonAttenuation/screenshot/screenshot_large.png",
+            "size": 852231
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DragonAttenuation/screenshot/screenshot_pathTraced.png",
+            "size": 753329
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DragonAttenuation/screenshot/surface_color.png",
+            "size": 643107
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DragonAttenuation/screenshot/too-dark.png",
+            "size": 1246273
+        }
+    ],
+    "Duck/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Duck/glTF-Binary/Duck.glb",
+            "size": 120484
+        }
+    ],
+    "Duck/glTF-Draco": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Duck/glTF-Draco/Duck.bin",
+            "size": 10368
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Duck/glTF-Draco/Duck.gltf",
+            "size": 3797
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Duck/glTF-Draco/DuckCM.png",
+            "size": 16302
+        }
+    ],
+    "Duck/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Duck/glTF-Embedded/Duck.gltf",
+            "size": 162796
+        }
+    ],
+    "Duck/glTF-Quantized": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Duck/glTF-Quantized/Duck.bin",
+            "size": 63656
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Duck/glTF-Quantized/Duck.gltf",
+            "size": 3729
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Duck/glTF-Quantized/DuckCM.png",
+            "size": 16302
+        }
+    ],
+    "Duck/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Duck/glTF/Duck.gltf",
+            "size": 4964
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Duck/glTF/Duck0.bin",
+            "size": 102040
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Duck/glTF/DuckCM.png",
+            "size": 16302
+        }
+    ],
+    "Duck/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Duck/screenshot/screenshot.png",
+            "size": 15991
+        }
+    ],
+    "EmissiveStrengthTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/EmissiveStrengthTest/glTF-Binary/EmissiveStrengthTest.glb",
+            "size": 10668
+        }
+    ],
+    "EmissiveStrengthTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/EmissiveStrengthTest/glTF/EmissiveStrengthTest.bin",
+            "size": 5308
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/EmissiveStrengthTest/glTF/EmissiveStrengthTest.gltf",
+            "size": 12458
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/EmissiveStrengthTest/glTF/PlainGrid.png",
+            "size": 618
+        }
+    ],
+    "EmissiveStrengthTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/EmissiveStrengthTest/screenshot/screenshot.jpg",
+            "size": 20819
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/EmissiveStrengthTest/screenshot/screenshot_large_bloom.jpg",
+            "size": 101463
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/EmissiveStrengthTest/screenshot/screenshot_large_plain.jpg",
+            "size": 95448
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/EmissiveStrengthTest/screenshot/test_fail.jpg",
+            "size": 41072
+        }
+    ],
+    "EnvironmentTest/glTF-IBL": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/EnvironmentTest/glTF-IBL/EnvironmentTest.gltf",
+            "size": 19373
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/EnvironmentTest/glTF-IBL/EnvironmentTest_binary.bin",
+            "size": 1414042
+        },
+        {
+            "download_url": null,
+            "size": 0
+        }
+    ],
+    "EnvironmentTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/EnvironmentTest/glTF/EnvironmentTest.gltf",
+            "size": 8258
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/EnvironmentTest/glTF/EnvironmentTest_binary.bin",
+            "size": 340472
+        },
+        {
+            "download_url": null,
+            "size": 0
+        }
+    ],
+    "EnvironmentTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/EnvironmentTest/screenshot/screenshot.jpg",
+            "size": 14072
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/EnvironmentTest/screenshot/screenshot_large.png",
+            "size": 989754
+        }
+    ],
+    "FlightHelmet/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet.bin",
+            "size": 3227148
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet.gltf",
+            "size": 18511
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet_Materials_GlassPlasticMat_BaseColor.png",
+            "size": 2306649
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet_Materials_GlassPlasticMat_Normal.png",
+            "size": 2648815
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet_Materials_GlassPlasticMat_OcclusionRoughMetal.png",
+            "size": 3696183
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet_Materials_LeatherPartsMat_BaseColor.png",
+            "size": 5478748
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet_Materials_LeatherPartsMat_Normal.png",
+            "size": 5675531
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet_Materials_LeatherPartsMat_OcclusionRoughMetal.png",
+            "size": 4375686
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet_Materials_LensesMat_BaseColor.png",
+            "size": 696304
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet_Materials_LensesMat_Normal.png",
+            "size": 5575
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet_Materials_LensesMat_OcclusionRoughMetal.png",
+            "size": 601603
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet_Materials_MetalPartsMat_BaseColor.png",
+            "size": 2680488
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet_Materials_MetalPartsMat_Normal.png",
+            "size": 3273483
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet_Materials_MetalPartsMat_OcclusionRoughMetal.png",
+            "size": 2976508
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet_Materials_RubberWoodMat_BaseColor.png",
+            "size": 3594300
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet_Materials_RubberWoodMat_Normal.png",
+            "size": 3327566
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet_Materials_RubberWoodMat_OcclusionRoughMetal.png",
+            "size": 3809284
+        }
+    ],
+    "FlightHelmet/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/screenshot/screenshot.jpg",
+            "size": 3795
+        }
+    ],
+    "Fox/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Fox/glTF-Binary/Fox.glb",
+            "size": 162852
+        }
+    ],
+    "Fox/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Fox/glTF/Fox.bin",
+            "size": 119904
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Fox/glTF/Fox.gltf",
+            "size": 45064
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Fox/glTF/Texture.png",
+            "size": 26764
+        }
+    ],
+    "Fox/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Fox/screenshot/screenshot.jpg",
+            "size": 6639
+        }
+    ],
+    "GearboxAssy/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/GearboxAssy/glTF-Binary/GearboxAssy.glb",
+            "size": 4958788
+        }
+    ],
+    "GearboxAssy/glTF-Draco": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/GearboxAssy/glTF-Draco/GearboxAssy.bin",
+            "size": 349056
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/GearboxAssy/glTF-Draco/GearboxAssy.gltf",
+            "size": 98603
+        }
+    ],
+    "GearboxAssy/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/GearboxAssy/glTF-Embedded/GearboxAssy.gltf",
+            "size": 6678903
+        }
+    ],
+    "GearboxAssy/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/GearboxAssy/glTF/GearboxAssy.gltf",
+            "size": 124610
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/GearboxAssy/glTF/GearboxAssy0.bin",
+            "size": 4915704
+        }
+    ],
+    "GearboxAssy/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/GearboxAssy/screenshot/screenshot.png",
+            "size": 10126
+        }
+    ],
+    "GlamVelvetSofa/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/GlamVelvetSofa/glTF-Binary/GlamVelvetSofa.glb",
+            "size": 3149844
+        }
+    ],
+    "GlamVelvetSofa/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/GlamVelvetSofa/glTF/GlamVelvetSofa.bin",
+            "size": 124952
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/GlamVelvetSofa/glTF/GlamVelvetSofa.gltf",
+            "size": 16868
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/GlamVelvetSofa/glTF/GlamVelvetSofa_normal.png",
+            "size": 2487826
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/GlamVelvetSofa/glTF/GlamVelvetSofa_occlusion.png",
+            "size": 530651
+        }
+    ],
+    "GlamVelvetSofa/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/GlamVelvetSofa/screenshot/normalTexture.jpg",
+            "size": 505216
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/GlamVelvetSofa/screenshot/photoreference_vs_customer.jpg",
+            "size": 258733
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/GlamVelvetSofa/screenshot/screenshot.jpg",
+            "size": 26867
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/GlamVelvetSofa/screenshot/screenshot_large.jpg",
+            "size": 120052
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/GlamVelvetSofa/screenshot/screenshot_layers.jpg",
+            "size": 249775
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/GlamVelvetSofa/screenshot/screenshot_punctual.jpg",
+            "size": 252607
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/GlamVelvetSofa/screenshot/screenshot_variants.jpg",
+            "size": 168715
+        }
+    ],
+    "InterpolationTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/InterpolationTest/glTF-Binary/InterpolationTest.glb",
+            "size": 33304
+        }
+    ],
+    "InterpolationTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/InterpolationTest/glTF/InterpolationTest.gltf",
+            "size": 34490
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/InterpolationTest/glTF/interpolation.bin",
+            "size": 8672
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/InterpolationTest/glTF/l.jpg",
+            "size": 11376
+        }
+    ],
+    "InterpolationTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/InterpolationTest/screenshot/screenshot.gif",
+            "size": 455009
+        }
+    ],
+    "IridescenceDielectricSpheres/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceDielectricSpheres/glTF/IridescenceDielectricSpheres.bin",
+            "size": 10559132
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceDielectricSpheres/glTF/IridescenceDielectricSpheres.gltf",
+            "size": 834191
+        },
+        {
+            "download_url": null,
+            "size": 0
+        }
+    ],
+    "IridescenceDielectricSpheres/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceDielectricSpheres/screenshot/screenshot.jpg",
+            "size": 32496
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceDielectricSpheres/screenshot/screenshot_large.jpg",
+            "size": 333286
+        }
+    ],
+    "IridescenceLamp/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceLamp/glTF-Binary/IridescenceLamp.glb",
+            "size": 5291216
+        }
+    ],
+    "IridescenceLamp/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceLamp/glTF/IridescenceLamp.bin",
+            "size": 455052
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceLamp/glTF/IridescenceLamp.gltf",
+            "size": 8772
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceLamp/glTF/IridescenceLamp_BaseColor.png",
+            "size": 1164997
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceLamp/glTF/IridescenceLamp_Iridescence.png",
+            "size": 725084
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceLamp/glTF/IridescenceLamp_OcclusionRoughnessMetalness.png",
+            "size": 2941814
+        }
+    ],
+    "IridescenceLamp/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceLamp/screenshot/reference_Photos.jpg",
+            "size": 378216
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceLamp/screenshot/screenshot.jpg",
+            "size": 40704
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceLamp/screenshot/screenshot_Large.jpg",
+            "size": 247094
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceLamp/screenshot/textures.jpg",
+            "size": 214440
+        }
+    ],
+    "IridescenceMetallicSpheres/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceMetallicSpheres/glTF/IridescenceMetallicSpheres.bin",
+            "size": 10559132
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceMetallicSpheres/glTF/IridescenceMetallicSpheres.gltf",
+            "size": 812271
+        },
+        {
+            "download_url": null,
+            "size": 0
+        }
+    ],
+    "IridescenceMetallicSpheres/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceMetallicSpheres/screenshot/screenshot.jpg",
+            "size": 51361
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceMetallicSpheres/screenshot/screenshot_large.jpg",
+            "size": 615960
+        }
+    ],
+    "IridescenceSuzanne/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceSuzanne/glTF-Binary/IridescenceSuzanne.glb",
+            "size": 507608
+        }
+    ],
+    "IridescenceSuzanne/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceSuzanne/glTF/IridescenceSuzanne.bin",
+            "size": 129888
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceSuzanne/glTF/IridescenceSuzanne.gltf",
+            "size": 7725
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceSuzanne/glTF/noise.png",
+            "size": 374268
+        }
+    ],
+    "IridescenceSuzanne/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceSuzanne/screenshot/screenshot.jpg",
+            "size": 9747
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescenceSuzanne/screenshot/screenshot_large.jpg",
+            "size": 112411
+        }
+    ],
+    "IridescentDishWithOlives/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescentDishWithOlives/glTF-Binary/IridescentDishWithOlives.glb",
+            "size": 8547764
+        }
+    ],
+    "IridescentDishWithOlives/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescentDishWithOlives/glTF/IridescentDishWithOlives.bin",
+            "size": 830680
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescentDishWithOlives/glTF/IridescentDishWithOlives.gltf",
+            "size": 16710
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescentDishWithOlives/glTF/glasscover_nrm.png",
+            "size": 369297
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescentDishWithOlives/glTF/glasscover_orm.png",
+            "size": 9879
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescentDishWithOlives/glTF/glasscover_spec.png",
+            "size": 1841941
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescentDishWithOlives/glTF/glasscover_thick.png",
+            "size": 543381
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescentDishWithOlives/glTF/glassdish_spec.png",
+            "size": 409942
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescentDishWithOlives/glTF/goldleaf_col.png",
+            "size": 1199857
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescentDishWithOlives/glTF/goldleaf_nrm.png",
+            "size": 1672434
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescentDishWithOlives/glTF/goldleaf_orm.png",
+            "size": 712065
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescentDishWithOlives/glTF/olives_col.png",
+            "size": 183816
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescentDishWithOlives/glTF/olives_nrm.png",
+            "size": 228989
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescentDishWithOlives/glTF/olives_orm.png",
+            "size": 537508
+        }
+    ],
+    "IridescentDishWithOlives/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescentDishWithOlives/screenshot/DassaultPBRSampleRenderer.jpg",
+            "size": 156230
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescentDishWithOlives/screenshot/ReferencePhotos.jpg",
+            "size": 289672
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescentDishWithOlives/screenshot/glassCover_animation.gif",
+            "size": 798477
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescentDishWithOlives/screenshot/glassCover_textures.jpg",
+            "size": 38325
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescentDishWithOlives/screenshot/glassDish_occlusion.jpg",
+            "size": 44787
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescentDishWithOlives/screenshot/screenshot.jpg",
+            "size": 25505
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/IridescentDishWithOlives/screenshot/screenshot_Large.jpg",
+            "size": 117814
+        }
+    ],
+    "Lantern/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF-Binary/Lantern.glb",
+            "size": 9872848
+        }
+    ],
+    "Lantern/glTF-Draco": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF-Draco/Lantern.bin",
+            "size": 80968
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF-Draco/Lantern.gltf",
+            "size": 6806
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF-Draco/Lantern_baseColor.png",
+            "size": 4461532
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF-Draco/Lantern_emissive.png",
+            "size": 169335
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF-Draco/Lantern_normal.png",
+            "size": 2928441
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF-Draco/Lantern_roughnessMetallic.png",
+            "size": 2078597
+        }
+    ],
+    "Lantern/glTF-Quantized": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF-Quantized/Lantern.bin",
+            "size": 115264
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF-Quantized/Lantern.gltf",
+            "size": 4560
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF-Quantized/Lantern_baseColor.png",
+            "size": 4461532
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF-Quantized/Lantern_emissive.png",
+            "size": 169335
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF-Quantized/Lantern_normal.png",
+            "size": 2928441
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF-Quantized/Lantern_roughnessMetallic.png",
+            "size": 2078597
+        }
+    ],
+    "Lantern/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF/Lantern.bin",
+            "size": 231324
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF/Lantern.gltf",
+            "size": 5970
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF/Lantern_baseColor.png",
+            "size": 4461532
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF/Lantern_emissive.png",
+            "size": 169335
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF/Lantern_normal.png",
+            "size": 2928441
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF/Lantern_roughnessMetallic.png",
+            "size": 2078597
+        }
+    ],
+    "Lantern/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/screenshot/screenshot.jpg",
+            "size": 2615
+        }
+    ],
+    "LightsPunctualLamp/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/LightsPunctualLamp/glTF-Binary/LightsPunctualLamp.glb",
+            "size": 4454736
+        }
+    ],
+    "LightsPunctualLamp/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/LightsPunctualLamp/glTF/LightsPunctualLamp.data.bin",
+            "size": 254640
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/LightsPunctualLamp/glTF/LightsPunctualLamp.gltf",
+            "size": 13375
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/LightsPunctualLamp/glTF/material0_basecolor.jpeg",
+            "size": 505404
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/LightsPunctualLamp/glTF/material0_emissive.jpeg",
+            "size": 128060
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/LightsPunctualLamp/glTF/material0_metallic_roughness.jpeg",
+            "size": 184485
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/LightsPunctualLamp/glTF/material0_normal.png",
+            "size": 3141333
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/LightsPunctualLamp/glTF/material1_basecolor.png",
+            "size": 55574
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/LightsPunctualLamp/glTF/material1_normal.png",
+            "size": 126
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/LightsPunctualLamp/glTF/material2_transmission.jpeg",
+            "size": 177035
+        }
+    ],
+    "LightsPunctualLamp/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/LightsPunctualLamp/screenshot/lamp_white_bg.png",
+            "size": 753753
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/LightsPunctualLamp/screenshot/lights_on_off.gif",
+            "size": 210571
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/LightsPunctualLamp/screenshot/screenshot.png",
+            "size": 49999
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/LightsPunctualLamp/screenshot/shade_details.gif",
+            "size": 620491
+        }
+    ],
+    "MaterialsVariantsShoe/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MaterialsVariantsShoe/glTF-Binary/MaterialsVariantsShoe.glb",
+            "size": 7833592
+        }
+    ],
+    "MaterialsVariantsShoe/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MaterialsVariantsShoe/glTF/MaterialsVariantsShoe.bin",
+            "size": 705680
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MaterialsVariantsShoe/glTF/MaterialsVariantsShoe.gltf",
+            "size": 7005
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MaterialsVariantsShoe/glTF/diffuseBeach.jpg",
+            "size": 1249172
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MaterialsVariantsShoe/glTF/diffuseMidnight.jpg",
+            "size": 1252316
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MaterialsVariantsShoe/glTF/diffuseStreet.jpg",
+            "size": 1204836
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MaterialsVariantsShoe/glTF/normal.jpg",
+            "size": 2298412
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MaterialsVariantsShoe/glTF/occlusionRougnessMetalness.jpg",
+            "size": 1119084
+        }
+    ],
+    "MaterialsVariantsShoe/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MaterialsVariantsShoe/screenshot/screenshot-large.png",
+            "size": 853191
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MaterialsVariantsShoe/screenshot/screenshot.jpg",
+            "size": 22747
+        }
+    ],
+    "MetalRoughSpheres/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MetalRoughSpheres/glTF-Binary/MetalRoughSpheres.glb",
+            "size": 11221356
+        }
+    ],
+    "MetalRoughSpheres/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MetalRoughSpheres/glTF-Embedded/MetalRoughSpheres.gltf",
+            "size": 14967419
+        }
+    ],
+    "MetalRoughSpheres/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MetalRoughSpheres/glTF/MetalRoughSpheres.gltf",
+            "size": 11899
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MetalRoughSpheres/glTF/MetalRoughSpheres0.bin",
+            "size": 11199904
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MetalRoughSpheres/glTF/Spheres_BaseColor.png",
+            "size": 8500
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MetalRoughSpheres/glTF/Spheres_MetalRough.png",
+            "size": 8220
+        }
+    ],
+    "MetalRoughSpheres/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MetalRoughSpheres/screenshot/screenshot.png",
+            "size": 132610
+        }
+    ],
+    "MetalRoughSpheresNoTextures/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MetalRoughSpheresNoTextures/glTF-Binary/MetalRoughSpheresNoTextures.glb",
+            "size": 291316
+        }
+    ],
+    "MetalRoughSpheresNoTextures/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MetalRoughSpheresNoTextures/glTF/MetalRoughSpheresNoTextures.bin",
+            "size": 241588
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MetalRoughSpheresNoTextures/glTF/MetalRoughSpheresNoTextures.gltf",
+            "size": 128886
+        }
+    ],
+    "MetalRoughSpheresNoTextures/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MetalRoughSpheresNoTextures/screenshot/screenshot.png",
+            "size": 87822
+        }
+    ],
+    "MorphPrimitivesTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MorphPrimitivesTest/glTF-Binary/MorphPrimitivesTest.glb",
+            "size": 53656
+        }
+    ],
+    "MorphPrimitivesTest/glTF-Draco": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MorphPrimitivesTest/glTF-Draco/MorphPrimitivesTest.bin",
+            "size": 880
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MorphPrimitivesTest/glTF-Draco/MorphPrimitivesTest.gltf",
+            "size": 5295
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MorphPrimitivesTest/glTF-Draco/uv_texture.jpg",
+            "size": 49535
+        }
+    ],
+    "MorphPrimitivesTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MorphPrimitivesTest/glTF/MorphPrimitivesTest.bin",
+            "size": 1512
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MorphPrimitivesTest/glTF/MorphPrimitivesTest.gltf",
+            "size": 5610
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MorphPrimitivesTest/glTF/uv_texture.jpg",
+            "size": 49535
+        }
+    ],
+    "MorphPrimitivesTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MorphPrimitivesTest/screenshot/screenshot.jpg",
+            "size": 22158
+        }
+    ],
+    "MorphStressTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MorphStressTest/glTF-Binary/MorphStressTest.glb",
+            "size": 575900
+        }
+    ],
+    "MorphStressTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MorphStressTest/glTF/Base_AO.png",
+            "size": 178434
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MorphStressTest/glTF/ColorSwatches.png",
+            "size": 208
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MorphStressTest/glTF/MorphStressTest.bin",
+            "size": 388084
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MorphStressTest/glTF/MorphStressTest.gltf",
+            "size": 23726
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MorphStressTest/glTF/TinyGrid.png",
+            "size": 186
+        }
+    ],
+    "MorphStressTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MorphStressTest/screenshot/Anim_Individuals.gif",
+            "size": 190120
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MorphStressTest/screenshot/Anim_Pulse.gif",
+            "size": 219417
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MorphStressTest/screenshot/Anim_TheWave.gif",
+            "size": 129123
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MorphStressTest/screenshot/screenshot.jpg",
+            "size": 19604
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MorphStressTest/screenshot/screenshot_large.png",
+            "size": 150098
+        }
+    ],
+    "MosquitoInAmber/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MosquitoInAmber/glTF-Binary/MosquitoInAmber.glb",
+            "size": 24229904
+        }
+    ],
+    "MosquitoInAmber/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MosquitoInAmber/glTF/MosquitoInAmber.bin",
+            "size": 1068732
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MosquitoInAmber/glTF/MosquitoInAmber.gltf",
+            "size": 12108
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MosquitoInAmber/glTF/MosquitoInAmber0.jpg",
+            "size": 5075318
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MosquitoInAmber/glTF/MosquitoInAmber1.png",
+            "size": 8252506
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MosquitoInAmber/glTF/MosquitoInAmber2.png",
+            "size": 5109210
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MosquitoInAmber/glTF/MosquitoInAmber3.jpg",
+            "size": 1978714
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MosquitoInAmber/glTF/MosquitoInAmber4.jpg",
+            "size": 2738829
+        }
+    ],
+    "MosquitoInAmber/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MosquitoInAmber/screenshot/screenshot.jpg",
+            "size": 10858
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MosquitoInAmber/screenshot/screenshot_large.jpg",
+            "size": 100344
+        }
+    ],
+    "MultiUVTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MultiUVTest/glTF-Binary/MultiUVTest.glb",
+            "size": 43004
+        }
+    ],
+    "MultiUVTest/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MultiUVTest/glTF-Embedded/MultiUVTest.gltf",
+            "size": 60000
+        }
+    ],
+    "MultiUVTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MultiUVTest/glTF/MultiUVTest.bin",
+            "size": 1380
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MultiUVTest/glTF/MultiUVTest.gltf",
+            "size": 5904
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MultiUVTest/glTF/uv0.png",
+            "size": 32939
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MultiUVTest/glTF/uv1.png",
+            "size": 56185
+        }
+    ],
+    "MultiUVTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MultiUVTest/screenshot/screenshot.jpg",
+            "size": 95050
+        }
+    ],
+    "NormalTangentMirrorTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentMirrorTest/glTF-Binary/NormalTangentMirrorTest.glb",
+            "size": 2019856
+        }
+    ],
+    "NormalTangentMirrorTest/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentMirrorTest/glTF-Embedded/NormalTangentMirrorTest.gltf",
+            "size": 2694907
+        }
+    ],
+    "NormalTangentMirrorTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentMirrorTest/glTF/NormalTangentMirrorTest.bin",
+            "size": 164400
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentMirrorTest/glTF/NormalTangentMirrorTest.gltf",
+            "size": 4956
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentMirrorTest/glTF/NormalTangentMirrorTest_BaseColor.png",
+            "size": 60447
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentMirrorTest/glTF/NormalTangentMirrorTest_OcclusionRoughnessMetallic.png",
+            "size": 1456044
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentMirrorTest/glTF/NormalTangentTest_Normal.png",
+            "size": 336676
+        }
+    ],
+    "NormalTangentMirrorTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentMirrorTest/screenshot/back-side.png",
+            "size": 193337
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentMirrorTest/screenshot/incorrect-flipped-y.png",
+            "size": 177355
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentMirrorTest/screenshot/screenshot-larger.png",
+            "size": 265801
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentMirrorTest/screenshot/screenshot.png",
+            "size": 50407
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentMirrorTest/screenshot/supplied-tangents-ignored.png",
+            "size": 327871
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentMirrorTest/screenshot/top-down.png",
+            "size": 12431
+        }
+    ],
+    "NormalTangentTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentTest/glTF-Binary/NormalTangentTest.glb",
+            "size": 1921176
+        }
+    ],
+    "NormalTangentTest/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentTest/glTF-Embedded/NormalTangentTest.gltf",
+            "size": 2563105
+        }
+    ],
+    "NormalTangentTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentTest/glTF/NormalTangentTest.gltf",
+            "size": 4459
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentTest/glTF/NormalTangentTest0.bin",
+            "size": 174100
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentTest/glTF/NormalTangentTest_BaseColor.png",
+            "size": 36384
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentTest/glTF/NormalTangentTest_Normal.png",
+            "size": 336676
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentTest/glTF/NormalTangentTest_OcclusionRoughnessMetallic.png",
+            "size": 1371840
+        }
+    ],
+    "NormalTangentTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentTest/screenshot/back-side.png",
+            "size": 206004
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentTest/screenshot/incorrect-flipped-y.png",
+            "size": 122388
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentTest/screenshot/screenshot-larger.png",
+            "size": 122252
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentTest/screenshot/screenshot.png",
+            "size": 41054
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NormalTangentTest/screenshot/top-down.png",
+            "size": 13904
+        }
+    ],
+    "OrientationTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/OrientationTest/glTF-Binary/OrientationTest.glb",
+            "size": 38920
+        }
+    ],
+    "OrientationTest/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/OrientationTest/glTF-Embedded/OrientationTest.gltf",
+            "size": 67527
+        }
+    ],
+    "OrientationTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/OrientationTest/glTF/OrientationTest.bin",
+            "size": 27168
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/OrientationTest/glTF/OrientationTest.gltf",
+            "size": 31285
+        }
+    ],
+    "OrientationTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/OrientationTest/screenshot/OrientationTestFail.png",
+            "size": 58520
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/OrientationTest/screenshot/screenshot.png",
+            "size": 44099
+        }
+    ],
+    "ReciprocatingSaw/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ReciprocatingSaw/glTF-Binary/ReciprocatingSaw.glb",
+            "size": 3562996
+        }
+    ],
+    "ReciprocatingSaw/glTF-Draco": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ReciprocatingSaw/glTF-Draco/ReciprocatingSaw.bin",
+            "size": 303404
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ReciprocatingSaw/glTF-Draco/ReciprocatingSaw.gltf",
+            "size": 150174
+        }
+    ],
+    "ReciprocatingSaw/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ReciprocatingSaw/glTF-Embedded/ReciprocatingSaw.gltf",
+            "size": 4848383
+        }
+    ],
+    "ReciprocatingSaw/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ReciprocatingSaw/glTF/ReciprocatingSaw.gltf",
+            "size": 186015
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ReciprocatingSaw/glTF/ReciprocatingSaw0.bin",
+            "size": 3496764
+        }
+    ],
+    "ReciprocatingSaw/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ReciprocatingSaw/screenshot/screenshot.png",
+            "size": 6987
+        }
+    ],
+    "RecursiveSkeletons/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/RecursiveSkeletons/glTF-Binary/RecursiveSkeletons.glb",
+            "size": 561620
+        }
+    ],
+    "RecursiveSkeletons/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/RecursiveSkeletons/glTF/RecursiveSkeletons.bin",
+            "size": 106056
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/RecursiveSkeletons/glTF/RecursiveSkeletons.gltf",
+            "size": 939613
+        }
+    ],
+    "RecursiveSkeletons/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/RecursiveSkeletons/screenshot/screenshot-skin-rigging.jpg",
+            "size": 49277
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/RecursiveSkeletons/screenshot/screenshot.jpg",
+            "size": 4588
+        }
+    ],
+    "RiggedFigure/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/RiggedFigure/glTF-Binary/RiggedFigure.glb",
+            "size": 50116
+        }
+    ],
+    "RiggedFigure/glTF-Draco": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/RiggedFigure/glTF-Draco/RiggedFigure.gltf",
+            "size": 50939
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/RiggedFigure/glTF-Draco/RiggedFigure0.bin",
+            "size": 6172
+        }
+    ],
+    "RiggedFigure/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/RiggedFigure/glTF-Embedded/RiggedFigure.gltf",
+            "size": 99902
+        }
+    ],
+    "RiggedFigure/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/RiggedFigure/glTF/RiggedFigure.gltf",
+            "size": 70302
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/RiggedFigure/glTF/RiggedFigure0.bin",
+            "size": 22184
+        }
+    ],
+    "RiggedFigure/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/RiggedFigure/screenshot/screenshot.gif",
+            "size": 35670
+        }
+    ],
+    "RiggedSimple/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/RiggedSimple/glTF-Binary/RiggedSimple.glb",
+            "size": 15104
+        }
+    ],
+    "RiggedSimple/glTF-Draco": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/RiggedSimple/glTF-Draco/RiggedSimple.gltf",
+            "size": 7550
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/RiggedSimple/glTF-Draco/RiggedSimple0.bin",
+            "size": 4520
+        }
+    ],
+    "RiggedSimple/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/RiggedSimple/glTF-Embedded/RiggedSimple.gltf",
+            "size": 25435
+        }
+    ],
+    "RiggedSimple/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/RiggedSimple/glTF/RiggedSimple.gltf",
+            "size": 10567
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/RiggedSimple/glTF/RiggedSimple0.bin",
+            "size": 11136
+        }
+    ],
+    "RiggedSimple/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/RiggedSimple/screenshot/screenshot.gif",
+            "size": 66007
+        }
+    ],
+    "SciFiHelmet/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SciFiHelmet/glTF/SciFiHelmet.bin",
+            "size": 3643848
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SciFiHelmet/glTF/SciFiHelmet.gltf",
+            "size": 4461
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SciFiHelmet/glTF/SciFiHelmet_AmbientOcclusion.png",
+            "size": 3919556
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SciFiHelmet/glTF/SciFiHelmet_BaseColor.png",
+            "size": 7841138
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SciFiHelmet/glTF/SciFiHelmet_MetallicRoughness.png",
+            "size": 9488811
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SciFiHelmet/glTF/SciFiHelmet_Normal.png",
+            "size": 9019058
+        }
+    ],
+    "SciFiHelmet/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SciFiHelmet/screenshot/screenshot.jpg",
+            "size": 9925
+        }
+    ],
+    "SheenChair/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenChair/glTF-Binary/SheenChair.glb",
+            "size": 4396728
+        }
+    ],
+    "SheenChair/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenChair/glTF/SheenChair.bin",
+            "size": 1137976
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenChair/glTF/SheenChair.gltf",
+            "size": 20636
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenChair/glTF/chair_fabric_albedo.png",
+            "size": 225681
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenChair/glTF/chair_fabric_normal.png",
+            "size": 1475646
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenChair/glTF/chair_label.png",
+            "size": 692759
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenChair/glTF/chair_occlusion.png",
+            "size": 208194
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenChair/glTF/chair_wood_albedo.png",
+            "size": 299307
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenChair/glTF/chair_woodblack_roughnessmetallic.png",
+            "size": 138891
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenChair/glTF/chair_woodbrown_roughnessmetallic.png",
+            "size": 210158
+        }
+    ],
+    "SheenChair/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenChair/screenshot/mango_reference.jpg",
+            "size": 915716
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenChair/screenshot/peacock_reference.jpg",
+            "size": 868733
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenChair/screenshot/screenshot-large.jpg",
+            "size": 316185
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenChair/screenshot/screenshot.jpg",
+            "size": 10188
+        }
+    ],
+    "SheenCloth/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenCloth/glTF/SheenCloth.bin",
+            "size": 3479088
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenCloth/glTF/SheenCloth.gltf",
+            "size": 6681
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenCloth/glTF/technicalFabricSmall_basecolor_256.png",
+            "size": 125026
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenCloth/glTF/technicalFabricSmall_normal_256.png",
+            "size": 150880
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenCloth/glTF/technicalFabricSmall_orm_256.png",
+            "size": 131303
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenCloth/glTF/technicalFabricSmall_sheen_256.png",
+            "size": 170368
+        }
+    ],
+    "SheenCloth/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenCloth/screenshot/screenshot.jpg",
+            "size": 14811
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenCloth/screenshot/sheenTextureSample.jpg",
+            "size": 107274
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SheenCloth/screenshot/sheen_technicalFabric_side.jpg",
+            "size": 164453
+        }
+    ],
+    "SimpleMeshes/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleMeshes/glTF-Embedded/SimpleMeshes.gltf",
+            "size": 1574
+        }
+    ],
+    "SimpleMeshes/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleMeshes/glTF/SimpleMeshes.gltf",
+            "size": 1439
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleMeshes/glTF/triangle.bin",
+            "size": 80
+        }
+    ],
+    "SimpleMeshes/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleMeshes/screenshot/screenshot.png",
+            "size": 775
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleMeshes/screenshot/triangle.png",
+            "size": 62895
+        }
+    ],
+    "SimpleMorph/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleMorph/glTF-Embedded/SimpleMorph.gltf",
+            "size": 3191
+        }
+    ],
+    "SimpleMorph/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleMorph/glTF/SimpleMorph.gltf",
+            "size": 2924
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleMorph/glTF/simpleMorphAnimation.bin",
+            "size": 60
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleMorph/glTF/simpleMorphGeometry.bin",
+            "size": 116
+        }
+    ],
+    "SimpleMorph/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleMorph/screenshot/screenshot.png",
+            "size": 2381
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleMorph/screenshot/simpleMorphStructure.png",
+            "size": 81897
+        }
+    ],
+    "SimpleSkin/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleSkin/glTF-Embedded/SimpleSkin.gltf",
+            "size": 3696
+        }
+    ],
+    "SimpleSkin/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleSkin/glTF/SimpleSkin.gltf",
+            "size": 2480
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleSkin/glTF/inverseBindMatrices.bin",
+            "size": 128
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleSkin/glTF/skinAnimation.bin",
+            "size": 240
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleSkin/glTF/skinGeometry.bin",
+            "size": 168
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleSkin/glTF/skinningData.bin",
+            "size": 320
+        }
+    ],
+    "SimpleSkin/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleSkin/screenshot/inverseBindMatrices.png",
+            "size": 43880
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleSkin/screenshot/screenshot.gif",
+            "size": 2000860
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleSkin/screenshot/skinAnimation.png",
+            "size": 100791
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleSkin/screenshot/skinGeometry.png",
+            "size": 74566
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleSkin/screenshot/skinningData.png",
+            "size": 86339
+        }
+    ],
+    "SimpleSparseAccessor/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleSparseAccessor/glTF-Embedded/SimpleSparseAccessor.gltf",
+            "size": 1759
+        }
+    ],
+    "SimpleSparseAccessor/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleSparseAccessor/glTF/SimpleSparseAccessor.bin",
+            "size": 284
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleSparseAccessor/glTF/SimpleSparseAccessor.gltf",
+            "size": 1862
+        }
+    ],
+    "SimpleSparseAccessor/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleSparseAccessor/screenshot/SimpleSparseAccessorDescription.png",
+            "size": 81348
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleSparseAccessor/screenshot/screenshot.png",
+            "size": 7103
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SimpleSparseAccessor/screenshot/simpleSparseAccessorStructure.png",
+            "size": 107522
+        }
+    ],
+    "SpecGlossVsMetalRough/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecGlossVsMetalRough/glTF-Binary/SpecGlossVsMetalRough.glb",
+            "size": 15465324
+        }
+    ],
+    "SpecGlossVsMetalRough/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecGlossVsMetalRough/glTF/SpecGlossVsMetalRough.gltf",
+            "size": 11923
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecGlossVsMetalRough/glTF/SpecGlossVsMetalRough.png",
+            "size": 8668
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecGlossVsMetalRough/glTF/SpecGlossVsMetalRoughLabel.bin",
+            "size": 536
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecGlossVsMetalRough/glTF/WaterBottle.bin",
+            "size": 149412
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecGlossVsMetalRough/glTF/WaterBottle_baseColor.png",
+            "size": 2165850
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecGlossVsMetalRough/glTF/WaterBottle_diffuse.png",
+            "size": 2426300
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecGlossVsMetalRough/glTF/WaterBottle_emissive.png",
+            "size": 59102
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecGlossVsMetalRough/glTF/WaterBottle_normal.png",
+            "size": 3007372
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecGlossVsMetalRough/glTF/WaterBottle_occlusion.png",
+            "size": 336010
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecGlossVsMetalRough/glTF/WaterBottle_roughnessMetallic.png",
+            "size": 3331960
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecGlossVsMetalRough/glTF/WaterBottle_specularGlossiness.png",
+            "size": 3974780
+        }
+    ],
+    "SpecGlossVsMetalRough/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecGlossVsMetalRough/screenshot/screenshot-large.jpg",
+            "size": 35558
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecGlossVsMetalRough/screenshot/screenshot.jpg",
+            "size": 11089
+        }
+    ],
+    "SpecularTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecularTest/glTF-Binary/SpecularTest.glb",
+            "size": 223376
+        }
+    ],
+    "SpecularTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecularTest/glTF/LeftLabels.png",
+            "size": 30517
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecularTest/glTF/SpecularTest.bin",
+            "size": 180088
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecularTest/glTF/SpecularTest.gltf",
+            "size": 32846
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecularTest/glTF/WhiteGrid.png",
+            "size": 205
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecularTest/glTF/YellowGrid.png",
+            "size": 204
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecularTest/glTF/specularTextureGrid.png",
+            "size": 242
+        }
+    ],
+    "SpecularTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecularTest/screenshot/purple.jpg",
+            "size": 28560
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecularTest/screenshot/screenshot-large.png",
+            "size": 705020
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/SpecularTest/screenshot/screenshot.jpg",
+            "size": 15720
+        }
+    ],
+    "Sponza/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/10381718147657362067.jpg",
+            "size": 881980
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/10388182081421875623.jpg",
+            "size": 917202
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/11474523244911310074.jpg",
+            "size": 1079152
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/11490520546946913238.jpg",
+            "size": 321375
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/11872827283454512094.jpg",
+            "size": 668962
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/11968150294050148237.jpg",
+            "size": 530384
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/1219024358953944284.jpg",
+            "size": 329124
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/12501374198249454378.jpg",
+            "size": 418235
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/13196865903111448057.jpg",
+            "size": 281980
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/13824894030729245199.jpg",
+            "size": 313460
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/13982482287905699490.jpg",
+            "size": 347538
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/14118779221266351425.jpg",
+            "size": 1611314
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/14170708867020035030.jpg",
+            "size": 140738
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/14267839433702832875.jpg",
+            "size": 711217
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/14650633544276105767.jpg",
+            "size": 521947
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/15295713303328085182.jpg",
+            "size": 520162
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/15722799267630235092.jpg",
+            "size": 560258
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/16275776544635328252.png",
+            "size": 1077432
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/16299174074766089871.jpg",
+            "size": 322693
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/16885566240357350108.jpg",
+            "size": 12575
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/17556969131407844942.jpg",
+            "size": 370061
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/17876391417123941155.jpg",
+            "size": 1151448
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/2051777328469649772.jpg",
+            "size": 206618
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/2185409758123873465.jpg",
+            "size": 780166
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/2299742237651021498.jpg",
+            "size": 772672
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/2374361008830720677.jpg",
+            "size": 852079
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/2411100444841994089.jpg",
+            "size": 399963
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/2775690330959970771.jpg",
+            "size": 785678
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/2969916736137545357.jpg",
+            "size": 822373
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/332936164838540657.jpg",
+            "size": 852079
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/3371964815757888145.jpg",
+            "size": 682743
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/3455394979645218238.jpg",
+            "size": 551432
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/3628158980083700836.jpg",
+            "size": 527788
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/3827035219084910048.jpg",
+            "size": 608394
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/4477655471536070370.jpg",
+            "size": 211322
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/4601176305987539675.jpg",
+            "size": 1043152
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/466164707995436622.jpg",
+            "size": 486634
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/4675343432951571524.jpg",
+            "size": 764529
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/4871783166746854860.jpg",
+            "size": 570081
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/4910669866631290573.jpg",
+            "size": 1043152
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/4975155472559461469.jpg",
+            "size": 399027
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/5061699253647017043.png",
+            "size": 2427921
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/5792855332885324923.jpg",
+            "size": 564801
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/5823059166183034438.jpg",
+            "size": 573157
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/6047387724914829168.jpg",
+            "size": 518310
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/6151467286084645207.jpg",
+            "size": 643517
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/6593109234861095314.jpg",
+            "size": 1043152
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/6667038893015345571.jpg",
+            "size": 703420
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/6772804448157695701.jpg",
+            "size": 599959
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/7056944414013900257.jpg",
+            "size": 852079
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/715093869573992647.jpg",
+            "size": 280745
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/7268504077753552595.jpg",
+            "size": 572245
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/7441062115984513793.jpg",
+            "size": 665796
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/755318871556304029.jpg",
+            "size": 302363
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/759203620573749278.jpg",
+            "size": 509411
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/7645212358685992005.jpg",
+            "size": 656995
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/7815564343179553343.jpg",
+            "size": 623144
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/8006627369776289000.png",
+            "size": 1225157
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/8051790464816141987.jpg",
+            "size": 260119
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/8114461559286000061.jpg",
+            "size": 193077
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/8481240838833932244.jpg",
+            "size": 531156
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/8503262930880235456.jpg",
+            "size": 104626
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/8747919177698443163.jpg",
+            "size": 872255
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/8750083169368950601.jpg",
+            "size": 362437
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/8773302468495022225.jpg",
+            "size": 413837
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/8783994986360286082.jpg",
+            "size": 388462
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/9288698199695299068.jpg",
+            "size": 1044330
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/9916269861720640319.jpg",
+            "size": 608687
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/Sponza.bin",
+            "size": 9528220
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/Sponza.gltf",
+            "size": 167176
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/glTF/white.png",
+            "size": 951
+        }
+    ],
+    "Sponza/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/screenshot/large.jpg",
+            "size": 885111
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Sponza/screenshot/screenshot.jpg",
+            "size": 31768
+        }
+    ],
+    "StainedGlassLamp/glTF-JPG-PNG": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-JPG-PNG/StainedGlassLamp.bin",
+            "size": 1847592
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-JPG-PNG/StainedGlassLamp.gltf",
+            "size": 21750
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-JPG-PNG/StainedGlassLamp_base_basecolor.jpg",
+            "size": 1410691
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-JPG-PNG/StainedGlassLamp_base_emissive.jpg",
+            "size": 457400
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-JPG-PNG/StainedGlassLamp_base_normal.jpg",
+            "size": 210672
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-JPG-PNG/StainedGlassLamp_base_occlusion-rough-metal.jpg",
+            "size": 696202
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-JPG-PNG/StainedGlassLamp_bulbs_occlusion-rough-metal.jpg",
+            "size": 16906
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-JPG-PNG/StainedGlassLamp_glass_basecolor-alpha.png",
+            "size": 2577418
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-JPG-PNG/StainedGlassLamp_glass_emissive.jpg",
+            "size": 524778
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-JPG-PNG/StainedGlassLamp_glass_normal.jpg",
+            "size": 1294054
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-JPG-PNG/StainedGlassLamp_glass_occlusion-rough-metal.jpg",
+            "size": 625090
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-JPG-PNG/StainedGlassLamp_grill_basecolor-alpha.png",
+            "size": 913262
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-JPG-PNG/StainedGlassLamp_grill_emissive.jpg",
+            "size": 70629
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-JPG-PNG/StainedGlassLamp_grill_normal.jpg",
+            "size": 631024
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-JPG-PNG/StainedGlassLamp_grill_occlusion-rough-metal.jpg",
+            "size": 402827
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-JPG-PNG/StainedGlassLamp_hardware_basecolor.jpg",
+            "size": 48357
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-JPG-PNG/StainedGlassLamp_hardware_emissive.jpg",
+            "size": 154041
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-JPG-PNG/StainedGlassLamp_hardware_normal.jpg",
+            "size": 94009
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-JPG-PNG/StainedGlassLamp_hardware_occlusion-rough-metal.jpg",
+            "size": 212866
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-JPG-PNG/StainedGlassLamp_steel_occlusion-rough-metal.jpg",
+            "size": 41925
+        }
+    ],
+    "StainedGlassLamp/glTF-KTX-BasisU": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-KTX-BasisU/StainedGlassLamp.bin",
+            "size": 1847592
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-KTX-BasisU/StainedGlassLamp.gltf",
+            "size": 31546
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-KTX-BasisU/StainedGlassLamp_base_basecolor.ktx2",
+            "size": 303936
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-KTX-BasisU/StainedGlassLamp_base_emissive.ktx2",
+            "size": 174821
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-KTX-BasisU/StainedGlassLamp_base_normal.ktx2",
+            "size": 282290
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-KTX-BasisU/StainedGlassLamp_base_occlusion-rough-metal.ktx2",
+            "size": 919576
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-KTX-BasisU/StainedGlassLamp_bulbs_occlusion-rough-metal.ktx2",
+            "size": 26976
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-KTX-BasisU/StainedGlassLamp_glass_basecolor-alpha.ktx2",
+            "size": 1779325
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-KTX-BasisU/StainedGlassLamp_glass_emissive.ktx2",
+            "size": 541399
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-KTX-BasisU/StainedGlassLamp_glass_normal.ktx2",
+            "size": 1563379
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-KTX-BasisU/StainedGlassLamp_glass_occlusion-rough-metal_transmission.ktx2",
+            "size": 503612
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-KTX-BasisU/StainedGlassLamp_glass_transmission-clearcoat.ktx2",
+            "size": 439778
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-KTX-BasisU/StainedGlassLamp_grill_basecolor-alpha.ktx2",
+            "size": 217120
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-KTX-BasisU/StainedGlassLamp_grill_emissive.ktx2",
+            "size": 29183
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-KTX-BasisU/StainedGlassLamp_grill_normal.ktx2",
+            "size": 780467
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-KTX-BasisU/StainedGlassLamp_grill_occlusion-rough-metal.ktx2",
+            "size": 590811
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-KTX-BasisU/StainedGlassLamp_hardware_basecolor.ktx2",
+            "size": 17224
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-KTX-BasisU/StainedGlassLamp_hardware_emissive.ktx2",
+            "size": 59008
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-KTX-BasisU/StainedGlassLamp_hardware_normal.ktx2",
+            "size": 112123
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-KTX-BasisU/StainedGlassLamp_hardware_occlusion-rough-metal.ktx2",
+            "size": 210306
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF-KTX-BasisU/StainedGlassLamp_steel_occlusion-rough-metal.ktx2",
+            "size": 44947
+        }
+    ],
+    "StainedGlassLamp/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF/StainedGlassLamp.bin",
+            "size": 1847592
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF/StainedGlassLamp.gltf",
+            "size": 29877
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF/StainedGlassLamp_base_basecolor.png",
+            "size": 1748139
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF/StainedGlassLamp_base_emissive.png",
+            "size": 2621610
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF/StainedGlassLamp_base_normal.png",
+            "size": 1801836
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF/StainedGlassLamp_base_occlusion-rough-metal.png",
+            "size": 4028160
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF/StainedGlassLamp_bulbs_occlusion-rough-metal.png",
+            "size": 41487
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF/StainedGlassLamp_glass_basecolor-alpha.png",
+            "size": 2577418
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF/StainedGlassLamp_glass_emissive.png",
+            "size": 2086291
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF/StainedGlassLamp_glass_normal.png",
+            "size": 2043272
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF/StainedGlassLamp_glass_occlusion-rough-metal_transmission.png",
+            "size": 2043086
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF/StainedGlassLamp_glass_transmission-clearcoat.png",
+            "size": 1518385
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF/StainedGlassLamp_grill_basecolor-alpha.png",
+            "size": 2188625
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF/StainedGlassLamp_grill_emissive.png",
+            "size": 1126960
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF/StainedGlassLamp_grill_normal.png",
+            "size": 2471166
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF/StainedGlassLamp_grill_occlusion-rough-metal.png",
+            "size": 2122990
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF/StainedGlassLamp_hardware_basecolor.png",
+            "size": 906525
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF/StainedGlassLamp_hardware_emissive.png",
+            "size": 3172019
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF/StainedGlassLamp_hardware_normal.png",
+            "size": 2458725
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF/StainedGlassLamp_hardware_occlusion-rough-metal.png",
+            "size": 2490318
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/glTF/StainedGlassLamp_steel_occlusion-rough-metal.png",
+            "size": 42555
+        }
+    ],
+    "StainedGlassLamp/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/screenshot/chart_jpg-ktx.jpg",
+            "size": 56667
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/screenshot/photo2.jpg",
+            "size": 119700
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/screenshot/photo3.jpg",
+            "size": 121423
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/screenshot/photo_and_screenshot.jpg",
+            "size": 864973
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/screenshot/render_enterprisepbr.jpg",
+            "size": 725909
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/screenshot/render_ospray.jpg",
+            "size": 157978
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/screenshot/screenshot.jpg",
+            "size": 107415
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/screenshot/screenshot_clearcoat_on-off.gif",
+            "size": 145711
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/screenshot/screenshot_jpg-png.jpg",
+            "size": 417901
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/screenshot/screenshot_ktx.jpg",
+            "size": 1414866
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/screenshot/screenshot_large.jpg",
+            "size": 501150
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/screenshot/screenshot_transmission_on-off.gif",
+            "size": 258232
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/screenshot/screenshot_transmission_rotation.gif",
+            "size": 766139
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/screenshot/screenshot_variants_on-off.gif",
+            "size": 228910
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/StainedGlassLamp/screenshot/screenshot_volume_on-off.gif",
+            "size": 201379
+        }
+    ],
+    "Suzanne/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Suzanne/glTF/Suzanne.bin",
+            "size": 590400
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Suzanne/glTF/Suzanne.gltf",
+            "size": 3730
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Suzanne/glTF/Suzanne_BaseColor.png",
+            "size": 1161624
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Suzanne/glTF/Suzanne_MetallicRoughness.png",
+            "size": 860478
+        }
+    ],
+    "Suzanne/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Suzanne/screenshot/screenshot.jpg",
+            "size": 9620
+        }
+    ],
+    "TextureCoordinateTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureCoordinateTest/glTF-Binary/TextureCoordinateTest.glb",
+            "size": 14232
+        }
+    ],
+    "TextureCoordinateTest/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureCoordinateTest/glTF-Embedded/TextureCoordinateTest.gltf",
+            "size": 25772
+        }
+    ],
+    "TextureCoordinateTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureCoordinateTest/glTF/TextureCoordinateTemplate.png",
+            "size": 7284
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureCoordinateTest/glTF/TextureCoordinateTest.bin",
+            "size": 648
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureCoordinateTest/glTF/TextureCoordinateTest.gltf",
+            "size": 15191
+        }
+    ],
+    "TextureCoordinateTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureCoordinateTest/screenshot/screenshot.png",
+            "size": 11478
+        }
+    ],
+    "TextureEncodingTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureEncodingTest/glTF-Binary/TextureEncodingTest.glb",
+            "size": 26836
+        }
+    ],
+    "TextureEncodingTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureEncodingTest/glTF/0_136_0.png",
+            "size": 69
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureEncodingTest/glTF/0_136_0_gamma.png",
+            "size": 129
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureEncodingTest/glTF/0_136_0_icc.png",
+            "size": 471
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureEncodingTest/glTF/0_136_255.png",
+            "size": 69
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureEncodingTest/glTF/0_136_255_gamma.png",
+            "size": 129
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureEncodingTest/glTF/0_136_255_icc.png",
+            "size": 471
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureEncodingTest/glTF/Plane.bin",
+            "size": 92
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureEncodingTest/glTF/SlotLabels.png",
+            "size": 6548
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureEncodingTest/glTF/Sphere.bin",
+            "size": 8480
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureEncodingTest/glTF/TestLabels.png",
+            "size": 5211
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureEncodingTest/glTF/TextureEncodingTest.gltf",
+            "size": 14686
+        }
+    ],
+    "TextureEncodingTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureEncodingTest/screenshot/non-ignored_metadata.png",
+            "size": 77611
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureEncodingTest/screenshot/screenshot.png",
+            "size": 195667
+        }
+    ],
+    "TextureLinearInterpolationTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureLinearInterpolationTest/glTF-Binary/TextureLinearInterpolationTest.glb",
+            "size": 13468
+        }
+    ],
+    "TextureLinearInterpolationTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureLinearInterpolationTest/glTF/0_0_0-0_255_0.png",
+            "size": 72
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureLinearInterpolationTest/glTF/Plane.bin",
+            "size": 92
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureLinearInterpolationTest/glTF/Sphere.bin",
+            "size": 8480
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureLinearInterpolationTest/glTF/TestLabels.png",
+            "size": 2717
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureLinearInterpolationTest/glTF/TextureLinearInterpolationTest.gltf",
+            "size": 5633
+        }
+    ],
+    "TextureLinearInterpolationTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureLinearInterpolationTest/screenshot/incorrect.png",
+            "size": 18517
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureLinearInterpolationTest/screenshot/screenshot.png",
+            "size": 31406
+        }
+    ],
+    "TextureSettingsTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureSettingsTest/glTF-Binary/TextureSettingsTest.glb",
+            "size": 42840
+        }
+    ],
+    "TextureSettingsTest/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureSettingsTest/glTF-Embedded/TextureSettingsTest.gltf",
+            "size": 69427
+        }
+    ],
+    "TextureSettingsTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureSettingsTest/glTF/CheckAndX.png",
+            "size": 9775
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureSettingsTest/glTF/CheckAndX_V.png",
+            "size": 9878
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureSettingsTest/glTF/TextureSettingsTest.gltf",
+            "size": 26715
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureSettingsTest/glTF/TextureSettingsTest0.bin",
+            "size": 4976
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureSettingsTest/glTF/TextureTestLabels.png",
+            "size": 7376
+        }
+    ],
+    "TextureSettingsTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureSettingsTest/screenshot/screenshot.png",
+            "size": 35113
+        }
+    ],
+    "TextureTransformMultiTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureTransformMultiTest/glTF-Binary/TextureTransformMultiTest.glb",
+            "size": 450036
+        }
+    ],
+    "TextureTransformMultiTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureTransformMultiTest/glTF/TTMT_Labels.png",
+            "size": 22486
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureTransformMultiTest/glTF/TestMap-1.png",
+            "size": 31260
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureTransformMultiTest/glTF/TestMap.png",
+            "size": 25791
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureTransformMultiTest/glTF/TestMap_Normal.png",
+            "size": 247942
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureTransformMultiTest/glTF/TextureTransformMultiTest.bin",
+            "size": 89676
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureTransformMultiTest/glTF/TextureTransformMultiTest.gltf",
+            "size": 83764
+        }
+    ],
+    "TextureTransformMultiTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureTransformMultiTest/screenshot/sample_clearcoat.jpg",
+            "size": 73888
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureTransformMultiTest/screenshot/sample_notNormal.jpg",
+            "size": 82347
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureTransformMultiTest/screenshot/sample_occlusion.jpg",
+            "size": 82600
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureTransformMultiTest/screenshot/sample_wrongMath.jpg",
+            "size": 34372
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureTransformMultiTest/screenshot/screenshot.jpg",
+            "size": 42642
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureTransformMultiTest/screenshot/screenshot_large.jpg",
+            "size": 164870
+        }
+    ],
+    "TextureTransformTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureTransformTest/glTF/Arrow.png",
+            "size": 867
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureTransformTest/glTF/Correct.png",
+            "size": 2457
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureTransformTest/glTF/Error.png",
+            "size": 2273
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureTransformTest/glTF/NotSupported.png",
+            "size": 3291
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureTransformTest/glTF/TextureTransformTest.bin",
+            "size": 136
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureTransformTest/glTF/TextureTransformTest.gltf",
+            "size": 9179
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureTransformTest/glTF/UV.png",
+            "size": 12345
+        }
+    ],
+    "TextureTransformTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TextureTransformTest/screenshot/screenshot.jpg",
+            "size": 17903
+        }
+    ],
+    "ToyCar/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ToyCar/glTF-Binary/ToyCar.glb",
+            "size": 6022056
+        }
+    ],
+    "ToyCar/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ToyCar/glTF/Fabric_baseColor.png",
+            "size": 474752
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ToyCar/glTF/Fabric_normal.png",
+            "size": 326700
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ToyCar/glTF/Fabric_occlusion.png",
+            "size": 527296
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ToyCar/glTF/ToyCar.bin",
+            "size": 3664368
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ToyCar/glTF/ToyCar.gltf",
+            "size": 17537
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ToyCar/glTF/ToyCar_basecolor.png",
+            "size": 270583
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ToyCar/glTF/ToyCar_clearcoat.png",
+            "size": 29288
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ToyCar/glTF/ToyCar_emissive.png",
+            "size": 102833
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ToyCar/glTF/ToyCar_normal.png",
+            "size": 130678
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ToyCar/glTF/ToyCar_occlusion_roughness_metallic.png",
+            "size": 487985
+        }
+    ],
+    "ToyCar/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ToyCar/screenshot/screenshot.jpg",
+            "size": 16229
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ToyCar/screenshot/screenshot_large.jpg",
+            "size": 99296
+        }
+    ],
+    "TransmissionRoughnessTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TransmissionRoughnessTest/glTF-Binary/TransmissionRoughnessTest.glb",
+            "size": 393808
+        }
+    ],
+    "TransmissionRoughnessTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TransmissionRoughnessTest/glTF/GridWithDetails.png",
+            "size": 27613
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TransmissionRoughnessTest/glTF/IOR_Labels.png",
+            "size": 21200
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TransmissionRoughnessTest/glTF/RoughnessGrid-1.png",
+            "size": 290
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TransmissionRoughnessTest/glTF/RoughnessGrid.png",
+            "size": 184
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TransmissionRoughnessTest/glTF/SmoothVsRough.png",
+            "size": 5285
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TransmissionRoughnessTest/glTF/TransmissionRoughnessTest.bin",
+            "size": 331712
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TransmissionRoughnessTest/glTF/TransmissionRoughnessTest.gltf",
+            "size": 18102
+        }
+    ],
+    "TransmissionRoughnessTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TransmissionRoughnessTest/screenshot/left-column-detail.jpg",
+            "size": 463805
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TransmissionRoughnessTest/screenshot/screenshot-large.png",
+            "size": 917952
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TransmissionRoughnessTest/screenshot/screenshot.jpg",
+            "size": 36597
+        }
+    ],
+    "TransmissionTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TransmissionTest/glTF-Binary/TransmissionTest.glb",
+            "size": 1697892
+        }
+    ],
+    "TransmissionTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TransmissionTest/glTF/TransmissionTest.gltf",
+            "size": 43022
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TransmissionTest/glTF/TransmissionTest_binary.bin",
+            "size": 1441156
+        },
+        {
+            "download_url": null,
+            "size": 0
+        }
+    ],
+    "TransmissionTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TransmissionTest/screenshot/screenshot.jpg",
+            "size": 60322
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TransmissionTest/screenshot/screenshot_large.png",
+            "size": 2524626
+        }
+    ],
+    "Triangle/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Triangle/glTF-Embedded/Triangle.gltf",
+            "size": 1192
+        }
+    ],
+    "Triangle/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Triangle/glTF/Triangle.gltf",
+            "size": 1113
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Triangle/glTF/simpleTriangle.bin",
+            "size": 44
+        }
+    ],
+    "Triangle/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Triangle/screenshot/screenshot.png",
+            "size": 836
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Triangle/screenshot/simpleTriangle.png",
+            "size": 43858
+        }
+    ],
+    "TriangleWithoutIndices/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TriangleWithoutIndices/glTF-Embedded/TriangleWithoutIndices.gltf",
+            "size": 857
+        }
+    ],
+    "TriangleWithoutIndices/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TriangleWithoutIndices/glTF/TriangleWithoutIndices.gltf",
+            "size": 802
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TriangleWithoutIndices/glTF/triangleWithoutIndices.bin",
+            "size": 36
+        }
+    ],
+    "TriangleWithoutIndices/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TriangleWithoutIndices/screenshot/screenshot.png",
+            "size": 836
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TriangleWithoutIndices/screenshot/triangleWithoutIndices.png",
+            "size": 25349
+        }
+    ],
+    "TwoSidedPlane/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TwoSidedPlane/glTF/TwoSidedPlane.bin",
+            "size": 300
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TwoSidedPlane/glTF/TwoSidedPlane.gltf",
+            "size": 3927
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TwoSidedPlane/glTF/TwoSidedPlane_BaseColor.png",
+            "size": 82997
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TwoSidedPlane/glTF/TwoSidedPlane_MetallicRoughness.png",
+            "size": 21654
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TwoSidedPlane/glTF/TwoSidedPlane_Normal.png",
+            "size": 51450
+        }
+    ],
+    "TwoSidedPlane/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/TwoSidedPlane/screenshot/screenshot.jpg",
+            "size": 8650
+        }
+    ],
+    "Unicode\u2764\u267bTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Unicode%E2%9D%A4%E2%99%BBTest/glTF-Binary/Unicode%E2%9D%A4%E2%99%BBTest.glb",
+            "size": 8088
+        }
+    ],
+    "Unicode\u2764\u267bTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Unicode%E2%9D%A4%E2%99%BBTest/glTF/Unicode%E2%9D%A4%E2%99%BBBinary.bin",
+            "size": 152
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Unicode%E2%9D%A4%E2%99%BBTest/glTF/Unicode%E2%9D%A4%E2%99%BBTest.gltf",
+            "size": 2711
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Unicode%E2%9D%A4%E2%99%BBTest/glTF/Unicode%E2%9D%A4%E2%99%BBTexture.png",
+            "size": 6754
+        }
+    ],
+    "Unicode\u2764\u267bTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Unicode%E2%9D%A4%E2%99%BBTest/screenshot/screenshot.png",
+            "size": 18305
+        }
+    ],
+    "UnlitTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/UnlitTest/glTF-Binary/UnlitTest.glb",
+            "size": 3992
+        }
+    ],
+    "UnlitTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/UnlitTest/glTF/UnlitTest.bin",
+            "size": 2568
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/UnlitTest/glTF/UnlitTest.gltf",
+            "size": 3496
+        }
+    ],
+    "UnlitTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/UnlitTest/screenshot/screenshot.png",
+            "size": 1250
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/UnlitTest/screenshot/screenshot_large.jpg",
+            "size": 15195
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/UnlitTest/screenshot/unlit_test_fail.jpg",
+            "size": 21986
+        }
+    ],
+    "VC/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Binary/VC.glb",
+            "size": 3085416
+        }
+    ],
+    "VC/glTF-Draco": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/001.jpg",
+            "size": 60967
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/002.jpg",
+            "size": 37442
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/11.jpg",
+            "size": 32523
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/5.jpg",
+            "size": 31216
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/O21.jpg",
+            "size": 35913
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/VC.gltf",
+            "size": 492884
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/VC0.bin",
+            "size": 1392204
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/cockpit-map.jpg",
+            "size": 63992
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/f22.jpg",
+            "size": 143381
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/heli.jpg",
+            "size": 206056
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/machine.jpg",
+            "size": 57559
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/prop128.png",
+            "size": 4213
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/s_01.jpg",
+            "size": 20053
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/s_02.jpg",
+            "size": 20323
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/s_03.jpg",
+            "size": 20182
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/s_04.jpg",
+            "size": 16998
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/s_05.jpg",
+            "size": 22899
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/s_06.jpg",
+            "size": 21265
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/s_07.jpg",
+            "size": 21483
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/s_08.jpg",
+            "size": 18950
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/scrapsurf03-red.jpg",
+            "size": 24026
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Draco/surface01.jpg",
+            "size": 22231
+        }
+    ],
+    "VC/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF-Embedded/VC.gltf",
+            "size": 4389833
+        }
+    ],
+    "VC/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/001.jpg",
+            "size": 60967
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/002.jpg",
+            "size": 37442
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/11.jpg",
+            "size": 32523
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/5.jpg",
+            "size": 31216
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/O21.jpg",
+            "size": 35913
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/VC.gltf",
+            "size": 590960
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/VC0.bin",
+            "size": 1967226
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/cockpit-map.jpg",
+            "size": 63992
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/f22.jpg",
+            "size": 143381
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/heli.jpg",
+            "size": 206056
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/machine.jpg",
+            "size": 57559
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/prop128.png",
+            "size": 4213
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/s_01.jpg",
+            "size": 20053
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/s_02.jpg",
+            "size": 20323
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/s_03.jpg",
+            "size": 20182
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/s_04.jpg",
+            "size": 16998
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/s_05.jpg",
+            "size": 22899
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/s_06.jpg",
+            "size": 21265
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/s_07.jpg",
+            "size": 21483
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/s_08.jpg",
+            "size": 18950
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/scrapsurf03-red.jpg",
+            "size": 24026
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/glTF/surface01.jpg",
+            "size": 22231
+        }
+    ],
+    "VC/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VC/screenshot/screenshot.gif",
+            "size": 495094
+        }
+    ],
+    "VertexColorTest/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VertexColorTest/glTF-Binary/VertexColorTest.glb",
+            "size": 26220
+        }
+    ],
+    "VertexColorTest/glTF-Embedded": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VertexColorTest/glTF-Embedded/VertexColorTest.gltf",
+            "size": 38896
+        }
+    ],
+    "VertexColorTest/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VertexColorTest/glTF/VertexColorChecks.png",
+            "size": 8658
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VertexColorTest/glTF/VertexColorTest.bin",
+            "size": 4332
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VertexColorTest/glTF/VertexColorTest.gltf",
+            "size": 8660
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VertexColorTest/glTF/VertexColorTestLabels.png",
+            "size": 9674
+        }
+    ],
+    "VertexColorTest/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/VertexColorTest/screenshot/screenshot.png",
+            "size": 20357
+        }
+    ],
+    "WaterBottle/glTF-Binary": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/WaterBottle/glTF-Binary/WaterBottle.glb",
+            "size": 8961340
+        }
+    ],
+    "WaterBottle/glTF-Draco": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/WaterBottle/glTF-Draco/WaterBottle.bin",
+            "size": 49580
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/WaterBottle/glTF-Draco/WaterBottle.gltf",
+            "size": 3418
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/WaterBottle/glTF-Draco/WaterBottle_baseColor.png",
+            "size": 2165850
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/WaterBottle/glTF-Draco/WaterBottle_emissive.png",
+            "size": 59102
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/WaterBottle/glTF-Draco/WaterBottle_normal.png",
+            "size": 3007372
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/WaterBottle/glTF-Draco/WaterBottle_occlusionRoughnessMetallic.png",
+            "size": 3577832
+        }
+    ],
+    "WaterBottle/glTF": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/WaterBottle/glTF/WaterBottle.bin",
+            "size": 149412
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/WaterBottle/glTF/WaterBottle.gltf",
+            "size": 2727
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/WaterBottle/glTF/WaterBottle_baseColor.png",
+            "size": 2165850
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/WaterBottle/glTF/WaterBottle_emissive.png",
+            "size": 59102
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/WaterBottle/glTF/WaterBottle_normal.png",
+            "size": 3007372
+        },
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/WaterBottle/glTF/WaterBottle_occlusionRoughnessMetallic.png",
+            "size": 3577832
+        }
+    ],
+    "WaterBottle/screenshot": [
+        {
+            "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/WaterBottle/screenshot/screenshot.jpg",
+            "size": 3557
+        }
+    ]
+}

--- a/fury/data/files/KhronosGltfSamples.json
+++ b/fury/data/files/KhronosGltfSamples.json
@@ -1,5 +1,5 @@
 {
-    "__comments__": "2022-06-26, url",
+    "__comments__": "2022-06-26, generated using: https://github.com/xtanion/fury/blob/gltf-json-gen/fury/data/fetcher.py#L330",
     "2CylinderEngine/glTF-Binary": [
         {
             "download_url": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/2CylinderEngine/glTF-Binary/2CylinderEngine.glb",

--- a/fury/data/tests/test_fetcher.py
+++ b/fury/data/tests/test_fetcher.py
@@ -33,6 +33,7 @@ def tests_fetch_gltf():
     npt.assert_raises(ValueError, fetch_gltf, ['Duck'], 'GLTF')
 
     fetch_gltf()
+    list_gltf = os.listdir(folder)
     default_list = ['BoxTextured', 'Duck', 'CesiumMilkTruck', 'CesiumMan']
     results = [model in list_gltf for model in default_list]
     npt.assert_equal(results, [True, True, True, True])

--- a/fury/data/tests/test_fetcher.py
+++ b/fury/data/tests/test_fetcher.py
@@ -76,6 +76,6 @@ def test_read_viz_gltf():
     npt.assert_raises(ValueError, read_viz_gltf, 'Box')
 
     filenames, path = fetch_gltf('Box')
-    out_path = read_viz_gltf('Box').split('/')
+    out_path = read_viz_gltf('Box').split(os.sep)
     mode = out_path[-2:][0]
     npt.assert_equal(mode, 'glTF')

--- a/fury/data/tests/test_fetcher.py
+++ b/fury/data/tests/test_fetcher.py
@@ -53,20 +53,7 @@ def tests_fetch_gltf():
 
 
 def test_list_gltf_sample_models():
-    gltf_path = pjoin(fury_home, 'glTF')
-    list_json = pjoin(gltf_path, 'list.json')
-    if not os.path.exists(list_json):
-        json_data = urlopen(f'{GLTF_DATA_URL}').read()
-        with open(list_json, 'wb') as f:
-            f.write(json_data)
-
-    with open(list_json, 'r') as r:
-        data = json.load(r)
-    model_names = [model['name'] for model in data if model['size'] == 0]
     fetch_names = list_gltf_sample_models()
-    npt.assert_equal(len(fetch_names), len(model_names))
-    npt.assert_array_equal(model_names, fetch_names)
-
     default_list = ['BoxTextured', 'Duck', 'CesiumMilkTruck', 'CesiumMan']
     result = [model in fetch_names for model in default_list]
     npt.assert_equal(result, [True, True, True, True])


### PR DESCRIPTION
This PR adds a JSON file containing downloadable links of all models from [glTF samples](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0). This eliminates the need for API calls.

The json is generated using [this function](https://github.com/xtanion/fury/blob/gltf-json-gen/fury/data/fetcher.py#L330).