### PR TITLE
[WIP] Implementation of PBR in glTF

### DIFF
--- a/docs/tutorials/01_introductory/viz_gltf_pbr.py
+++ b/docs/tutorials/01_introductory/viz_gltf_pbr.py
@@ -1,0 +1,41 @@
+from fury import window, material, utils
+from fury.gltf import glTF
+from fury.io import load_cubemap_texture, load_image
+from fury.data import fetch_gltf, read_viz_gltf, read_viz_cubemap
+from fury.lib import Texture, ImageFlip
+
+# rgb_array = load_image(
+#     '/home/shivam/Downloads/skybox.jpg')
+
+# grid = utils.rgb_to_vtk(rgb_array)
+# cubemap = Texture()
+# flip = ImageFlip()
+# flip.SetInputDataObject(grid)
+# flip.SetFilteredAxis(1)
+# cubemap.InterpolateOn()
+# cubemap.MipmapOn()
+# cubemap.SetInputConnection(0, flip.GetOutputPort(0))
+# cubemap.UseSRGBColorSpaceOn()
+
+scene = window.Scene(skybox=None)
+# scene.SetBackground(0.5, 0.3, 0.3)
+
+fetch_gltf('DamagedHelmet')
+filename = read_viz_gltf('DamagedHelmet')
+
+gltf_obj = glTF(filename, apply_normals=True)
+actors = gltf_obj.actors()
+
+scene.add(*actors)
+scene.UseImageBasedLightingOn()
+
+cameras = gltf_obj.cameras
+if cameras:
+    scene.SetActiveCamera(cameras[0])
+
+interactive = True
+
+if interactive:
+    window.show(scene, size=(1280, 720))
+
+window.record(scene, out_path='viz_gltf.png', size=(1280, 720))

--- a/fury/gltf.py
+++ b/fury/gltf.py
@@ -4,14 +4,16 @@ import os
 import numpy as np
 import copy
 import pygltflib as gltflib
-from pygltflib.utils import glb2gltf, gltf2glb
 from PIL import Image
-from fury.lib import Texture, Camera, numpy_support, Transform, Matrix4x4, PolyDataTangents
-from fury import transform, utils, io, actor, material
+from pygltflib.utils import glb2gltf, gltf2glb
+
+from fury import actor, io, transform, utils, material
 from fury.animation import Animation
-from fury.animation.interpolator import (linear_interpolator, slerp,
+from fury.animation.interpolator import (linear_interpolator,
+                                         slerp,
                                          step_interpolator,
                                          tan_cubic_spline_interpolator)
+from fury.lib import Camera, Matrix4x4, Texture, Transform, numpy_support, PolyDataTangents
 
 comp_type = {
     5120: {'size': 1, 'dtype': np.byte},

--- a/fury/lib.py
+++ b/fury/lib.py
@@ -121,6 +121,7 @@ PolyDataNormals = fcvtk.vtkPolyDataNormals
 ContourFilter = fcvtk.vtkContourFilter
 TubeFilter = fcvtk.vtkTubeFilter
 Glyph3D = fcvtk.vtkGlyph3D
+PolyDataTangents = fcvtk.vtkPolyDataTangents
 
 ##############################################################
 #  vtkFiltersGeneral Module

--- a/fury/lib.py
+++ b/fury/lib.py
@@ -121,6 +121,7 @@ PolyDataNormals = fcvtk.vtkPolyDataNormals
 ContourFilter = fcvtk.vtkContourFilter
 TubeFilter = fcvtk.vtkTubeFilter
 Glyph3D = fcvtk.vtkGlyph3D
+TriangleFilter = fcvtk.vtkTriangleFilter
 PolyDataTangents = fcvtk.vtkPolyDataTangents
 
 ##############################################################


### PR DESCRIPTION
This PR needs a lot of cleaning and still in progress. As of now this PR adds ORM, Normal & Emissive materials. Most of the glTF models has been modified to use the ORM material, however few of them still use `MetallicRoughness`  and  `AmbientOcclusion` materials separately (for e.g. DamagedHelmet & Avocado).
Few model may have `RoughnessMetallic` instead of `MetallicRoughness` which changes switches the channels (For e.g. the `Avocado` model), as mentioned in this [comment](https://github.com/KhronosGroup/glTF/issues/857#issuecomment-285746166). This PR currently **does not** support the RoughnessMetallic.

Preview with the `DamagedHelmet` (has all three of materials) model:
![image](https://user-images.githubusercontent.com/74976752/206835882-eeaf3d0a-5674-4ce9-ba65-7178dc688115.png)

Sample of the `Avocado` model (without switching the channels in `RoughnessMetallic` to `MetallicRoughness`) ( _Left_) 
After switching channels  (_Right_):


<div align="center">
 
  <img src="https://user-images.githubusercontent.com/74976752/206836099-5aba473b-ad89-41ef-8550-ce9ea5a85aea.png" width="40%" >
  <img src="https://user-images.githubusercontent.com/74976752/206836137-3c29499b-71ed-4ac6-9d61-0af684db61b6.png" width="40%">
 
</div>
