### PR TITLE
fix: double render call with timeline obj causes a seg fault

### DIFF
--- a/fury/tests/test_gltf.py
+++ b/fury/tests/test_gltf.py
@@ -309,7 +309,6 @@ def test_morphing():
 
     timeline_1.seek(1.50)
     gltf_obj.update_morph(timeline_1)
-    showm.render()
     showm.save_screenshot('keyframe2.png')
     res_2 = window.analyze_snapshot('keyframe2.png')
 


### PR DESCRIPTION
This closes #705