### PR TITLE
DrawPanel Update: Repositioning the `mode_panel` and `mode_text`

### DIFF
--- a/docs/tutorials/02_ui/viz_drawpanel.py
+++ b/docs/tutorials/02_ui/viz_drawpanel.py
@@ -19,7 +19,7 @@ fetch_viz_new_icons()
 #########################################################################
 # We then create a DrawPanel Object.
 
-drawing_canvas = ui.DrawPanel(size=(550, 550), position=(25, 25))
+drawing_canvas = ui.DrawPanel(size=(560, 560), position=(40, 10))
 
 ###############################################################################
 # Show Manager
@@ -27,7 +27,7 @@ drawing_canvas = ui.DrawPanel(size=(550, 550), position=(25, 25))
 #
 # Now we add DrawPanel to the scene.
 
-current_size = (600, 600)
+current_size = (650, 650)
 showm = window.ShowManager(size=current_size, title="DrawPanel UI Example")
 
 showm.scene.add(drawing_canvas)

--- a/fury/ui/elements.py
+++ b/fury/ui/elements.py
@@ -3429,10 +3429,10 @@ class DrawPanel(UI):
             self.mode_panel.add_element(btn, btn_pos+padding)
             btn_pos[0] += btn.size[0]+padding
 
-        self.canvas.add_element(self.mode_panel, (0, 0))
+        self.canvas.add_element(self.mode_panel, (0, -mode_panel_size[1]))
 
         self.mode_text = TextBlock2D(text="Select appropriate drawing mode using below icon")
-        self.canvas.add_element(self.mode_text, (0.0, 0.95))
+        self.canvas.add_element(self.mode_text, (0.0, 1.0))
 
     def _get_actors(self):
         """Get the actors composing this UI component."""
@@ -3460,7 +3460,7 @@ class DrawPanel(UI):
         coords: (float, float)
             Absolute pixel coordinates (x, y).
         """
-        self.canvas.position = coords
+        self.canvas.position = coords + [0, self.mode_panel.size[1]]
 
     def resize(self, size):
         """Resize the UI.


### PR DESCRIPTION
Whenever we create, translate, or rotate the shapes on the panel it sometimes overlaps the `mode_panel` or `mode_text` which are used to select and show the current mode respectively.
eg. 
![python_jHAyyCrRD2](https://user-images.githubusercontent.com/64432063/188268649-65ea24f0-3f46-4545-8e52-e07513a94b9f.gif)

Repositioning the `mode_panel` and the `mode_text` to be outside the panel to solve the overlapping issue.
eg.
![python_OZovev32PG](https://user-images.githubusercontent.com/64432063/188268804-949ec656-7da3-4310-ba8b-7e4f0281faa1.gif)

