### PR TITLE
Commented the self.initialize

### DIFF
--- a/fury/window.py
+++ b/fury/window.py
@@ -392,8 +392,8 @@ class ShowManager(object):
         self.iren.SetInteractorStyle(self.style)
         self.iren.SetRenderWindow(self.window)
 
-        if is_win:
-            self.initialize()
+        # if is_win:
+        #     self.initialize()
 
     def initialize(self):
         """Initialize interaction."""


### PR DESCRIPTION
When I upgraded FURY in Furious Atoms [(https://furiousatoms.com),](https://furiousatoms.com) I noticed a second window appears and the loaded file is shown in the second window as you see here:

![demo](https://user-images.githubusercontent.com/32108826/202525583-c666e45c-ea06-43e5-8d22-c810a4968cef.gif)

The issue is in `ShowManager`. I commented the lines 395 and 396 in `window.py` and now it works perfectly:

![demo2](https://user-images.githubusercontent.com/32108826/202526877-64f93e70-7fe0-4045-86ea-137452f864c2.gif)
