### PR TITLE
Added primitives count to the the Actor's polydata

### DIFF
--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1603,8 +1603,9 @@ def sphere(centers, colors, radii=1., phi=16, theta=16,
                               directions=directions, centers=centers,
                               colors=colors, scales=scales)
     big_verts, big_faces, big_colors, _ = res
+    prim_count = len(centers)
     sphere_actor = get_actor_from_primitive(
-            big_verts, big_faces, big_colors)
+            big_verts, big_faces, big_colors, prim_count=prim_count)
     sphere_actor.GetProperty().SetOpacity(opacity)
     return sphere_actor
 
@@ -1772,7 +1773,9 @@ def square(centers, directions=(1, 0, 0), colors=(1, 0, 0), scales=1):
                               centers=centers, colors=colors, scales=scales)
 
     big_verts, big_faces, big_colors, _ = res
-    sq_actor = get_actor_from_primitive(big_verts, big_faces, big_colors)
+    prim_count = len(centers)
+    sq_actor = get_actor_from_primitive(big_verts, big_faces, big_colors,
+                                        prim_count=prim_count)
     sq_actor.GetProperty().BackfaceCullingOff()
     return sq_actor
 
@@ -1851,7 +1854,9 @@ def box(centers, directions=(1, 0, 0), colors=(1, 0, 0), scales=(1, 2, 3)):
                               centers=centers, colors=colors, scales=scales)
 
     big_verts, big_faces, big_colors, _ = res
-    box_actor = get_actor_from_primitive(big_verts, big_faces, big_colors)
+    prim_count = len(centers)
+    box_actor = get_actor_from_primitive(big_verts, big_faces, big_colors,
+                                         prim_count=prim_count)
     return box_actor
 
 
@@ -1940,7 +1945,9 @@ def arrow(centers, directions, colors, heights=1., resolution=10,
         res = fp.repeat_primitive(vertices, faces, directions=directions, centers=centers,
                                   colors=colors, scales=scales)
         big_vertices, big_faces, big_colors, _ = res
-        arrow_actor = get_actor_from_primitive(big_vertices, big_faces, big_colors)
+        prim_count = len(centers)
+        arrow_actor = get_actor_from_primitive(big_vertices, big_faces, big_colors,
+                                               prim_count=prim_count)
         return arrow_actor
 
     src = ArrowSource() if faces is None else None
@@ -2018,7 +2025,9 @@ def cone(centers, directions, colors, heights=1., resolution=10,
                     directions=directions, colors=colors, scales=heights)
 
     big_verts, big_faces, big_colors, _ = res
-    cone_actor = get_actor_from_primitive(big_verts, big_faces, big_colors)
+    prim_count = len(centers)
+    cone_actor = get_actor_from_primitive(big_verts, big_faces, big_colors,
+                                          prim_count=prim_count)
 
     return cone_actor
 
@@ -2059,7 +2068,9 @@ def triangularprism(centers, directions=(1, 0, 0), colors=(1, 0, 0),
     res = fp.repeat_primitive(verts, faces, directions=directions,
                               centers=centers, colors=colors, scales=scales)
     big_verts, big_faces, big_colors, _ = res
-    tprism_actor = get_actor_from_primitive(big_verts, big_faces, big_colors)
+    prim_count = len(centers)
+    tprism_actor = get_actor_from_primitive(big_verts, big_faces, big_colors,
+                                            prim_count=prim_count)
     return tprism_actor
 
 
@@ -2099,7 +2110,9 @@ def rhombicuboctahedron(centers, directions=(1, 0, 0), colors=(1, 0, 0),
     res = fp.repeat_primitive(verts, faces, directions=directions,
                               centers=centers, colors=colors, scales=scales)
     big_verts, big_faces, big_colors, _ = res
-    rcoh_actor = get_actor_from_primitive(big_verts, big_faces, big_colors)
+    prim_count = len(centers)
+    rcoh_actor = get_actor_from_primitive(big_verts, big_faces, big_colors,
+                                          prim_count=prim_count)
     return rcoh_actor
 
 
@@ -2141,7 +2154,9 @@ def pentagonalprism(centers, directions=(1, 0, 0), colors=(1, 0, 0),
                               centers=centers, colors=colors, scales=scales)
 
     big_verts, big_faces, big_colors, _ = res
-    pent_actor = get_actor_from_primitive(big_verts, big_faces, big_colors)
+    prim_count = len(centers)
+    pent_actor = get_actor_from_primitive(big_verts, big_faces, big_colors,
+                                          prim_count=prim_count)
     return pent_actor
 
 
@@ -2182,7 +2197,9 @@ def octagonalprism(centers, directions=(1, 0, 0), colors=(1, 0, 0),
                               centers=centers, colors=colors, scales=scales)
 
     big_verts, big_faces, big_colors, _ = res
-    oct_actor = get_actor_from_primitive(big_verts, big_faces, big_colors)
+    prim_count = len(centers)
+    oct_actor = get_actor_from_primitive(big_verts, big_faces, big_colors,
+                                         prim_count=prim_count)
     return oct_actor
 
 
@@ -2221,7 +2238,9 @@ def frustum(centers, directions=(1, 0, 0), colors=(0, 1, 0), scales=1):
                               centers=centers, colors=colors, scales=scales)
 
     big_verts, big_faces, big_colors, _ = res
-    frustum_actor = get_actor_from_primitive(big_verts, big_faces, big_colors)
+    prim_count = len(centers)
+    frustum_actor = get_actor_from_primitive(big_verts, big_faces, big_colors,
+                                             prim_count=prim_count)
     return frustum_actor
 
 
@@ -2281,7 +2300,9 @@ def superquadric(centers, roundness=(1, 1), directions=(1, 0, 0),
                                        colors=colors, scales=scales)
 
     big_verts, big_faces, big_colors, _ = res
-    spq_actor = get_actor_from_primitive(big_verts, big_faces, big_colors)
+    prim_count = len(centers)
+    spq_actor = get_actor_from_primitive(big_verts, big_faces, big_colors,
+                                         prim_count=prim_count)
     return spq_actor
 
 
@@ -2324,7 +2345,9 @@ def billboard(centers, colors=(0, 1, 0), scales=1, vs_dec=None, vs_impl=None,
 
     big_verts, big_faces, big_colors, big_centers = res
 
-    bb_actor = get_actor_from_primitive(big_verts, big_faces, big_colors)
+    prim_count = len(centers)
+    bb_actor = get_actor_from_primitive(big_verts, big_faces, big_colors,
+                                        prim_count=prim_count)
     bb_actor.GetMapper().SetVBOShiftScaleMethod(False)
     bb_actor.GetProperty().BackfaceCullingOff()
     attribute_to_actor(bb_actor, big_centers, 'center')
@@ -2975,7 +2998,9 @@ def sdf(centers, directions=(1, 0, 0), colors=(1, 0, 0), primitives='torus',
                                    scales=scales)
 
     rep_verts, rep_faces, rep_colors, rep_centers = repeated
-    box_actor = get_actor_from_primitive(rep_verts, rep_faces, rep_colors)
+    prim_count = len(centers)
+    box_actor = get_actor_from_primitive(rep_verts, rep_faces, rep_colors,
+                                         prim_count=prim_count)
     box_actor.GetMapper().SetVBOShiftScaleMethod(False)
 
     if isinstance(primitives,  (list, tuple, np.ndarray)):
@@ -3054,7 +3079,9 @@ def markers(
                               scales=scales)
 
     big_verts, big_faces, big_colors, big_centers = res
-    sq_actor = get_actor_from_primitive(big_verts, big_faces, big_colors)
+    prim_count = len(centers)
+    sq_actor = get_actor_from_primitive(big_verts, big_faces, big_colors,
+                                        prim_count=prim_count)
     sq_actor.GetMapper().SetVBOShiftScaleMethod(False)
     sq_actor.GetProperty().BackfaceCullingOff()
 

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -32,7 +32,7 @@ from fury.utils import (lines_to_vtk_polydata, set_input, apply_affine,
                         set_polydata_vertices, set_polydata_triangles,
                         shallow_copy, rgb_to_vtk, numpy_to_vtk_matrix,
                         repeat_sources, get_actor_from_primitive,
-                        fix_winding_order, numpy_to_vtk_colors, color_check)
+                        fix_winding_order, numpy_to_vtk_colors, color_check, add_primitives_count_to_actor)
 
 
 def slicer(data, affine=None, value_range=None, opacity=1.,
@@ -644,6 +644,9 @@ def streamtube(lines, colors=None, opacity=1, linewidth=0.1, tube_sides=9,
     actor.GetProperty().BackfaceCullingOn()
     actor.GetProperty().SetOpacity(opacity)
 
+    prim_count = len(lines)
+    add_primitives_count_to_actor(actor, prim_count)
+
     return actor
 
 
@@ -755,6 +758,9 @@ def line(lines, colors=None, opacity=1, linewidth=1,
     actor.SetMapper(poly_mapper)
     actor.GetProperty().SetLineWidth(linewidth)
     actor.GetProperty().SetOpacity(opacity)
+
+    prim_count = len(lines)
+    add_primitives_count_to_actor(actor, prim_count)
 
     if depth_cue:
         def callback(_caller, _event, calldata=None):
@@ -1487,6 +1493,9 @@ def dot(points, colors=None, opacity=None, dot_size=5):
     # Create an actor
     poly_actor = Actor()
     poly_actor.SetMapper(mapper)
+
+    prim_count = len(points)
+    add_primitives_count_to_actor(poly_actor, prim_count)
 
     if opacity is not None:
         poly_actor.GetProperty().SetOpacity(opacity)

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -32,7 +32,7 @@ from fury.utils import (lines_to_vtk_polydata, set_input, apply_affine,
                         set_polydata_vertices, set_polydata_triangles,
                         shallow_copy, rgb_to_vtk, numpy_to_vtk_matrix,
                         repeat_sources, get_actor_from_primitive,
-                        fix_winding_order, numpy_to_vtk_colors, color_check, add_primitives_count_to_actor)
+                        fix_winding_order, numpy_to_vtk_colors, color_check, set_actor_primitives_count)
 
 
 def slicer(data, affine=None, value_range=None, opacity=1.,
@@ -645,7 +645,7 @@ def streamtube(lines, colors=None, opacity=1, linewidth=0.1, tube_sides=9,
     actor.GetProperty().SetOpacity(opacity)
 
     prim_count = len(lines)
-    add_primitives_count_to_actor(actor, prim_count)
+    set_actor_primitives_count(actor, prim_count)
 
     return actor
 
@@ -760,7 +760,7 @@ def line(lines, colors=None, opacity=1, linewidth=1,
     actor.GetProperty().SetOpacity(opacity)
 
     prim_count = len(lines)
-    add_primitives_count_to_actor(actor, prim_count)
+    set_actor_primitives_count(actor, prim_count)
 
     if depth_cue:
         def callback(_caller, _event, calldata=None):
@@ -1495,7 +1495,7 @@ def dot(points, colors=None, opacity=None, dot_size=5):
     poly_actor.SetMapper(mapper)
 
     prim_count = len(points)
-    add_primitives_count_to_actor(poly_actor, prim_count)
+    set_actor_primitives_count(poly_actor, prim_count)
 
     if opacity is not None:
         poly_actor.GetProperty().SetOpacity(opacity)

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -22,7 +22,8 @@ from fury.lib import (numpy_support, Transform, ImageData, PolyData, Matrix4x4,
                       PolyDataNormals, Assembly, LODActor, VTK_UNSIGNED_CHAR,
                       PolyDataMapper2D, ScalarBarActor, PolyVertex, CellArray,
                       UnstructuredGrid, DataSetMapper, ConeSource, ArrowSource,
-                      SphereSource, CylinderSource, DiskSource, TexturedSphereSource,
+                      SphereSource, CylinderSource, DiskSource,
+                      TexturedSphereSource,
                       Texture, FloatArray, VTK_TEXT_LEFT, VTK_TEXT_RIGHT,
                       VTK_TEXT_BOTTOM, VTK_TEXT_TOP, VTK_TEXT_CENTERED,
                       TexturedActor2D, TextureMapToPlane, TextActor3D,
@@ -33,7 +34,7 @@ from fury.utils import (lines_to_vtk_polydata, set_input, apply_affine,
                         shallow_copy, rgb_to_vtk, numpy_to_vtk_matrix,
                         repeat_sources, get_actor_from_primitive,
                         fix_winding_order, numpy_to_vtk_colors, color_check,
-                        set_actor_primitives_count, set_polydata_primitives_count)
+                        set_polydata_primitives_count)
 
 
 def slicer(data, affine=None, value_range=None, opacity=1.,
@@ -1035,9 +1036,6 @@ def _color_fa(fa, evecs):
         raise ValueError("Wrong number of dimensions for evecs")
 
     return np.abs(evecs[..., 0]) * np.clip(fa, 0, 1)[..., None]
-
-
-
 
 
 def tensor_slicer(evals, evecs, affine=None, mask=None, sphere=None, scale=2.2,

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -32,7 +32,8 @@ from fury.utils import (lines_to_vtk_polydata, set_input, apply_affine,
                         set_polydata_vertices, set_polydata_triangles,
                         shallow_copy, rgb_to_vtk, numpy_to_vtk_matrix,
                         repeat_sources, get_actor_from_primitive,
-                        fix_winding_order, numpy_to_vtk_colors, color_check, set_actor_primitives_count)
+                        fix_winding_order, numpy_to_vtk_colors, color_check,
+                        set_actor_primitives_count)
 
 
 def slicer(data, affine=None, value_range=None, opacity=1.,

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -33,7 +33,7 @@ from fury.utils import (lines_to_vtk_polydata, set_input, apply_affine,
                         shallow_copy, rgb_to_vtk, numpy_to_vtk_matrix,
                         repeat_sources, get_actor_from_primitive,
                         fix_winding_order, numpy_to_vtk_colors, color_check,
-                        set_actor_primitives_count)
+                        set_actor_primitives_count, set_polydata_primitives_count)
 
 
 def slicer(data, affine=None, value_range=None, opacity=1.,
@@ -588,6 +588,10 @@ def streamtube(lines, colors=None, opacity=1, linewidth=0.1, tube_sides=9,
     poly_data, color_is_scalar = lines_to_vtk_polydata(lines, colors)
     next_input = poly_data
 
+    # set primitives count
+    prim_count = len(lines)
+    set_polydata_primitives_count(poly_data, prim_count)
+
     # Set Normals
     poly_normals = set_input(PolyDataNormals(), next_input)
     poly_normals.ComputeCellNormalsOn()
@@ -644,9 +648,6 @@ def streamtube(lines, colors=None, opacity=1, linewidth=0.1, tube_sides=9,
     actor.GetProperty().SetInterpolationToPhong()
     actor.GetProperty().BackfaceCullingOn()
     actor.GetProperty().SetOpacity(opacity)
-
-    prim_count = len(lines)
-    set_actor_primitives_count(actor, prim_count)
 
     return actor
 
@@ -725,6 +726,10 @@ def line(lines, colors=None, opacity=1, linewidth=1,
     poly_data, color_is_scalar = lines_to_vtk_polydata(lines, colors)
     next_input = poly_data
 
+    # set primitives count
+    prim_count = len(lines)
+    set_polydata_primitives_count(poly_data, prim_count)
+
     # use spline interpolation
     if (spline_subdiv is not None) and (spline_subdiv > 0):
         spline_filter = set_input(SplineFilter(), next_input)
@@ -759,9 +764,6 @@ def line(lines, colors=None, opacity=1, linewidth=1,
     actor.SetMapper(poly_mapper)
     actor.GetProperty().SetLineWidth(linewidth)
     actor.GetProperty().SetOpacity(opacity)
-
-    prim_count = len(lines)
-    set_actor_primitives_count(actor, prim_count)
 
     if depth_cue:
         def callback(_caller, _event, calldata=None):
@@ -1487,6 +1489,10 @@ def dot(points, colors=None, opacity=None, dot_size=5):
     polydata.SetVerts(vtk_faces)
     polydata.GetPointData().SetScalars(color_array)
 
+    # set primitives count
+    prim_count = len(points)
+    set_polydata_primitives_count(polydata, prim_count)
+
     # Visualize
     mapper = PolyDataMapper()
     mapper.SetInputData(polydata)
@@ -1494,9 +1500,6 @@ def dot(points, colors=None, opacity=None, dot_size=5):
     # Create an actor
     poly_actor = Actor()
     poly_actor.SetMapper(mapper)
-
-    prim_count = len(points)
-    set_actor_primitives_count(poly_actor, prim_count)
 
     if opacity is not None:
         poly_actor.GetProperty().SetOpacity(opacity)

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -12,7 +12,7 @@ from fury import shaders
 from fury import actor, window, primitive as fp
 from fury.actor import grid
 from fury.decorators import skip_osx, skip_win
-from fury.utils import shallow_copy, rotate
+from fury.utils import shallow_copy, rotate, get_primitives_count_from_actor
 from fury.testing import assert_greater, assert_greater_equal
 from fury.primitive import prim_sphere
 
@@ -1492,3 +1492,12 @@ def test_marker_actor(interactive=False):
     report = window.analyze_snapshot(arr, colors=colors)
     npt.assert_equal(report.objects, 12)
 
+
+def test_actors_primitives_count():
+    centers = np.array([[1, 1, 1], [2, 2, 2]])
+    box_actor = actor.box(centers)
+    npt.assert_equal(get_primitives_count_from_actor(box_actor), len(centers))
+    box_actor = actor.sphere(centers, (1, 0, 0))
+    npt.assert_equal(get_primitives_count_from_actor(box_actor), len(centers))
+    box_actor = actor.sphere(centers, (1, 0, 0), use_primitive=True)
+    npt.assert_equal(get_primitives_count_from_actor(box_actor), len(centers))

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -1560,10 +1560,10 @@ def test_actors_primitives_count():
 
     lines = np.array([[[0, 0, 0], [1, 1, 1]], [[1, 1, 1], [2, 2, 2]]])
     line_actor = actor.line(np.array(lines))
-    npt.assert_equal(get_actor_primitives_count(line_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(line_actor), len(lines))
 
     streamtube_actor = actor.streamtube(np.array(lines))
-    npt.assert_equal(get_actor_primitives_count(streamtube_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(streamtube_actor), len(lines))
 
     dots_actor = actor.dots(centers)
     npt.assert_equal(get_actor_primitives_count(dots_actor), len(centers))

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -1497,6 +1497,7 @@ def test_actors_primitives_count():
     centers = np.array([[1, 1, 1], [2, 2, 2]])
     directions = np.array([[1, 0, 0], [1, 0, 0]])
     colors = np.array([[1, 0, 0], [1, 0, 0]])
+    lines = np.array([[[0, 0, 0], [1, 1, 1]], [[1, 1, 1], [2, 2, 2]]])
 
     box_actor = actor.box(centers)
     npt.assert_equal(primitives_count_from_actor(box_actor), len(centers))
@@ -1571,7 +1572,6 @@ def test_actors_primitives_count():
     cylinder_actor = actor.cylinder(centers, directions, colors)
     npt.assert_equal(primitives_count_from_actor(cylinder_actor), len(centers))
 
-    lines = np.array([[[0, 0, 0], [1, 1, 1]], [[1, 1, 1], [2, 2, 2]]])
     line_actor = actor.line(np.array(lines))
     npt.assert_equal(primitives_count_from_actor(line_actor), len(lines))
 

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -1528,7 +1528,7 @@ def test_actors_primitives_count():
         [actor.cone, {**args_3, 'use_primitive': True}, cen_c],
         [actor.arrow, {**args_3, 'repeat_primitive': False}, cen_c],
         [actor.arrow, {**args_3, 'repeat_primitive': True}, cen_c],
-        [actor.dots, {'points': centers}, cen_c],
+        [actor.dot, {'points': centers}, cen_c],
         [actor.point, {'points': centers, 'colors': colors}, cen_c],
         [actor.line, {'lines': lines}, lin_c],
         [actor.streamtube, {'lines': lines}, lin_c],

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -1499,85 +1499,43 @@ def test_actors_primitives_count():
     colors = np.array([[1, 0, 0], [1, 0, 0]])
     lines = np.array([[[0, 0, 0], [1, 1, 1]], [[1, 1, 1], [2, 2, 2]]])
 
-    box_actor = actor.box(centers)
-    npt.assert_equal(primitives_count_from_actor(box_actor), len(centers))
+    args_1 = {'centers': centers}
+    args_2 = {**args_1, 'colors': colors}
+    args_3 = {**args_2, 'directions': directions}
 
-    square_actor = actor.square(centers)
-    npt.assert_equal(primitives_count_from_actor(square_actor), len(centers))
+    cen_c = len(centers)
+    lin_c = len(lines)
 
-    sphere_actor = actor.sphere(centers, colors)
-    npt.assert_equal(primitives_count_from_actor(sphere_actor), len(centers))
-
-    prim_sphere_actor = actor.sphere(centers, colors, use_primitive=False)
-    npt.assert_equal(primitives_count_from_actor(prim_sphere_actor),
-                     len(centers))
-
-    prim_sphere_actor = actor.sphere(centers, colors, use_primitive=True)
-    npt.assert_equal(primitives_count_from_actor(prim_sphere_actor),
-                     len(centers))
-
-    sdf_actor = actor.sdf(centers, (1, 0, 0))
-    npt.assert_equal(primitives_count_from_actor(sdf_actor), len(centers))
-
-    billboard_actor = actor.billboard(centers)
-    npt.assert_equal(primitives_count_from_actor(billboard_actor),
-                     len(centers))
-
-    superquadric_actor = actor.superquadric(centers)
-    npt.assert_equal(primitives_count_from_actor(superquadric_actor),
-                     len(centers))
-
-    markers_actor = actor.markers(centers)
-    npt.assert_equal(primitives_count_from_actor(markers_actor), len(centers))
-
-    octagonalprism_actor = actor.octagonalprism(centers)
-    npt.assert_equal(primitives_count_from_actor(octagonalprism_actor),
-                     len(centers))
-
-    frustum_actor = actor.frustum(centers)
-    npt.assert_equal(primitives_count_from_actor(frustum_actor),
-                     len(centers))
-
-    pentagonalprism_actor = actor.pentagonalprism(centers)
-    npt.assert_equal(primitives_count_from_actor(pentagonalprism_actor),
-                     len(centers))
-
-    triangularprism_actor = actor.triangularprism(centers)
-    npt.assert_equal(primitives_count_from_actor(triangularprism_actor),
-                     len(centers))
-
-    prim_rhombicuboctahedron = actor.rhombicuboctahedron(centers)
-    npt.assert_equal(primitives_count_from_actor(prim_rhombicuboctahedron),
-                     len(centers))
-
-    cone_actor = actor.cone(centers, directions, colors, use_primitive=False)
-    npt.assert_equal(primitives_count_from_actor(cone_actor), len(centers))
-
-    prim_cone_actor = actor.cone(centers, directions, colors,
-                                 use_primitive=True)
-    npt.assert_equal(primitives_count_from_actor(prim_cone_actor),
-                     len(centers))
-
-    arrow_actor = actor.arrow(centers, directions, colors,
-                              repeat_primitive=True)
-    npt.assert_equal(primitives_count_from_actor(arrow_actor), len(centers))
-
-    arrow_actor = actor.arrow(centers, directions, colors,
-                              repeat_primitive=False)
-    npt.assert_equal(primitives_count_from_actor(arrow_actor), len(centers))
-
-    disk_actor = actor.disk(centers, directions, colors)
-    npt.assert_equal(primitives_count_from_actor(disk_actor), len(centers))
-
-    cylinder_actor = actor.cylinder(centers, directions, colors)
-    npt.assert_equal(primitives_count_from_actor(cylinder_actor), len(centers))
-
-    line_actor = actor.line(np.array(lines))
-    npt.assert_equal(primitives_count_from_actor(line_actor), len(lines))
-
-    streamtube_actor = actor.streamtube(np.array(lines))
-    npt.assert_equal(primitives_count_from_actor(streamtube_actor), len(lines))
-
-    dots_actor = actor.dots(centers)
-    npt.assert_equal(primitives_count_from_actor(dots_actor), len(centers))
-
+    actors_test_cases = [
+        [actor.box, args_1, cen_c],
+        [actor.rectangle, args_1, cen_c],
+        [actor.square, args_1, cen_c],
+        [actor.cube, args_1, cen_c],
+        [actor.sphere, {**args_2, 'use_primitive': True}, cen_c],
+        [actor.sphere, {**args_2, 'use_primitive': False}, cen_c],
+        [actor.sdf, args_1, cen_c],
+        [actor.billboard, args_1, cen_c],
+        [actor.superquadric, args_1, cen_c],
+        [actor.markers, args_1, cen_c],
+        [actor.octagonalprism, args_1, cen_c],
+        [actor.frustum, args_1, cen_c],
+        [actor.pentagonalprism, args_1, cen_c],
+        [actor.triangularprism, args_1, cen_c],
+        [actor.rhombicuboctahedron, args_1, cen_c],
+        [actor.cylinder, args_3, cen_c],
+        [actor.disk, args_3, cen_c],
+        [actor.cone, {**args_3, 'use_primitive': False}, cen_c],
+        [actor.cone, {**args_3, 'use_primitive': True}, cen_c],
+        [actor.arrow, {**args_3, 'repeat_primitive': False}, cen_c],
+        [actor.arrow, {**args_3, 'repeat_primitive': True}, cen_c],
+        [actor.dots, {'points': centers}, cen_c],
+        [actor.point, {'points': centers, 'colors': colors}, cen_c],
+        [actor.line, {'lines': lines}, lin_c],
+        [actor.streamtube, {'lines': lines}, lin_c],
+    ]
+    for test_case in actors_test_cases:
+        act_func = test_case[0]
+        args = test_case[1]
+        primitives_count = test_case[2]
+        act = act_func(**args)
+        npt.assert_equal(primitives_count_from_actor(act), primitives_count)

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -12,7 +12,7 @@ from fury import shaders
 from fury import actor, window, primitive as fp
 from fury.actor import grid
 from fury.decorators import skip_osx, skip_win
-from fury.utils import shallow_copy, rotate, get_actor_primitives_count
+from fury.utils import shallow_copy, rotate, primitives_count_from_actor
 from fury.testing import assert_greater, assert_greater_equal
 from fury.primitive import prim_sphere
 
@@ -1499,72 +1499,85 @@ def test_actors_primitives_count():
     colors = np.array([[1, 0, 0], [1, 0, 0]])
 
     box_actor = actor.box(centers)
-    npt.assert_equal(get_actor_primitives_count(box_actor), len(centers))
+    npt.assert_equal(primitives_count_from_actor(box_actor), len(centers))
+
+    square_actor = actor.square(centers)
+    npt.assert_equal(primitives_count_from_actor(square_actor), len(centers))
 
     sphere_actor = actor.sphere(centers, colors)
-    npt.assert_equal(get_actor_primitives_count(sphere_actor), len(centers))
+    npt.assert_equal(primitives_count_from_actor(sphere_actor), len(centers))
 
     prim_sphere_actor = actor.sphere(centers, colors, use_primitive=False)
-    npt.assert_equal(get_actor_primitives_count(prim_sphere_actor), len(centers))
+    npt.assert_equal(primitives_count_from_actor(prim_sphere_actor),
+                     len(centers))
 
-    prim_sphere_actor = actor.sphere(centers, directions, use_primitive=True)
-    npt.assert_equal(get_actor_primitives_count(prim_sphere_actor), len(centers))
+    prim_sphere_actor = actor.sphere(centers, colors, use_primitive=True)
+    npt.assert_equal(primitives_count_from_actor(prim_sphere_actor),
+                     len(centers))
 
     sdf_actor = actor.sdf(centers, (1, 0, 0))
-    npt.assert_equal(get_actor_primitives_count(sdf_actor), len(centers))
+    npt.assert_equal(primitives_count_from_actor(sdf_actor), len(centers))
 
     billboard_actor = actor.billboard(centers)
-    npt.assert_equal(get_actor_primitives_count(billboard_actor), len(centers))
+    npt.assert_equal(primitives_count_from_actor(billboard_actor),
+                     len(centers))
 
     superquadric_actor = actor.superquadric(centers)
-    npt.assert_equal(get_actor_primitives_count(superquadric_actor), len(centers))
+    npt.assert_equal(primitives_count_from_actor(superquadric_actor),
+                     len(centers))
 
     markers_actor = actor.markers(centers)
-    npt.assert_equal(get_actor_primitives_count(markers_actor), len(centers))
+    npt.assert_equal(primitives_count_from_actor(markers_actor), len(centers))
 
     octagonalprism_actor = actor.octagonalprism(centers)
-    npt.assert_equal(get_actor_primitives_count(octagonalprism_actor), len(centers))
+    npt.assert_equal(primitives_count_from_actor(octagonalprism_actor),
+                     len(centers))
 
     frustum_actor = actor.frustum(centers)
-    npt.assert_equal(get_actor_primitives_count(frustum_actor), len(centers))
-
-    rhombicuboctahedron_actor = actor.rhombicuboctahedron(centers)
-    npt.assert_equal(get_actor_primitives_count(rhombicuboctahedron_actor), len(centers))
+    npt.assert_equal(primitives_count_from_actor(frustum_actor),
+                     len(centers))
 
     pentagonalprism_actor = actor.pentagonalprism(centers)
-    npt.assert_equal(get_actor_primitives_count(pentagonalprism_actor), len(centers))
+    npt.assert_equal(primitives_count_from_actor(pentagonalprism_actor),
+                     len(centers))
 
     triangularprism_actor = actor.triangularprism(centers)
-    npt.assert_equal(get_actor_primitives_count(triangularprism_actor), len(centers))
+    npt.assert_equal(primitives_count_from_actor(triangularprism_actor),
+                     len(centers))
 
     prim_rhombicuboctahedron = actor.rhombicuboctahedron(centers)
-    npt.assert_equal(get_actor_primitives_count(prim_rhombicuboctahedron), len(centers))
+    npt.assert_equal(primitives_count_from_actor(prim_rhombicuboctahedron),
+                     len(centers))
 
     cone_actor = actor.cone(centers, directions, colors, use_primitive=False)
-    npt.assert_equal(get_actor_primitives_count(cone_actor), len(centers))
+    npt.assert_equal(primitives_count_from_actor(cone_actor), len(centers))
 
-    prim_cone_actor = actor.cone(centers, directions, colors, use_primitive=True)
-    npt.assert_equal(get_actor_primitives_count(prim_cone_actor), len(centers))
+    prim_cone_actor = actor.cone(centers, directions, colors,
+                                 use_primitive=True)
+    npt.assert_equal(primitives_count_from_actor(prim_cone_actor),
+                     len(centers))
 
-    arrow_actor = actor.arrow(centers, directions, colors, repeat_primitive=True)
-    npt.assert_equal(get_actor_primitives_count(arrow_actor), len(centers))
+    arrow_actor = actor.arrow(centers, directions, colors,
+                              repeat_primitive=True)
+    npt.assert_equal(primitives_count_from_actor(arrow_actor), len(centers))
 
-    arrow_actor = actor.arrow(centers, directions, colors, repeat_primitive=False)
-    npt.assert_equal(get_actor_primitives_count(arrow_actor), len(centers))
+    arrow_actor = actor.arrow(centers, directions, colors,
+                              repeat_primitive=False)
+    npt.assert_equal(primitives_count_from_actor(arrow_actor), len(centers))
 
     disk_actor = actor.disk(centers, directions, colors)
-    npt.assert_equal(get_actor_primitives_count(disk_actor), len(centers))
+    npt.assert_equal(primitives_count_from_actor(disk_actor), len(centers))
 
     cylinder_actor = actor.cylinder(centers, directions, colors)
-    npt.assert_equal(get_actor_primitives_count(cylinder_actor), len(centers))
+    npt.assert_equal(primitives_count_from_actor(cylinder_actor), len(centers))
 
     lines = np.array([[[0, 0, 0], [1, 1, 1]], [[1, 1, 1], [2, 2, 2]]])
     line_actor = actor.line(np.array(lines))
-    npt.assert_equal(get_actor_primitives_count(line_actor), len(lines))
+    npt.assert_equal(primitives_count_from_actor(line_actor), len(lines))
 
     streamtube_actor = actor.streamtube(np.array(lines))
-    npt.assert_equal(get_actor_primitives_count(streamtube_actor), len(lines))
+    npt.assert_equal(primitives_count_from_actor(streamtube_actor), len(lines))
 
     dots_actor = actor.dots(centers)
-    npt.assert_equal(get_actor_primitives_count(dots_actor), len(centers))
+    npt.assert_equal(primitives_count_from_actor(dots_actor), len(centers))
 

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -1495,9 +1495,9 @@ def test_marker_actor(interactive=False):
 
 def test_actors_primitives_count():
     centers = np.array([[1, 1, 1], [2, 2, 2]])
-    box_actor = actor.box(centers)
-    npt.assert_equal(get_primitives_count_from_actor(box_actor), len(centers))
-    box_actor = actor.sphere(centers, (1, 0, 0))
-    npt.assert_equal(get_primitives_count_from_actor(box_actor), len(centers))
-    box_actor = actor.sphere(centers, (1, 0, 0), use_primitive=True)
-    npt.assert_equal(get_primitives_count_from_actor(box_actor), len(centers))
+    sphere_actor = actor.box(centers)
+    npt.assert_equal(get_primitives_count_from_actor(sphere_actor), len(centers))
+    sphere_actor = actor.sphere(centers, (1, 0, 0))
+    npt.assert_equal(get_primitives_count_from_actor(sphere_actor), len(centers))
+    prim_sphere_actor = actor.sphere(centers, (1, 0, 0), use_primitive=True)
+    npt.assert_equal(get_primitives_count_from_actor(prim_sphere_actor), len(centers))

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -1495,9 +1495,73 @@ def test_marker_actor(interactive=False):
 
 def test_actors_primitives_count():
     centers = np.array([[1, 1, 1], [2, 2, 2]])
+    directions = np.array([[1, 0, 0], [1, 0, 0]])
+    colors = np.array([[1, 0, 0], [1, 0, 0]])
+
     box_actor = actor.box(centers)
     npt.assert_equal(get_primitives_count_from_actor(box_actor), len(centers))
-    sphere_actor = actor.sphere(centers, (1, 0, 0))
+
+    sphere_actor = actor.sphere(centers, colors)
     npt.assert_equal(get_primitives_count_from_actor(sphere_actor), len(centers))
-    prim_sphere_actor = actor.sphere(centers, (1, 0, 0), use_primitive=True)
+
+    prim_sphere_actor = actor.sphere(centers, colors, use_primitive=False)
     npt.assert_equal(get_primitives_count_from_actor(prim_sphere_actor), len(centers))
+
+    prim_sphere_actor = actor.sphere(centers, directions, use_primitive=True)
+    npt.assert_equal(get_primitives_count_from_actor(prim_sphere_actor), len(centers))
+
+    sdf_actor = actor.sdf(centers, (1, 0, 0))
+    npt.assert_equal(get_primitives_count_from_actor(sdf_actor), len(centers))
+
+    billboard_actor = actor.billboard(centers)
+    npt.assert_equal(get_primitives_count_from_actor(billboard_actor), len(centers))
+
+    superquadric_actor = actor.superquadric(centers)
+    npt.assert_equal(get_primitives_count_from_actor(superquadric_actor), len(centers))
+
+    markers_actor = actor.markers(centers)
+    npt.assert_equal(get_primitives_count_from_actor(markers_actor), len(centers))
+
+    octagonalprism_actor = actor.octagonalprism(centers)
+    npt.assert_equal(get_primitives_count_from_actor(octagonalprism_actor), len(centers))
+
+    frustum_actor = actor.frustum(centers)
+    npt.assert_equal(get_primitives_count_from_actor(frustum_actor), len(centers))
+
+    rhombicuboctahedron_actor = actor.rhombicuboctahedron(centers)
+    npt.assert_equal(get_primitives_count_from_actor(rhombicuboctahedron_actor), len(centers))
+
+    pentagonalprism_actor = actor.pentagonalprism(centers)
+    npt.assert_equal(get_primitives_count_from_actor(pentagonalprism_actor), len(centers))
+
+    triangularprism_actor = actor.triangularprism(centers)
+    npt.assert_equal(get_primitives_count_from_actor(triangularprism_actor), len(centers))
+
+    prim_rhombicuboctahedron = actor.rhombicuboctahedron(centers)
+    npt.assert_equal(get_primitives_count_from_actor(prim_rhombicuboctahedron), len(centers))
+
+    cone_actor = actor.cone(centers, directions, colors, use_primitive=False)
+    npt.assert_equal(get_primitives_count_from_actor(cone_actor), len(centers))
+
+    prim_cone_actor = actor.cone(centers, directions, colors, use_primitive=True)
+    npt.assert_equal(get_primitives_count_from_actor(prim_cone_actor), len(centers))
+
+    arrow_actor = actor.arrow(centers, directions, colors, repeat_primitive=True)
+    npt.assert_equal(get_primitives_count_from_actor(arrow_actor), len(centers))
+
+    arrow_actor = actor.arrow(centers, directions, colors, repeat_primitive=False)
+    npt.assert_equal(get_primitives_count_from_actor(arrow_actor), len(centers))
+
+    disk_actor = actor.disk(centers, directions, colors)
+    npt.assert_equal(get_primitives_count_from_actor(disk_actor), len(centers))
+
+    cylinder_actor = actor.cylinder(centers, directions, colors)
+    npt.assert_equal(get_primitives_count_from_actor(cylinder_actor), len(centers))
+
+    lines = np.array([[[0, 0, 0], [1, 1, 1]], [[1, 1, 1], [2, 2, 2]]])
+    line_actor = actor.line(np.array(lines))
+    npt.assert_equal(get_primitives_count_from_actor(line_actor), len(centers))
+
+    dots_actor = actor.dots(centers)
+    npt.assert_equal(get_primitives_count_from_actor(dots_actor), len(centers))
+

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -1562,6 +1562,9 @@ def test_actors_primitives_count():
     line_actor = actor.line(np.array(lines))
     npt.assert_equal(get_actor_primitives_count(line_actor), len(centers))
 
+    streamtube_actor = actor.streamtube(np.array(lines))
+    npt.assert_equal(get_actor_primitives_count(streamtube_actor), len(centers))
+
     dots_actor = actor.dots(centers)
     npt.assert_equal(get_actor_primitives_count(dots_actor), len(centers))
 

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -12,7 +12,7 @@ from fury import shaders
 from fury import actor, window, primitive as fp
 from fury.actor import grid
 from fury.decorators import skip_osx, skip_win
-from fury.utils import shallow_copy, rotate, get_primitives_count_from_actor
+from fury.utils import shallow_copy, rotate, get_actor_primitives_count
 from fury.testing import assert_greater, assert_greater_equal
 from fury.primitive import prim_sphere
 
@@ -1499,69 +1499,69 @@ def test_actors_primitives_count():
     colors = np.array([[1, 0, 0], [1, 0, 0]])
 
     box_actor = actor.box(centers)
-    npt.assert_equal(get_primitives_count_from_actor(box_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(box_actor), len(centers))
 
     sphere_actor = actor.sphere(centers, colors)
-    npt.assert_equal(get_primitives_count_from_actor(sphere_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(sphere_actor), len(centers))
 
     prim_sphere_actor = actor.sphere(centers, colors, use_primitive=False)
-    npt.assert_equal(get_primitives_count_from_actor(prim_sphere_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(prim_sphere_actor), len(centers))
 
     prim_sphere_actor = actor.sphere(centers, directions, use_primitive=True)
-    npt.assert_equal(get_primitives_count_from_actor(prim_sphere_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(prim_sphere_actor), len(centers))
 
     sdf_actor = actor.sdf(centers, (1, 0, 0))
-    npt.assert_equal(get_primitives_count_from_actor(sdf_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(sdf_actor), len(centers))
 
     billboard_actor = actor.billboard(centers)
-    npt.assert_equal(get_primitives_count_from_actor(billboard_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(billboard_actor), len(centers))
 
     superquadric_actor = actor.superquadric(centers)
-    npt.assert_equal(get_primitives_count_from_actor(superquadric_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(superquadric_actor), len(centers))
 
     markers_actor = actor.markers(centers)
-    npt.assert_equal(get_primitives_count_from_actor(markers_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(markers_actor), len(centers))
 
     octagonalprism_actor = actor.octagonalprism(centers)
-    npt.assert_equal(get_primitives_count_from_actor(octagonalprism_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(octagonalprism_actor), len(centers))
 
     frustum_actor = actor.frustum(centers)
-    npt.assert_equal(get_primitives_count_from_actor(frustum_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(frustum_actor), len(centers))
 
     rhombicuboctahedron_actor = actor.rhombicuboctahedron(centers)
-    npt.assert_equal(get_primitives_count_from_actor(rhombicuboctahedron_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(rhombicuboctahedron_actor), len(centers))
 
     pentagonalprism_actor = actor.pentagonalprism(centers)
-    npt.assert_equal(get_primitives_count_from_actor(pentagonalprism_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(pentagonalprism_actor), len(centers))
 
     triangularprism_actor = actor.triangularprism(centers)
-    npt.assert_equal(get_primitives_count_from_actor(triangularprism_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(triangularprism_actor), len(centers))
 
     prim_rhombicuboctahedron = actor.rhombicuboctahedron(centers)
-    npt.assert_equal(get_primitives_count_from_actor(prim_rhombicuboctahedron), len(centers))
+    npt.assert_equal(get_actor_primitives_count(prim_rhombicuboctahedron), len(centers))
 
     cone_actor = actor.cone(centers, directions, colors, use_primitive=False)
-    npt.assert_equal(get_primitives_count_from_actor(cone_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(cone_actor), len(centers))
 
     prim_cone_actor = actor.cone(centers, directions, colors, use_primitive=True)
-    npt.assert_equal(get_primitives_count_from_actor(prim_cone_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(prim_cone_actor), len(centers))
 
     arrow_actor = actor.arrow(centers, directions, colors, repeat_primitive=True)
-    npt.assert_equal(get_primitives_count_from_actor(arrow_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(arrow_actor), len(centers))
 
     arrow_actor = actor.arrow(centers, directions, colors, repeat_primitive=False)
-    npt.assert_equal(get_primitives_count_from_actor(arrow_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(arrow_actor), len(centers))
 
     disk_actor = actor.disk(centers, directions, colors)
-    npt.assert_equal(get_primitives_count_from_actor(disk_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(disk_actor), len(centers))
 
     cylinder_actor = actor.cylinder(centers, directions, colors)
-    npt.assert_equal(get_primitives_count_from_actor(cylinder_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(cylinder_actor), len(centers))
 
     lines = np.array([[[0, 0, 0], [1, 1, 1]], [[1, 1, 1], [2, 2, 2]]])
     line_actor = actor.line(np.array(lines))
-    npt.assert_equal(get_primitives_count_from_actor(line_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(line_actor), len(centers))
 
     dots_actor = actor.dots(centers)
-    npt.assert_equal(get_primitives_count_from_actor(dots_actor), len(centers))
+    npt.assert_equal(get_actor_primitives_count(dots_actor), len(centers))
 

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -1495,8 +1495,8 @@ def test_marker_actor(interactive=False):
 
 def test_actors_primitives_count():
     centers = np.array([[1, 1, 1], [2, 2, 2]])
-    sphere_actor = actor.box(centers)
-    npt.assert_equal(get_primitives_count_from_actor(sphere_actor), len(centers))
+    box_actor = actor.box(centers)
+    npt.assert_equal(get_primitives_count_from_actor(box_actor), len(centers))
     sphere_actor = actor.sphere(centers, (1, 0, 0))
     npt.assert_equal(get_primitives_count_from_actor(sphere_actor), len(centers))
     prim_sphere_actor = actor.sphere(centers, (1, 0, 0), use_primitive=True)

--- a/fury/tests/test_utils.py
+++ b/fury/tests/test_utils.py
@@ -17,12 +17,14 @@ from fury.utils import (add_polydata_numeric_field, get_polydata_field,
                         update_actor, get_actor_from_primitive,
                         get_bounds, update_surface_actor_colors,
                         apply_affine_to_actor, color_check, is_ui,
-                        set_actor_primitives_count, get_actor_primitives_count,
-                        set_polydata_primitives_count, get_polydata_primitives_count)
+                        primitives_count_to_actor, primitives_count_from_actor,
+                        set_polydata_primitives_count,
+                        get_polydata_primitives_count)
 from fury import actor, window, utils
 from fury.lib import (numpy_support, PolyData, PolyDataMapper2D, Points,
-                      CellArray, Polygon, Actor2D, DoubleArray,
-                      UnsignedCharArray, TextActor3D, VTK_DOUBLE, VTK_FLOAT, Actor, PolyDataMapper, VTK_INT)
+                      CellArray, Polygon, Actor2D, DoubleArray, VTK_INT,
+                      UnsignedCharArray, TextActor3D, VTK_DOUBLE, VTK_FLOAT)
+
 import fury.primitive as fp
 
 from fury.optpkg import optional_package
@@ -848,7 +850,7 @@ def test_get_polydata_primitives_count():
 
 def test_set_actor_primitives_count():
     act = actor.axes()
-    set_actor_primitives_count(act, 1)
+    primitives_count_to_actor(act, 1)
     polydata = act.GetMapper().GetInput()
     prim_count = get_polydata_field(polydata, 'prim_count')[0]
     npt.assert_equal(prim_count, 1)
@@ -858,15 +860,15 @@ def test_get_actor_primitives_count():
     act = actor.axes()
     polydata = act.GetMapper().GetInput()
     add_polydata_numeric_field(polydata, "prim_count", 1, array_type=VTK_INT)
-    prim_count = get_actor_primitives_count(act)
+    prim_count = primitives_count_from_actor(act)
     npt.assert_equal(prim_count, 1)
 
 
 def test_primitives_count():
     # testing on actor
     act = actor.axes()
-    set_actor_primitives_count(act, 3)
-    prim_count = get_actor_primitives_count(act)
+    primitives_count_to_actor(act, 3)
+    prim_count = primitives_count_from_actor(act)
     npt.assert_equal(prim_count, 3)
 
     # testing on polydata

--- a/fury/tests/test_utils.py
+++ b/fury/tests/test_utils.py
@@ -16,11 +16,13 @@ from fury.utils import (add_polydata_numeric_field, get_polydata_field,
                         compute_bounds, set_input,
                         update_actor, get_actor_from_primitive,
                         get_bounds, update_surface_actor_colors,
-                        apply_affine_to_actor, color_check, is_ui)
+                        apply_affine_to_actor, color_check, is_ui,
+                        set_actor_primitives_count, get_actor_primitives_count,
+                        set_polydata_primitives_count, get_polydata_primitives_count)
 from fury import actor, window, utils
 from fury.lib import (numpy_support, PolyData, PolyDataMapper2D, Points,
                       CellArray, Polygon, Actor2D, DoubleArray,
-                      UnsignedCharArray, TextActor3D, VTK_DOUBLE, VTK_FLOAT)
+                      UnsignedCharArray, TextActor3D, VTK_DOUBLE, VTK_FLOAT, Actor, PolyDataMapper, VTK_INT)
 import fury.primitive as fp
 
 from fury.optpkg import optional_package
@@ -814,12 +816,46 @@ def test_empty_list_to_polydata():
     lines = [[]]
     _, _ = utils.lines_to_vtk_polydata(lines)
 
+
 def test_empty_array_to_polydata():
     lines = np.array([[]])
     _, _ = utils.lines_to_vtk_polydata(lines)
+
 
 @pytest.mark.skipif(not have_dipy, reason="Requires DIPY")
 def test_empty_array_sequence_to_polydata():
     from dipy.tracking.streamline import Streamlines
     lines = Streamlines()
     _, _ = utils.lines_to_vtk_polydata(lines)
+
+
+def test_set_polydata_primitives_count():
+    polydata = PolyData()
+
+    set_polydata_primitives_count(polydata, 1)
+    prim_count = get_polydata_field(polydata, 'prim_count')[0]
+    npt.assert_equal(prim_count, 1)
+
+
+def test_get_polydata_primitives_count():
+    polydata = PolyData()
+    add_polydata_numeric_field(polydata, "prim_count", 1, array_type=VTK_INT)
+
+    prim_count = get_polydata_primitives_count(polydata)
+    npt.assert_equal(prim_count, 1)
+
+
+def test_set_actor_primitives_count():
+    act = actor.axes()
+    set_actor_primitives_count(act, 1)
+    polydata = act.GetMapper().GetInput()
+    prim_count = get_polydata_field(polydata, 'prim_count')[0]
+    npt.assert_equal(prim_count, 1)
+
+
+def test_get_actor_primitives_count():
+    act = actor.axes()
+    polydata = act.GetMapper().GetInput()
+    add_polydata_numeric_field(polydata, "prim_count", 1, array_type=VTK_INT)
+    prim_count = get_actor_primitives_count(act)
+    npt.assert_equal(prim_count, 1)

--- a/fury/tests/test_utils.py
+++ b/fury/tests/test_utils.py
@@ -848,7 +848,7 @@ def test_get_polydata_primitives_count():
     npt.assert_equal(prim_count, 1)
 
 
-def test_set_actor_primitives_count():
+def test_primitives_count_to_actor():
     act = actor.axes()
     primitives_count_to_actor(act, 1)
     polydata = act.GetMapper().GetInput()
@@ -856,7 +856,7 @@ def test_set_actor_primitives_count():
     npt.assert_equal(prim_count, 1)
 
 
-def test_get_actor_primitives_count():
+def test_primitives_count_from_actor():
     act = actor.axes()
     polydata = act.GetMapper().GetInput()
     add_polydata_numeric_field(polydata, "prim_count", 1, array_type=VTK_INT)

--- a/fury/tests/test_utils.py
+++ b/fury/tests/test_utils.py
@@ -860,3 +860,17 @@ def test_get_actor_primitives_count():
     add_polydata_numeric_field(polydata, "prim_count", 1, array_type=VTK_INT)
     prim_count = get_actor_primitives_count(act)
     npt.assert_equal(prim_count, 1)
+
+
+def test_primitives_count():
+    # testing on actor
+    act = actor.axes()
+    set_actor_primitives_count(act, 3)
+    prim_count = get_actor_primitives_count(act)
+    npt.assert_equal(prim_count, 3)
+
+    # testing on polydata
+    polydata = PolyData()
+    set_polydata_primitives_count(polydata, 4)
+    prim_count = get_polydata_primitives_count(polydata)
+    npt.assert_equal(prim_count, 4)

--- a/fury/tests/test_utils.py
+++ b/fury/tests/test_utils.py
@@ -28,6 +28,7 @@ import fury.primitive as fp
 from fury.optpkg import optional_package
 dipy, have_dipy, _ = optional_package('dipy')
 
+
 def test_apply_affine_to_actor(interactive=False):
     text_act = actor.text_3d("ALIGN TOP RIGHT", justification='right',
                              vertical_justification='top')

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -536,7 +536,7 @@ def get_polydata_primitives_count(polydata):
     return get_polydata_field(polydata, 'prim_count')[0]
 
 
-def set_actor_primitives_count(actor, primitives_count):
+def primitives_count_to_actor(actor, primitives_count):
     """Add primitives count to actor's polydata.
 
     Parameters
@@ -549,7 +549,7 @@ def set_actor_primitives_count(actor, primitives_count):
     set_polydata_primitives_count(polydata, primitives_count)
 
 
-def get_actor_primitives_count(actor):
+def primitives_count_from_actor(actor):
     """Get primitives count from actor's polydata.
 
     Parameters

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -719,7 +719,7 @@ def get_actor_from_primitive(vertices, triangles, colors=None,
         culling of polygons based on orientation of normal with respect to
         camera. If backface culling is True, polygons facing away from camera
         are not drawn. Default: True
-    prim_count: int
+    prim_count: int, optional
         primitives count to be associated with the actor
 
     Returns

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -509,6 +509,34 @@ def add_polydata_numeric_field(polydata, field_name, field_data,
     return polydata
 
 
+def add_primitives_count_to_actor(actor, primitives_count):
+    """Get primitives count from actor.
+
+    Parameters
+    ----------
+    actor: :class: `UI` or `vtkProp3D` actor
+    primitives_count : int
+
+    """
+    polydata = actor.GetMapper().GetInput()
+    add_polydata_numeric_field(polydata, "prim_count", 88, array_type=VTK_INT)
+
+
+def get_primitives_count_from_actor(actor):
+    """Get primitives count from actor.
+
+    Parameters
+    ----------
+    actor: :class: `UI` or `vtkProp3D` actor
+
+    Returns
+    -------
+    primitives count : int
+    """
+    polydata = actor.GetMapper().GetInput()
+    return get_polydata_field(polydata, 'prim_count')[0]
+
+
 def set_polydata_triangles(polydata, triangles):
     """Set polydata triangles with a numpy array (ndarrays Nx3 int).
 

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -719,8 +719,8 @@ def get_actor_from_primitive(vertices, triangles, colors=None,
         culling of polygons based on orientation of normal with respect to
         camera. If backface culling is True, polygons facing away from camera
         are not drawn. Default: True
-    prim_count: bool
-        primitives count inside the actor
+    prim_count: int
+        primitives count to be associated with the actor
 
     Returns
     -------

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -509,7 +509,34 @@ def add_polydata_numeric_field(polydata, field_name, field_data,
     return polydata
 
 
-def add_primitives_count_to_actor(actor, primitives_count):
+def set_polydata_primitives_count(polydata, primitives_count):
+    """Add primitives count to polydata.
+
+    Parameters
+    ----------
+    polydata: vtkPolyData
+    primitives_count : int
+
+    """
+    add_polydata_numeric_field(polydata, "prim_count", primitives_count,
+                               array_type=VTK_INT)
+
+
+def get_polydata_primitives_count(polydata):
+    """Get primitives count from actor's polydata.
+
+    Parameters
+    ----------
+    polydata: vtkPolyData
+
+    Returns
+    -------
+    primitives count : int
+    """
+    return get_polydata_field(polydata, 'prim_count')[0]
+
+
+def set_actor_primitives_count(actor, primitives_count):
     """Add primitives count to actor's polydata.
 
     Parameters
@@ -519,11 +546,10 @@ def add_primitives_count_to_actor(actor, primitives_count):
 
     """
     polydata = actor.GetMapper().GetInput()
-    add_polydata_numeric_field(polydata, "prim_count", primitives_count,
-                               array_type=VTK_INT)
+    set_polydata_primitives_count(polydata, primitives_count)
 
 
-def get_primitives_count_from_actor(actor):
+def get_actor_primitives_count(actor):
     """Get primitives count from actor's polydata.
 
     Parameters
@@ -535,7 +561,7 @@ def get_primitives_count_from_actor(actor):
     primitives count : int
     """
     polydata = actor.GetMapper().GetInput()
-    return get_polydata_field(polydata, 'prim_count')[0]
+    return get_polydata_primitives_count(polydata)
 
 
 def set_polydata_triangles(polydata, triangles):
@@ -745,7 +771,7 @@ def get_actor_from_primitive(vertices, triangles, colors=None,
 
     current_actor = get_actor_from_polydata(pd)
     current_actor.GetProperty().SetBackfaceCulling(backface_culling)
-    add_primitives_count_to_actor(current_actor, prim_count)
+    set_actor_primitives_count(current_actor, prim_count)
     return current_actor
 
 
@@ -816,7 +842,7 @@ def repeat_sources(centers, colors, active_scalars=1., directions=None,
 
     actor = Actor()
     actor.SetMapper(mapper)
-    add_primitives_count_to_actor(actor, len(centers))
+    set_actor_primitives_count(actor, len(centers))
     return actor
 
 

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -757,6 +757,7 @@ def get_actor_from_primitive(vertices, triangles, colors=None,
     pd = PolyData()
     set_polydata_vertices(pd, vertices)
     set_polydata_triangles(pd, triangles)
+    set_polydata_primitives_count(pd, prim_count)
     if isinstance(colors, np.ndarray):
         if len(colors) != len(vertices):
             msg = "Vertices and Colors should have the same size."
@@ -771,7 +772,6 @@ def get_actor_from_primitive(vertices, triangles, colors=None,
 
     current_actor = get_actor_from_polydata(pd)
     current_actor.GetProperty().SetBackfaceCulling(backface_culling)
-    set_actor_primitives_count(current_actor, prim_count)
     return current_actor
 
 
@@ -810,6 +810,8 @@ def repeat_sources(centers, colors, active_scalars=1., directions=None,
 
     polydata_centers.SetPoints(pts)
     polydata_centers.GetPointData().AddArray(cols)
+    set_polydata_primitives_count(polydata_centers, len(centers))
+
     if directions is not None:
         polydata_centers.GetPointData().AddArray(directions_fa)
         polydata_centers.GetPointData().SetActiveVectors('directions')
@@ -842,7 +844,6 @@ def repeat_sources(centers, colors, active_scalars=1., directions=None,
 
     actor = Actor()
     actor.SetMapper(mapper)
-    set_actor_primitives_count(actor, len(centers))
     return actor
 
 

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -510,7 +510,7 @@ def add_polydata_numeric_field(polydata, field_name, field_data,
 
 
 def add_primitives_count_to_actor(actor, primitives_count):
-    """Get primitives count from actor.
+    """Add primitives count to actor's polydata.
 
     Parameters
     ----------
@@ -519,11 +519,12 @@ def add_primitives_count_to_actor(actor, primitives_count):
 
     """
     polydata = actor.GetMapper().GetInput()
-    add_polydata_numeric_field(polydata, "prim_count", 88, array_type=VTK_INT)
+    add_polydata_numeric_field(polydata, "prim_count", primitives_count,
+                               array_type=VTK_INT)
 
 
 def get_primitives_count_from_actor(actor):
-    """Get primitives count from actor.
+    """Get primitives count from actor's polydata.
 
     Parameters
     ----------
@@ -700,7 +701,7 @@ def get_actor_from_polydata(polydata):
 
 
 def get_actor_from_primitive(vertices, triangles, colors=None,
-                             normals=None, backface_culling=True):
+                             normals=None, backface_culling=True, prim_count=1):
     """Get actor from a vtkPolyData.
 
     Parameters
@@ -718,7 +719,8 @@ def get_actor_from_primitive(vertices, triangles, colors=None,
         culling of polygons based on orientation of normal with respect to
         camera. If backface culling is True, polygons facing away from camera
         are not drawn. Default: True
-
+    prim_count: bool
+        primitives count inside the actor
 
     Returns
     -------
@@ -743,6 +745,7 @@ def get_actor_from_primitive(vertices, triangles, colors=None,
 
     current_actor = get_actor_from_polydata(pd)
     current_actor.GetProperty().SetBackfaceCulling(backface_culling)
+    add_primitives_count_to_actor(current_actor, prim_count)
     return current_actor
 
 
@@ -813,6 +816,7 @@ def repeat_sources(centers, colors, active_scalars=1., directions=None,
 
     actor = Actor()
     actor.SetMapper(mapper)
+    add_primitives_count_to_actor(actor, len(centers))
     return actor
 
 


### PR DESCRIPTION
As @filipinascimento, @guaje, and I was trying to find an approach to only apply the keyframe animation on a partial subset of the actor's primitives not all of them, we found that there is no currently implemented way to get the primitives count of a single actor.
In this PR, the primitive's count is saved inside the polydata of the actor.
This can be used to distinguish the vertices of different primitives 