### PR TITLE
DrawPanel Update: Moving repetitive functions to helpers

### DIFF
--- a/fury/ui/elements.py
+++ b/fury/ui/elements.py
@@ -17,7 +17,7 @@ from fury.data import read_viz_icons
 from fury.lib import PolyDataMapper2D
 from fury.ui.core import UI, Rectangle2D, TextBlock2D, Disk2D
 from fury.ui.containers import Panel2D
-from fury.ui.helpers import TWO_PI, clip_overflow, cal_2d_bounding_box
+from fury.ui.helpers import TWO_PI, clip_overflow, cal_bounding_box_2d
 from fury.ui.core import Button2D
 from fury.utils import (set_polydata_vertices, vertices_from_actor,
                         update_actor)
@@ -3256,7 +3256,7 @@ class DrawShape(UI):
         vertices = self.position + vertices_from_actor(self.shape.actor)[:, :-1]
 
         self._bounding_box_min, self._bounding_box_max, \
-            self._bounding_box_size = cal_2d_bounding_box(vertices)
+            self._bounding_box_size = cal_bounding_box_2d(vertices)
 
         self._bounding_box_offset = self.position - self._bounding_box_min
 

--- a/fury/ui/elements.py
+++ b/fury/ui/elements.py
@@ -3255,8 +3255,8 @@ class DrawShape(UI):
         """
         vertices = self.position + vertices_from_actor(self.shape.actor)[:, :-1]
 
-        self._bounding_box_min, self._bounding_box_max, self._bounding_box_size = cal_2d_bounding_box(
-            vertices)
+        self._bounding_box_min, self._bounding_box_max, \
+            self._bounding_box_size = cal_2d_bounding_box(vertices)
 
         self._bounding_box_offset = self.position - self._bounding_box_min
 

--- a/fury/ui/elements.py
+++ b/fury/ui/elements.py
@@ -17,7 +17,7 @@ from fury.data import read_viz_icons
 from fury.lib import PolyDataMapper2D
 from fury.ui.core import UI, Rectangle2D, TextBlock2D, Disk2D
 from fury.ui.containers import Panel2D
-from fury.ui.helpers import TWO_PI, clip_overflow
+from fury.ui.helpers import TWO_PI, clip_overflow, cal_2d_bounding_box
 from fury.ui.core import Button2D
 from fury.utils import (set_polydata_vertices, vertices_from_actor,
                         update_actor)
@@ -3250,35 +3250,15 @@ class DrawShape(UI):
         self.rotation_slider.center = slider_position
         self.rotation_slider.set_visibility(True)
 
-    def cal_bounding_box(self, position=None):
+    def cal_bounding_box(self):
         """Calculate the min, max position and the size of the bounding box.
-
-        Parameters
-        ----------
-        position : (float, float)
-            (x, y) in pixels.
         """
-        position = self.position if position is None else position
-        vertices = position + vertices_from_actor(self.shape.actor)[:, :-1]
+        vertices = self.position + vertices_from_actor(self.shape.actor)[:, :-1]
 
-        min_x, min_y = vertices[0]
-        max_x, max_y = vertices[0]
+        self._bounding_box_min, self._bounding_box_max, self._bounding_box_size = cal_2d_bounding_box(
+            vertices)
 
-        for x, y in vertices:
-            if x < min_x:
-                min_x = x
-            if y < min_y:
-                min_y = y
-            if x > max_x:
-                max_x = x
-            if y > max_y:
-                max_y = y
-
-        self._bounding_box_min = np.asarray([min_x, min_y], dtype="int")
-        self._bounding_box_max = np.asarray([max_x, max_y], dtype="int")
-        self._bounding_box_size = np.asarray([max_x-min_x, max_y-min_y], dtype="int")
-
-        self._bounding_box_offset = position - self._bounding_box_min
+        self._bounding_box_offset = self.position - self._bounding_box_min
 
     def clamp_position(self, center=None):
         """Clamp the given center according to the DrawPanel canvas.

--- a/fury/ui/helpers.py
+++ b/fury/ui/helpers.py
@@ -123,3 +123,38 @@ def check_overflow(textblock, width, overflow_postfix='',
             if side == 'left':
                 textblock.message = textblock.message[::-1]
             return mid_ptr
+
+
+def cal_2d_bounding_box(vertices):
+    """Calculate the min, max position and the size of the bounding box.
+
+    Parameters
+    ----------
+    vertices : ndarray
+        vertices of the actors.
+    """
+
+    if vertices.ndim != 2 and vertices.shape[1] not in [2, 3]:
+        raise IOError("vertices should be a 2D array with shape (n,2) or (n,3).")
+
+    if vertices.shape[1] == 3:
+        vertices = vertices[:, :-1]
+
+    min_x, min_y = vertices[0]
+    max_x, max_y = vertices[0]
+
+    for x, y in vertices:
+        if x < min_x:
+            min_x = x
+        if y < min_y:
+            min_y = y
+        if x > max_x:
+            max_x = x
+        if y > max_y:
+            max_y = y
+
+    bounding_box_min = np.asarray([min_x, min_y], dtype="int")
+    bounding_box_max = np.asarray([max_x, max_y], dtype="int")
+    bounding_box_size = np.asarray([max_x-min_x, max_y-min_y], dtype="int")
+
+    return bounding_box_min, bounding_box_max, bounding_box_size

--- a/fury/ui/helpers.py
+++ b/fury/ui/helpers.py
@@ -125,7 +125,7 @@ def check_overflow(textblock, width, overflow_postfix='',
             return mid_ptr
 
 
-def cal_2d_bounding_box(vertices):
+def cal_bounding_box_2d(vertices):
     """Calculate the min, max position and the size of the bounding box.
 
     Parameters

--- a/fury/ui/tests/test_helpers.py
+++ b/fury/ui/tests/test_helpers.py
@@ -1,8 +1,10 @@
 """Test helpers fonction ."""
+import numpy as np
 import numpy.testing as npt
 
 from fury import window, ui
-from fury.ui.helpers import clip_overflow, wrap_overflow, check_overflow
+from fury.ui.helpers import (clip_overflow, wrap_overflow, check_overflow,
+                             cal_bounding_box_2d)
 
 
 def test_clip_overflow():
@@ -89,3 +91,25 @@ def test_check_overflow():
 
     npt.assert_equal(10, overflow_idx)
     npt.assert_equal('A very ver~', text.message)
+
+
+def test_cal_bounding_box_2d():
+    vertices = np.array([[2, 2], [2, 8], [9, 3], [7, 1]])
+    bb_min, bb_max, bb_size = cal_bounding_box_2d(vertices)
+
+    npt.assert_equal([2, 1], bb_min)
+    npt.assert_equal([9, 8], bb_max)
+    npt.assert_equal([7, 7], bb_size)
+
+    vertices = np.array([[1.76, 1.11], [1.82, 1.81], [0.85, 1.94],
+                         [8.87, 9.57], [5.96, 5.51], [1.18, 6.79],
+                         [8.21, -6.67], [3.38, -1.06], [1.31, 9.61]])
+    bb_min, bb_max, bb_size = cal_bounding_box_2d(vertices)
+
+    npt.assert_equal([0, -6], bb_min)
+    npt.assert_equal([8, 9], bb_max)
+    npt.assert_equal([8, 16], bb_size)
+
+    with npt.assert_raises(IOError):
+        vertices = np.array([[[0, 0]], [[0, 0]]])
+        bb_min, bb_max, bb_size = cal_bounding_box_2d(vertices)


### PR DESCRIPTION
Some code from the `DrawShape` UI is going to be reused in the Grouping Shape Feature #653 .
So to avoid these repetitive codes, moving them into `helper.py` file.

- [x] cal_bounding_box
- [ ] rotate