### PR TITLE
DrawPanel Update: Moving rotation_slider from `DrawShape` to `DrawPanel`

### DIFF
--- a/fury/ui/elements.py
+++ b/fury/ui/elements.py
@@ -3273,7 +3273,7 @@ class DrawShape(UI):
         self.shape_type = shape_type.lower()
         self.drawpanel = drawpanel
         self.max_size = None
-        self.is_selected = True
+        self.rotation = 0
         super(DrawShape, self).__init__(position)
         self.shape.color = np.random.random(3)
 
@@ -3295,29 +3295,6 @@ class DrawShape(UI):
         self.shape.on_left_mouse_button_dragged = self.left_button_dragged
         self.shape.on_left_mouse_button_released = self.left_button_released
 
-        self.rotation_slider = RingSlider2D(
-            initial_value=0, text_template='{angle:5.1f}°'
-        )
-        self.rotation_slider.set_visibility(False)
-
-        if self.drawpanel:
-            slider_position = self.drawpanel.canvas.position + [
-                self.drawpanel.canvas.size[0] - self.rotation_slider.size[0] / 2,
-                self.rotation_slider.size[1] / 2,
-            ]
-            self.rotation_slider.center = slider_position
-
-        def rotate_shape(slider):
-            angle = slider.value
-            previous_angle = slider.previous_value
-            rotation_angle = angle - previous_angle
-
-            current_center = self.center
-            self.rotate(np.deg2rad(rotation_angle))
-            self.update_shape_position(current_center - self.drawpanel.canvas.position)
-
-        self.rotation_slider.on_change = rotate_shape
-
     def _get_actors(self):
         """Get the actors composing this UI component."""
         return self.shape
@@ -3332,7 +3309,6 @@ class DrawShape(UI):
         """
         self._scene = scene
         self.shape.add_to_scene(scene)
-        self.rotation_slider.add_to_scene(scene)
 
     def _get_size(self):
         return self.shape.size
@@ -3393,8 +3369,10 @@ class DrawShape(UI):
         self.selection_change()
 
     def selection_change(self):
-        if not self.is_selected:
-            self.rotation_slider.set_visibility(False)
+        if self.is_selected:
+            self.drawpanel.rotation_slider.value = self.rotation
+        else:
+            self.drawpanel.rotation_slider.set_visibility(False)
 
     def rotate(self, angle):
         """Rotate the vertices of the UI component using specific angle.
@@ -3412,12 +3390,6 @@ class DrawShape(UI):
         update_actor(self.shape.actor)
 
         self.cal_bounding_box()
-
-    def show_rotation_slider(self):
-        """Display the RingSlider2D to allow rotation of shape from the center."""
-        self._scene.rm(*self.rotation_slider.actors)
-        self.rotation_slider.add_to_scene(self._scene)
-        self.rotation_slider.set_visibility(True)
 
     def cal_bounding_box(self):
         """Calculate the min, max position and the size of the bounding box."""
@@ -3473,7 +3445,7 @@ class DrawShape(UI):
     def remove(self):
         """Remove the Shape and all related actors."""
         self._scene.rm(self.shape.actor)
-        self._scene.rm(*self.rotation_slider.actors)
+        self.drawpanel.rotation_slider.set_visibility(False)
 
     def left_button_pressed(self, i_ren, _obj, shape):
         mode = self.drawpanel.current_mode
@@ -3482,7 +3454,7 @@ class DrawShape(UI):
 
             click_pos = np.array(i_ren.event.position)
             self._drag_offset = click_pos - self.center
-            self.show_rotation_slider()
+            self.drawpanel.show_rotation_slider()
             i_ren.event.abort()
         elif mode == 'delete':
             self.remove()
@@ -3491,8 +3463,8 @@ class DrawShape(UI):
         i_ren.force_render()
 
     def left_button_dragged(self, i_ren, _obj, shape):
-        if self.drawpanel.current_mode == 'selection':
-            self.rotation_slider.set_visibility(False)
+        if self.drawpanel.current_mode == "selection":
+            self.drawpanel.rotation_slider.set_visibility(False)
             if self._drag_offset is not None:
                 click_position = i_ren.event.position
                 relative_center_position = (
@@ -3504,8 +3476,8 @@ class DrawShape(UI):
             self.drawpanel.left_button_dragged(i_ren, _obj, self.drawpanel)
 
     def left_button_released(self, i_ren, _obj, shape):
-        if self.drawpanel.current_mode == 'selection':
-            self.show_rotation_slider()
+        if self.drawpanel.current_mode == "selection":
+            self.drawpanel.show_rotation_slider()
             i_ren.force_render()
 
 
@@ -3586,6 +3558,23 @@ class DrawPanel(UI):
         )
         self.canvas.add_element(self.mode_text, (0.0, 1.0))
 
+        self.rotation_slider = RingSlider2D(initial_value=0,
+                                            text_template="{angle:5.1f}°")
+        self.rotation_slider.set_visibility(False)
+
+        def rotate_shape(slider):
+            angle = slider.value
+            previous_angle = slider.previous_value
+            rotation_angle = angle - previous_angle
+
+            current_center = self.current_shape.center
+            self.current_shape.rotate(np.deg2rad(rotation_angle))
+            self.current_shape.rotation = slider.value
+            self.current_shape.update_shape_position(
+                current_center - self.canvas.position)
+
+        self.rotation_slider.on_moving_slider = rotate_shape
+
     def _get_actors(self):
         """Get the actors composing this UI component."""
         return self.canvas.actors
@@ -3598,7 +3587,7 @@ class DrawPanel(UI):
         scene : scene
 
         """
-        self.current_scene = scene
+        self._scene = scene
         self.canvas.add_to_scene(scene)
 
     def _get_size(self):
@@ -3613,6 +3602,10 @@ class DrawPanel(UI):
             Absolute pixel coordinates (x, y).
         """
         self.canvas.position = coords + [0, self.mode_panel.size[1]]
+        slider_position = self.canvas.position + \
+            [self.canvas.size[0] - self.rotation_slider.size[0]/2,
+                self.rotation_slider.size[1]/2]
+        self.rotation_slider.center = slider_position
 
     def resize(self, size):
         """Resize the UI."""
@@ -3666,9 +3659,9 @@ class DrawPanel(UI):
         if shape_type == 'circle':
             shape.max_size = self.cal_min_boundary_distance(current_position)
         self.shape_list.append(shape)
-        self.update_shape_selection(shape)
-        self.current_scene.add(shape)
+        self._scene.add(shape)
         self.canvas.add_element(shape, current_position - self.canvas.position)
+        self.update_shape_selection(shape)
 
     def resize_shape(self, current_position):
         """Resize the shape.
@@ -3688,6 +3681,13 @@ class DrawPanel(UI):
                 shape.is_selected = True
             else:
                 shape.is_selected = False
+
+    def show_rotation_slider(self):
+        """Display the  RingSlider2D to allow rotation of shape from the center.
+        """
+        self._scene.rm(*self.rotation_slider.actors)
+        self.rotation_slider.add_to_scene(self._scene)
+        self.rotation_slider.set_visibility(True)
 
     def update_button_icons(self, current_mode):
         """Update the button icon.


### PR DESCRIPTION
Currently, each `DrawShape` has its own individual rotation_slider which rotates the shape from the center.
This increases the dependency of `DrawShape` on `DrawPanel` which we don't want.
So moving the rotation_slider to `DrawPanel`, to keep a single rotation slider and avoid excessive memory usage.