### PR TITLE
Fixed `vector_text` not following camera

### DIFF
--- a/fury/actor.py
+++ b/fury/actor.py
@@ -2427,6 +2427,12 @@ def vector_text(text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.2),
     texta.GetProperty().SetColor(color)
     texta.SetPosition(pos)
 
+    def add_to_scene(scene):
+        texta.SetCamera(scene.GetActiveCamera())
+        scene.AddActor(texta)
+
+    texta.add_to_scene = add_to_scene
+
     return texta
 
 

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -2448,7 +2448,6 @@ def vector_text(text='Origin', pos=(0, 0, 0), direction=None,
         direction /= np.linalg.norm(direction)
         normal_vec = np.cross(orig_dir, direction)
         angle = np.arccos(np.dot(orig_dir, direction))
-        print(np.dot(orig_dir, direction))
         t.RotateWXYZ(np.rad2deg(angle), *normal_vec)
 
     t.Scale(*scale)

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -2383,8 +2383,8 @@ def billboard(centers, colors=(0, 1, 0), scales=1, vs_dec=None, vs_impl=None,
     return bb_actor
 
 
-def vector_text(text='Origin', pos=(0, 0, 0), direction=None,
-                scale=(0.2, 0.2, 0.2), color=(1, 1, 1), align_center=False):
+def vector_text(text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.2),
+                color=(1, 1, 1), direction=(0, 0, 1), align_center=False):
     """Create a label actor.
 
     This actor will always face the camera
@@ -2395,7 +2395,7 @@ def vector_text(text='Origin', pos=(0, 0, 0), direction=None,
         Text for the label.
     pos : (3,) array_like, optional
         Left down position of the label.
-    direction : (3,) array_like, optional, default: None
+    direction : (3,) array_like, optional, default: (0, 0, 1)
         The direction of the label. If None, label will follow the camera.
     scale : (3,) array_like
         Changes the size of the label.
@@ -2423,13 +2423,10 @@ def vector_text(text='Origin', pos=(0, 0, 0), direction=None,
     atext.SetText(text)
     textm = PolyDataMapper()
 
-    t = Transform()
-    t.PostMultiply()
+    trans_matrix = Transform()
+    trans_matrix.PostMultiply()
 
     textm.SetInputConnection(atext.GetOutputPort())
-
-    if align_center:
-        t.Translate(-np.array(textm.GetCenter()))
 
     if direction is None:
         texta = Follower()
@@ -2448,18 +2445,23 @@ def vector_text(text='Origin', pos=(0, 0, 0), direction=None,
         direction /= np.linalg.norm(direction)
         normal_vec = np.cross(orig_dir, direction)
         angle = np.arccos(np.dot(orig_dir, direction))
-        t.RotateWXYZ(np.rad2deg(angle), *normal_vec)
+        trans_matrix.RotateWXYZ(np.rad2deg(angle), *normal_vec)
 
-    t.Scale(*scale)
+    trans_matrix.Scale(*scale)
 
     plan = TransformPolyDataFilter()
-    plan.SetTransform(t)
-
     plan.SetInputConnection(atext.GetOutputPort())
+    plan.SetTransform(trans_matrix)
     textm.SetInputConnection(plan.GetOutputPort())
 
     texta.SetMapper(textm)
+
     texta.GetProperty().SetColor(color)
+
+    if align_center:
+        trans_matrix.Translate(-np.array(textm.GetCenter()))
+
+    texta.SetPosition(*pos)
 
     return texta
 

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -2385,9 +2385,8 @@ def billboard(centers, colors=(0, 1, 0), scales=1, vs_dec=None, vs_impl=None,
     return bb_actor
 
 
-def vector_text(text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.2),
-                color=(1, 1, 1), direction=(0, 0, 1), align_center=False,
-                extrusion=0.0):
+def vector_text(text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.1),
+                color=(1, 1, 1), direction=(0, 0, 1), align_center=False):
     """Create a label actor.
 
     This actor will always face the camera
@@ -2431,12 +2430,10 @@ def vector_text(text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.2),
     extrude = vtkLinearExtrusionFilter()
     extrude.SetInputConnection(atext.GetOutputPort())
     extrude.SetExtrusionTypeToNormalExtrusion()
-    extrude.SetVector(0, 0, extrusion)
+    extrude.SetVector(0, 0, scale[2])
 
     trans_matrix = Transform()
     trans_matrix.PostMultiply()
-
-    textm.SetInputConnection(extrude.GetOutputPort())
 
     if direction is None:
         texta = Follower()
@@ -2457,7 +2454,7 @@ def vector_text(text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.2),
         angle = np.arccos(np.dot(orig_dir, direction))
         trans_matrix.RotateWXYZ(np.rad2deg(angle), *normal_vec)
 
-    trans_matrix.Scale(*scale)
+    trans_matrix.Scale(*scale[0:2], 1)
 
     plan = TransformPolyDataFilter()
     plan.SetInputConnection(extrude.GetOutputPort())

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -4,8 +4,6 @@ import warnings
 from functools import partial
 
 import numpy as np
-from vtkmodules.vtkFiltersCore import vtkTriangleFilter
-from vtkmodules.vtkFiltersModeling import vtkLinearExtrusionFilter
 
 from fury.shaders import (add_shader_callback, attribute_to_actor,
                           compose_shader, import_fury_shader,
@@ -29,7 +27,8 @@ from fury.lib import (numpy_support, Transform, ImageData, PolyData, Matrix4x4,
                       Texture, FloatArray, VTK_TEXT_LEFT, VTK_TEXT_RIGHT,
                       VTK_TEXT_BOTTOM, VTK_TEXT_TOP, VTK_TEXT_CENTERED,
                       TexturedActor2D, TextureMapToPlane, TextActor3D,
-                      Follower, VectorText, TransformPolyDataFilter)
+                      Follower, VectorText, TransformPolyDataFilter,
+                      LinearExtrusionFilter)
 import fury.primitive as fp
 from fury.utils import (lines_to_vtk_polydata, set_input, apply_affine,
                         set_polydata_vertices, set_polydata_triangles,
@@ -2385,7 +2384,7 @@ def billboard(centers, colors=(0, 1, 0), scales=1, vs_dec=None, vs_impl=None,
     return bb_actor
 
 
-def vector_text(text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.1),
+def vector_text(text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.0),
                 color=(1, 1, 1), direction=(0, 0, 1), align_center=False):
     """Create a label actor.
 
@@ -2397,17 +2396,15 @@ def vector_text(text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.1),
         Text for the label.
     pos : (3,) array_like, optional
         Left down position of the label.
-    direction : (3,) array_like, optional, default: (0, 0, 1)
-        The direction of the label. If None, label will follow the camera.
     scale : (3,) array_like
         Changes the size of the label.
     color : (3,) array_like
         Label color as ``(r,g,b)`` tuple.
+    direction : (3,) array_like, optional, default: (0, 0, 1)
+        The direction of the label. If None, label will follow the camera.
     align_center : bool, default: True
         If `True`, the anchor of the actor will be the center of the text.
         If `False`, the anchor will be at the left bottom of the text.
-    extrusion: float, default: 0
-        Extrusion length of the text gives it a 3D look.
 
     Returns
     -------
@@ -2427,7 +2424,7 @@ def vector_text(text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.1),
     atext.SetText(text)
     textm = PolyDataMapper()
 
-    extrude = vtkLinearExtrusionFilter()
+    extrude = LinearExtrusionFilter()
     extrude.SetInputConnection(atext.GetOutputPort())
     extrude.SetExtrusionTypeToNormalExtrusion()
     extrude.SetVector(0, 0, scale[2])

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -2387,7 +2387,7 @@ def billboard(centers, colors=(0, 1, 0), scales=1, vs_dec=None, vs_impl=None,
 
 def vector_text(text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.2),
                 color=(1, 1, 1), direction=(0, 0, 1), align_center=False,
-                extrusion=8.0):
+                extrusion=0.0):
     """Create a label actor.
 
     This actor will always face the camera
@@ -2407,7 +2407,7 @@ def vector_text(text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.2),
     align_center : bool, default: True
         If `True`, the anchor of the actor will be the center of the text.
         If `False`, the anchor will be at the left bottom of the text.
-    extrusion: float
+    extrusion: float, default: 0
         Extrusion length of the text gives it a 3D look.
 
     Returns

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -2402,7 +2402,7 @@ def vector_text(text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.0),
         Label color as ``(r,g,b)`` tuple.
     direction : (3,) array_like, optional, default: (0, 0, 1)
         The direction of the label. If None, label will follow the camera.
-    align_center : bool, default: True
+    align_center : bool, optional, default: True
         If `True`, the anchor of the actor will be the center of the text.
         If `False`, the anchor will be at the left bottom of the text.
 

--- a/fury/lib.py
+++ b/fury/lib.py
@@ -136,6 +136,7 @@ RenderLargeImage = fhvtk.vtkRenderLargeImage
 LoopSubdivisionFilter = fmvtk.vtkLoopSubdivisionFilter
 ButterflySubdivisionFilter = fmvtk.vtkButterflySubdivisionFilter
 OutlineFilter = fmvtk.vtkOutlineFilter
+LinearExtrusionFilter = fmvtk.vtkLinearExtrusionFilter
 
 ##############################################################
 #  vtkFiltersTexture Module

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -828,16 +828,16 @@ def test_points(interactive=False):
     npt.assert_equal(report.objects, 3)
 
 
-def test_labels(interactive=False):
+def test_labels(interactive=1):
     npt.assert_warns(DeprecationWarning, actor.label, "FURY Rocks")
-    text_actor = actor.vector_text("FURY Rocks", direction=None)
+    text_actor = actor.vector_text("FURY Rocks")
 
     scene = window.Scene()
     scene.add(text_actor)
     scene.reset_camera()
     scene.reset_clipping_range()
 
-    assert text_actor.GetCamera() is scene.GetActiveCamera()
+    # assert text_actor.GetCamera() is scene.GetActiveCamera()
 
     if interactive:
         window.show(scene, reset_camera=False)

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -828,16 +828,16 @@ def test_points(interactive=False):
     npt.assert_equal(report.objects, 3)
 
 
-def test_labels(interactive=1):
+def test_labels(interactive=False):
     npt.assert_warns(DeprecationWarning, actor.label, "FURY Rocks")
-    text_actor = actor.vector_text("FURY Rocks")
+    text_actor = actor.vector_text("FURY Rocks", direction=None)
 
     scene = window.Scene()
     scene.add(text_actor)
     scene.reset_camera()
     scene.reset_clipping_range()
 
-    # assert text_actor.GetCamera() is scene.GetActiveCamera()
+    assert text_actor.GetCamera() is scene.GetActiveCamera()
 
     if interactive:
         window.show(scene, reset_camera=False)

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -863,16 +863,23 @@ def test_labels(interactive=False):
     center_3 = text_centered.GetCenter()
     npt.assert_almost_equal(np.linalg.norm(center_3), 0.0)
 
-    text_extruded = actor.vector_text("FURY Rocks", scale=(0.2, 0.2, 1.123))
+    text_extruded = actor.vector_text("FURY Rocks", scale=(0.2, 0.2, 0.2),
+                                      extrusion=1.123)
     z_max = text_extruded.GetBounds()[-1]
     npt.assert_almost_equal(z_max, 1.123)
 
     text_extruded_centered = actor.vector_text("FURY Rocks",
-                                               scale=(0.2, 0.2, 1.123),
-                                               align_center=True)
+                                               scale=(0.2, 0.2, 0.2),
+                                               direction=None,
+                                               align_center=True, extrusion=23)
+
     z_min, z_max = text_extruded_centered.GetBounds()[4:]
-    npt.assert_almost_equal(z_max - z_min, 1.123)
+    npt.assert_almost_equal(z_max - z_min, 23)
     npt.assert_almost_equal(z_max, - z_min)
+    # if following the camera, it should rotate around the center to prevent
+    # weirdness of the geometry.
+    center = np.array(text_actor_centered.GetCenter())
+    npt.assert_equal(center, np.zeros(3))
 
 
 def test_spheres(interactive=False):

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -857,10 +857,22 @@ def test_labels(interactive=False):
     center_2 = text_actor_rot_2.GetCenter()
     assert_not_equal(np.linalg.norm(center_1), np.linalg.norm(center_2))
 
-    text_rot_centered = actor.vector_text("FURY Rocks", align_center=True,
-                                          direction=(1, 1, 1))
-    center_3 = text_rot_centered.GetCenter()
+    # test centered
+    text_centered = actor.vector_text("FURY Rocks", align_center=True)
+
+    center_3 = text_centered.GetCenter()
     npt.assert_almost_equal(np.linalg.norm(center_3), 0.0)
+
+    text_extruded = actor.vector_text("FURY Rocks", scale=(0.2, 0.2, 1.123))
+    z_max = text_extruded.GetBounds()[-1]
+    npt.assert_almost_equal(z_max, 1.123)
+
+    text_extruded_centered = actor.vector_text("FURY Rocks",
+                                               scale=(0.2, 0.2, 1.123),
+                                               align_center=True)
+    z_min, z_max = text_extruded_centered.GetBounds()[4:]
+    npt.assert_almost_equal(z_max - z_min, 1.123)
+    npt.assert_almost_equal(z_max, - z_min)
 
 
 def test_spheres(interactive=False):

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -12,7 +12,8 @@ from fury import actor, window, primitive as fp
 from fury.actor import grid
 from fury.decorators import skip_osx, skip_win
 from fury.utils import shallow_copy, rotate, primitives_count_from_actor
-from fury.testing import assert_greater, assert_greater_equal
+from fury.testing import assert_greater, assert_greater_equal, \
+    assert_less_equal, assert_not_equal, assert_equal
 from fury.primitive import prim_sphere
 
 # Allow import, but disable doctests if we don't have dipy
@@ -829,17 +830,37 @@ def test_points(interactive=False):
 
 def test_labels(interactive=False):
     npt.assert_warns(DeprecationWarning, actor.label, "FURY Rocks")
-    text_actor = actor.vector_text("FURY Rocks")
+    text_actor = actor.vector_text("FURY Rocks", direction=None)
 
     scene = window.Scene()
     scene.add(text_actor)
     scene.reset_camera()
     scene.reset_clipping_range()
 
+    assert text_actor.GetCamera() is scene.GetActiveCamera()
+
     if interactive:
         window.show(scene, reset_camera=False)
 
+    text_actor = actor.vector_text("FURY Rocks")
     npt.assert_equal(scene.GetActors().GetNumberOfItems(), 1)
+    center = np.array(text_actor.GetCenter())
+    [assert_greater_equal(v, 0) for v in center]
+
+    text_actor_centered = actor.vector_text("FURY Rocks", align_center=True)
+    center = np.array(text_actor_centered.GetCenter())
+    npt.assert_equal(center, np.zeros(3))
+
+    text_actor_rot_1 = actor.vector_text("FURY Rocks", direction=(1, 1, 1))
+    text_actor_rot_2 = actor.vector_text("FURY Rocks", direction=(1, 1, 0))
+    center_1 = text_actor_rot_1.GetCenter()
+    center_2 = text_actor_rot_2.GetCenter()
+    assert_not_equal(np.linalg.norm(center_1), np.linalg.norm(center_2))
+
+    text_rot_centered = actor.vector_text("FURY Rocks", align_center=True,
+                                          direction=(1, 1, 1))
+    center_3 = text_rot_centered.GetCenter()
+    npt.assert_almost_equal(np.linalg.norm(center_3), 0.0)
 
 
 def test_spheres(interactive=False):


### PR DESCRIPTION
There is an issue with `vector_text` which was not following the camera because no camera was assigned for it to follow.
Not sure if this is intended for the vector text to follow the camera or should it also have a direction as well if user wants.
Below is a comparison
![image](https://user-images.githubusercontent.com/63170874/184692018-e1c035ea-1a3b-44ee-8123-28a8e5a2f50f.png)
![image](https://user-images.githubusercontent.com/63170874/184692099-faac3c3a-8dea-4cc0-9227-9eea7e100ad9.png)
