### PR TITLE
Add Timelines to ShowManager directly

### DIFF
--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -625,7 +625,6 @@ def test_add_timeline_to_show_manager():
     assert_true(cube in actors)
 
 
-
 # test_opengl_state_add_remove_and_check()
 # test_opengl_state_simple()
 # test_record()

--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -5,8 +5,10 @@ import numpy.testing as npt
 import pytest
 import itertools
 from fury import actor, window, io
+from fury.animation.timeline import Timeline
 from fury.lib import ImageData, Texture, numpy_support
-from fury.testing import captured_output, assert_less_equal, assert_greater
+from fury.testing import captured_output, assert_less_equal, assert_greater, \
+    assert_true
 from fury.decorators import skip_osx, skip_win, skip_linux
 from fury import shaders
 from fury.utils import remove_observer_from_actor
@@ -604,6 +606,25 @@ def test_frame_rate():
     assert_greater(actual_fps, 0)
     assert_greater(ideal_fps, 0)
     assert_greater(ideal_fps, actual_fps)
+
+
+def test_add_timeline_to_show_manager():
+    showm = window.ShowManager()
+    showm.initialize()
+
+    cube = actor.cube(np.array([[2, 2, 3]]))
+
+    timeline = Timeline(playback_panel=True)
+    timeline.add(cube)
+    showm.add_timeline(timeline)
+
+    npt.assert_equal(len(showm._timelines), 1)
+    assert_true(showm._timeline_cbk is not None)
+
+    actors = showm.scene.GetActors()
+    assert_true(cube in actors)
+
+
 
 # test_opengl_state_add_remove_and_check()
 # test_opengl_state_simple()

--- a/fury/window.py
+++ b/fury/window.py
@@ -9,6 +9,7 @@ import numpy as np
 from scipy import ndimage
 
 from fury import __version__ as fury_version
+from fury.animation.timeline import Timeline
 from fury.decorators import is_osx
 from fury.interactor import CustomInteractorStyle
 from fury.io import load_image, save_image
@@ -365,7 +366,6 @@ class ShowManager(object):
         self.timers = []
         self._fps = 0
         self._last_render_time = 0
-
         if self.reset_camera:
             self.scene.ResetCamera()
 
@@ -399,10 +399,36 @@ class ShowManager(object):
         self.style.SetInteractor(self.iren)
         self.iren.SetInteractorStyle(self.style)
         self.iren.SetRenderWindow(self.window)
+        self._timelines = []
+        self._timeline_cbk = None
 
     def initialize(self):
         """Initialize interaction."""
         self.iren.Initialize()
+
+    def add_timeline(self, timeline: Timeline):
+        """Add Timeline to the ShowManager.
+        Adding the Timeline to the ShowManager ensures that it gets added to
+        the scene, gets updated and rendered without any extra code.
+
+        Parameters
+        ----------
+        timeline : Timeline
+            The Timeline to be added to the ShowManager.
+        """
+
+        self.scene.add(timeline)
+        if timeline in self._timelines:
+            return
+        self._timelines.append(timeline)
+
+        if self._timeline_cbk is not None:
+            return
+
+        def animation_cbk(_obj, _event):
+            [tl.update_animation() for tl in self._timelines]
+            self.render()
+        self._timeline_cbk = self.add_timer_callback(True, 10, animation_cbk)
 
     def render(self):
         """Render only once."""


### PR DESCRIPTION
This PR is intended to make doing animations easier using Timeline.
Now, instead of adding the `Timeline` to the scene, it can be added to the Show manager.
Benefits of adding the TImeline/s to the show manager instead of the scene is that user will not be required to update the timeline and render the scene using a time callback function.