### PR TITLE
Fixing `ZeroDivisionError` thrown by UI sliders when the `value_range` is zero (0)

### DIFF
--- a/fury/ui/elements.py
+++ b/fury/ui/elements.py
@@ -613,9 +613,7 @@ class LineSlider2D(UI):
     @value.setter
     def value(self, value):
         value_range = self.max_value - self.min_value
-        if value_range == 0:
-            value_range = 1
-        self.ratio = (value - self.min_value) / value_range
+        self.ratio = (value - self.min_value) / value_range if value_range else 0
         self.on_value_changed(self)
 
     @property
@@ -972,9 +970,7 @@ class LineDoubleSlider2D(UI):
 
         """
         value_range = self.max_value - self.min_value
-        if value_range == 0:
-            value_range = 1
-        return (value - self.min_value) / value_range
+        return (value - self.min_value) / value_range if value_range else 0
 
     def ratio_to_coord(self, ratio):
         """Convert the ratio to the absolute coordinate.
@@ -1438,9 +1434,7 @@ class RingSlider2D(UI):
     @value.setter
     def value(self, value):
         value_range = self.max_value - self.min_value
-        if value_range == 0:
-            value_range = 1
-        self.ratio = (value - self.min_value) / value_range
+        self.ratio = (value - self.min_value) / value_range if value_range else 0
         self.on_value_changed(self)
 
     @property

--- a/fury/ui/elements.py
+++ b/fury/ui/elements.py
@@ -613,6 +613,8 @@ class LineSlider2D(UI):
     @value.setter
     def value(self, value):
         value_range = self.max_value - self.min_value
+        if value_range == 0:
+            value_range = 1
         self.ratio = (value - self.min_value) / value_range
         self.on_value_changed(self)
 
@@ -874,7 +876,6 @@ class LineDoubleSlider2D(UI):
         self.handles[1].on_left_mouse_button_released = \
             self.handle_release_callback
 
-
     def _get_actors(self):
         """Get the actors composing this UI component."""
         return (self.track.actors + self.handles[0].actors +
@@ -971,6 +972,8 @@ class LineDoubleSlider2D(UI):
 
         """
         value_range = self.max_value - self.min_value
+        if value_range == 0:
+            value_range = 1
         return (value - self.min_value) / value_range
 
     def ratio_to_coord(self, ratio):
@@ -1435,6 +1438,8 @@ class RingSlider2D(UI):
     @value.setter
     def value(self, value):
         value_range = self.max_value - self.min_value
+        if value_range == 0:
+            value_range = 1
         self.ratio = (value - self.min_value) / value_range
         self.on_value_changed(self)
 
@@ -2838,6 +2843,7 @@ class ListBoxItem2D(UI):
 
     def resize(self, size):
         self.background.resize(size)
+
 
 class FileMenu2D(UI):
     """A menu to select files in the current folder.

--- a/fury/ui/tests/test_elements.py
+++ b/fury/ui/tests/test_elements.py
@@ -472,22 +472,53 @@ def test_ui_range_slider(interactive=False):
         show_manager.start()
 
 
-def test_ui_slider_value_range(interactive=False):
-    sliders = []
+def test_ui_slider_value_range():
     with npt.assert_no_warnings():
-        sliders.append(ui.LineSlider2D(min_value=0, max_value=0, center=(200, 450)))
-        sliders.append(ui.LineDoubleSlider2D(min_value=0, max_value=0, center=(200, 200)))
-        sliders.append(ui.RingSlider2D(min_value=0, max_value=0, center=(200, 300)))
-        sliders.append(ui.RangeSlider(min_value=0, max_value=0))
+        # LineSlider2D
+        line_slider = ui.LineSlider2D(min_value=0, max_value=0)
+        assert_equal(line_slider.value, 0)
+        assert_equal(line_slider.min_value, 0)
+        assert_equal(line_slider.max_value, 0)
+        line_slider.value = 100
+        assert_equal(line_slider.value, 0)
+        line_slider.value = -100
+        assert_equal(line_slider.value, 0)
 
-    current_size = (600, 600)
-    show_manager = window.ShowManager(size=current_size,
-                                      title="FURY Sliders Value Range Test")
+        line_slider = ui.LineSlider2D(min_value=0, max_value=100)
+        line_slider.value = 105
+        assert_equal(line_slider.value, 100)
+        line_slider.value = -100
+        assert_equal(line_slider.value, 0)
 
-    show_manager.scene.add(*sliders)
+        # LineDoubleSlider2D
+        line_double_slider = ui.LineDoubleSlider2D(min_value=0, max_value=0)
+        assert_equal(line_double_slider.left_disk_value, 0)
+        assert_equal(line_double_slider.right_disk_value, 0)
+        line_double_slider.left_disk_value = 100
+        assert_equal(line_double_slider.left_disk_value, 0)
+        line_double_slider.right_disk_value = -100
+        assert_equal(line_double_slider.right_disk_value, 0)
 
-    if interactive:
-        show_manager.start()
+        line_double_slider = ui.LineDoubleSlider2D(min_value=50, max_value=100)
+        line_double_slider.right_disk_value = 150
+        assert_equal(line_double_slider.right_disk_value, 100)
+        line_double_slider.left_disk_value = -150
+        assert_equal(line_double_slider.left_disk_value, 50)
+
+        # RingSlider2D
+        ring_slider = ui.RingSlider2D(initial_value=0, min_value=0, max_value=0)
+        assert_equal(ring_slider.value, 0)
+        assert_equal(ring_slider.previous_value, 0)
+        ring_slider.value = 180
+        assert_equal(ring_slider.value, 0)
+        ring_slider.value = -180
+        assert_equal(ring_slider.value, 0)
+
+        # RangeSlider
+        range_slider_2d = ui.RangeSlider(min_value=0, max_value=0)
+        assert_equal(range_slider_2d.value_slider.value, 0)
+        range_slider_2d.value_slider.value = 100
+        assert_equal(range_slider_2d.value_slider.value, 0)
 
 
 def test_ui_option(interactive=False):

--- a/fury/ui/tests/test_elements.py
+++ b/fury/ui/tests/test_elements.py
@@ -199,7 +199,7 @@ def test_ui_2d_line_slider_hooks(recording=False):
     expected_events_counts_filename = pjoin(DATA_DIR, filename + ".json")
 
     line_slider_2d = ui.LineSlider2D(center=(300, 300))
-    
+
     event_counter = EventCounter()
     event_counter.monitor(line_slider_2d)
 
@@ -469,6 +469,23 @@ def test_ui_range_slider(interactive=False):
                                           title="FURY Line Double Slider")
         show_manager.scene.add(range_slider_test_horizontal)
         show_manager.scene.add(range_slider_test_vertical)
+        show_manager.start()
+
+
+def test_ui_slider_value_range(interactive=False):
+    sliders = []
+    sliders.append(ui.LineSlider2D(min_value=0, max_value=0, center=(200, 450)))
+    sliders.append(ui.LineDoubleSlider2D(min_value=0, max_value=0, center=(200, 200)))
+    sliders.append(ui.RingSlider2D(min_value=0, max_value=0, center=(200, 300)))
+    sliders.append(ui.RangeSlider(min_value=0, max_value=0))
+
+    current_size = (600, 600)
+    show_manager = window.ShowManager(size=current_size,
+                                      title="FURY Sliders Value Range Test")
+
+    show_manager.scene.add(*sliders)
+
+    if interactive:
         show_manager.start()
 
 

--- a/fury/ui/tests/test_elements.py
+++ b/fury/ui/tests/test_elements.py
@@ -474,10 +474,11 @@ def test_ui_range_slider(interactive=False):
 
 def test_ui_slider_value_range(interactive=False):
     sliders = []
-    sliders.append(ui.LineSlider2D(min_value=0, max_value=0, center=(200, 450)))
-    sliders.append(ui.LineDoubleSlider2D(min_value=0, max_value=0, center=(200, 200)))
-    sliders.append(ui.RingSlider2D(min_value=0, max_value=0, center=(200, 300)))
-    sliders.append(ui.RangeSlider(min_value=0, max_value=0))
+    with npt.assert_no_warnings():
+        sliders.append(ui.LineSlider2D(min_value=0, max_value=0, center=(200, 450)))
+        sliders.append(ui.LineDoubleSlider2D(min_value=0, max_value=0, center=(200, 200)))
+        sliders.append(ui.RingSlider2D(min_value=0, max_value=0, center=(200, 300)))
+        sliders.append(ui.RangeSlider(min_value=0, max_value=0))
 
     current_size = (600, 600)
     show_manager = window.ShowManager(size=current_size,


### PR DESCRIPTION
Currently, the UI sliders throw `ZeroDivisionError` whenever the `value_range` is zero ie. min_value and max_value are the same.
Adding checks to avoid these errors and setting the handle at the start.