### PR TITLE
fix image load flip issue

### DIFF
--- a/fury/io.py
+++ b/fury/io.py
@@ -105,7 +105,6 @@ def load_image(filename, as_vtktype=False, use_pillow=True):
                     raise RuntimeError('Unknown image mode {}'
                                        .format(pil_image.mode))
                 image = np.asarray(pil_image)
-            image = np.flipud(image)
 
         if as_vtktype:
             if image.ndim not in [2, 3]:


### PR DESCRIPTION
This PR aims to fix the image loading (Flip) issue.

The possibility is that the underlying pillow must have changed something in the newer versions. That will now not require flipping the NumPy array.