### PR TITLE
Bugfix: Visibility issues with ListBox2D

### DIFF
--- a/fury/ui/elements.py
+++ b/fury/ui/elements.py
@@ -2405,6 +2405,7 @@ class ListBox2D(UI):
                                             scroll_bar_height))
         if len(self.values) <= self.nb_slots:
             self.scroll_bar.set_visibility(False)
+            self.scroll_bar.height = 0
         self.panel.add_element(
             self.scroll_bar, size - self.scroll_bar.size - self.margin)
 

--- a/fury/ui/elements.py
+++ b/fury/ui/elements.py
@@ -2622,6 +2622,8 @@ class ListBox2D(UI):
             if slot.textblock.scene is not None:
                 clip_overflow(slot.textblock, self.slot_width)
             slot.set_visibility(True)
+            if slot.size[1] != self.slot_height:
+                slot.resize((self.slot_width, self.slot_height))
             if slot.element in self.selected:
                 slot.select()
             else:
@@ -2653,6 +2655,7 @@ class ListBox2D(UI):
 
         if len(self.values) <= self.nb_slots:
             self.scroll_bar.set_visibility(False)
+            self.scroll_bar.height = 0
 
     def clear_selection(self):
         del self.selected[:]

--- a/fury/ui/elements.py
+++ b/fury/ui/elements.py
@@ -2631,6 +2631,7 @@ class ListBox2D(UI):
         for slot in self.slots[len(values_to_show):]:
             slot.element = None
             slot.set_visibility(False)
+            slot.resize((self.slot_width, 0))
             slot.deselect()
 
     def update_scrollbar(self):
@@ -2816,6 +2817,8 @@ class ListBoxItem2D(UI):
         self.list_box.select(self, multiselect, range_select)
         i_ren.force_render()
 
+    def resize(self, size):
+        self.background.resize(size)
 
 class FileMenu2D(UI):
     """A menu to select files in the current folder.

--- a/fury/ui/tests/test_elements.py
+++ b/fury/ui/tests/test_elements.py
@@ -657,6 +657,24 @@ Text Overflow of List Box 2D"]]
     assert_arrays_equal(selected_values, expected)
 
 
+def test_ui_listbox_2d_visibility():
+    l1 = ui.ListBox2D(values=['Violet', 'Indigo', 'Blue', 'Yellow'],
+                      position=(12, 10), size=(100, 100))
+    l2 = ui.ListBox2D(values=['Violet', 'Indigo', 'Blue', 'Yellow'],
+                      position=(10, 10), size=(100, 300))
+
+    def assert_listbox(list_box, expected_scroll_bar_height):
+        view_end = list_box.view_offset + list_box.nb_slots
+        assert list_box.scroll_bar.height == expected_scroll_bar_height
+        for slot in list_box.slots[view_end:]:
+            assert slot.size[1] == list_box.slot_height
+
+    assert_listbox(l1, 40.0)
+
+    # Assert that for list 2 the slots and scrollbars aren't visible.
+    assert_listbox(l2, 0)
+
+
 def test_ui_file_menu_2d(interactive=False):
     filename = "test_ui_file_menu_2d"
     recording_filename = pjoin(DATA_DIR, filename + ".log.gz")


### PR DESCRIPTION
Setting the visibility of a ListBox2D from `False` to `True` after creation causes the scrollbar and unused ListBox2D items to render incorrectly.

This also fixes #418 