### PR TITLE
Fix flipped images in load, save, and snapshot

### DIFF
--- a/fury/gltf.py
+++ b/fury/gltf.py
@@ -445,7 +445,7 @@ class glTF:
             image_path = os.path.join(self.pwd, file)
 
         rgb = io.load_image(image_path)
-        grid = utils.rgb_to_vtk(rgb)
+        grid = utils.rgb_to_vtk(np.flipud(rgb))
         atexture = Texture()
         atexture.InterpolateOn()
         atexture.EdgeClampOn()

--- a/fury/io.py
+++ b/fury/io.py
@@ -232,7 +232,6 @@ def save_image(arr, filename, compression_quality=75,
                       format(filename, extension))
 
     if use_pillow:
-        arr = np.flipud(arr)
         im = Image.fromarray(arr)
         im.save(filename, quality=compression_quality, dpi=dpi)
     else:
@@ -241,6 +240,7 @@ def save_image(arr, filename, compression_quality=75,
             arr = arr[..., None]
 
         shape = arr.shape
+        arr = np.flipud(arr)
         if extension.lower() in ['.png', ]:
             arr = arr.astype(np.uint8)
         arr = arr.reshape((shape[1] * shape[0], shape[2]))

--- a/fury/io.py
+++ b/fury/io.py
@@ -105,7 +105,6 @@ def load_image(filename, as_vtktype=False, use_pillow=True):
                     raise RuntimeError('Unknown image mode {}'
                                        .format(pil_image.mode))
                 image = np.asarray(pil_image)
-            image = np.flipud(image)
 
         if as_vtktype:
             if image.ndim not in [2, 3]:
@@ -122,6 +121,7 @@ def load_image(filename, as_vtktype=False, use_pillow=True):
             vtk_image.SetSpacing(1.0, 1.0, 1.0)
             vtk_image.SetOrigin(0.0, 0.0, 0.0)
 
+            image = np.flipud(image)
             image = image.reshape(image.shape[1] * image.shape[0], depth)
             image = np.ascontiguousarray(image, dtype=image.dtype)
             vtk_array_type = numpy_support.get_vtk_array_type(image.dtype)
@@ -158,6 +158,7 @@ def load_image(filename, as_vtktype=False, use_pillow=True):
 
         components = vtk_array.GetNumberOfComponents()
         image = numpy_support.vtk_to_numpy(vtk_array).reshape(h, w, components)
+        image = np.flipud(image)
 
     if is_url:
         os.remove(filename)

--- a/fury/shaders/tests/test_base.py
+++ b/fury/shaders/tests/test_base.py
@@ -360,11 +360,11 @@ def test_replace_shader_in_actor(interactive=False):
     if interactive:
         window.show(scene)
     ss = window.snapshot(scene, size=(200, 200))
-    actual = ss[40, 140, :]
+    actual = ss[160, 140, :]
     npt.assert_array_equal(actual, [0, 0, 0])
-    actual = ss[140, 40, :]
+    actual = ss[60, 40, :]
     npt.assert_array_equal(actual, [0, 0, 0])
-    actual = ss[40, 40, :]
+    actual = ss[160, 40, :]
     npt.assert_array_equal(actual, [0, 0, 0])
     scene.clear()
     replace_shader_in_actor(test_actor, 'geometry', geometry_code)
@@ -372,11 +372,11 @@ def test_replace_shader_in_actor(interactive=False):
     if interactive:
         window.show(scene)
     ss = window.snapshot(scene, size=(200, 200))
-    actual = ss[40, 140, :]
+    actual = ss[160, 140, :]
     npt.assert_array_equal(actual, [255, 0, 0])
-    actual = ss[140, 40, :]
+    actual = ss[60, 40, :]
     npt.assert_array_equal(actual, [0, 255, 0])
-    actual = ss[40, 40, :]
+    actual = ss[160, 40, :]
     npt.assert_array_equal(actual, [0, 0, 255])
 
 

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -1086,9 +1086,9 @@ def test_text_3d():
     txt_actor.justification('left')
     scene.add(txt_actor)
     arr_left = window.snapshot(scene, size=(1920, 1080), offscreen=True)
-    # X axis of right alignment should have a lower center of mass position
+    # X axis of right alignment should have a higher center of mass position
     # than left
-    assert_greater(center_of_mass(arr_left)[0], center_of_mass(arr_right)[0])
+    assert_greater(center_of_mass(arr_right)[0], center_of_mass(arr_left)[0])
     scene.clear()
     txt_actor.justification('center')
     txt_actor.vertical_justification('top')
@@ -1099,8 +1099,8 @@ def test_text_3d():
     txt_actor.vertical_justification('bottom')
     scene.add(txt_actor)
     arr_bottom = window.snapshot(scene, size=(1920, 1080), offscreen=True)
-    assert_greater_equal(center_of_mass(arr_bottom)[0],
-                         center_of_mass(arr_top)[0])
+    assert_greater_equal(center_of_mass(arr_top)[0],
+                         center_of_mass(arr_bottom)[0])
 
     scene.clear()
     txt_actor.font_style(bold=True, italic=True, shadow=True)

--- a/fury/tests/test_gltf.py
+++ b/fury/tests/test_gltf.py
@@ -93,7 +93,7 @@ def test_orientation():
     scene = window.Scene()
     scene.add(actor)
     # if oriented correctly avg of blues on top half will be greater
-    # than the bottom half (window.snapshot captures oppsite of it)
+    # than the bottom half
     display = window.snapshot(scene)
     res = window.analyze_snapshot(display, bg_color=(0, 0, 0),
                                   colors=[(108, 173, 223), (92, 135, 39)],
@@ -104,7 +104,7 @@ def test_orientation():
     upper = np.mean(upper)
     lower = np.mean(lower)
 
-    assert_greater(lower, upper)
+    assert_greater(upper, lower)
     scene.clear()
 
 

--- a/fury/tests/test_material.py
+++ b/fury/tests/test_material.py
@@ -131,12 +131,12 @@ def test_manifest_standard():
     # scene.reset_camera()
     # window.show(scene)
     ss = window.snapshot(scene, size=(200, 200))
-    actual = ss[75, 100, :] / 1000
+    actual = ss[125, 100, :] / 1000
     desired = np.array([0, 0, 201]) / 1000
     npt.assert_array_almost_equal(actual, desired, decimal=2)
-    actual = ss[125, 75, :] / 1000
+    actual = ss[75, 75, :] / 1000
     npt.assert_array_almost_equal(actual, desired, decimal=2)
-    actual = ss[125, 75, :] / 1000
+    actual = ss[75, 75, :] / 1000
     desired = np.array([0, 0, 85]) / 1000
     # TODO: check if camera affects this assert
     # npt.assert_array_almost_equal(actual, desired, decimal=2)
@@ -144,23 +144,23 @@ def test_manifest_standard():
     # Test ambient level
     material.manifest_standard(test_actor, ambient_level=1)
     ss = window.snapshot(scene, size=(200, 200))
-    actual = ss[75, 100, :] / 1000
+    actual = ss[125, 100, :] / 1000
     desired = np.array([0, 0, 255]) / 1000
     npt.assert_array_almost_equal(actual, desired, decimal=2)
-    actual = ss[125, 125, :] / 1000
+    actual = ss[75, 125, :] / 1000
     npt.assert_array_almost_equal(actual, desired, decimal=2)
-    actual = ss[125, 75, :] / 1000
+    actual = ss[75, 75, :] / 1000
     npt.assert_array_almost_equal(actual, desired, decimal=2)
 
     # Test ambient color
     material.manifest_standard(test_actor, ambient_level=.5,
                                ambient_color=(1, 0, 0))
     ss = window.snapshot(scene, size=(200, 200))
-    actual = ss[75, 100, :] / 1000
+    actual = ss[125, 100, :] / 1000
     npt.assert_array_almost_equal(actual, desired, decimal=2)
-    actual = ss[125, 125, :] / 1000
+    actual = ss[75, 125, :] / 1000
     npt.assert_array_almost_equal(actual, desired, decimal=2)
-    actual = ss[125, 75, :] / 1000
+    actual = ss[75, 75, :] / 1000
     desired = np.array([0, 0, 212]) / 1000
     # TODO: check what affects this
     # npt.assert_array_almost_equal(actual, desired, decimal=2)
@@ -168,13 +168,13 @@ def test_manifest_standard():
     # Test diffuse level
     material.manifest_standard(test_actor, diffuse_level=.75)
     ss = window.snapshot(scene, size=(200, 200))
-    actual = ss[75, 100, :] / 1000
+    actual = ss[125, 100, :] / 1000
     desired = np.array([0, 0, 151]) / 1000
     npt.assert_array_almost_equal(actual, desired, decimal=2)
-    actual = ss[125, 125, :] / 1000
+    actual = ss[75, 125, :] / 1000
     desired = np.array([0, 0, 110]) / 1000
     npt.assert_array_almost_equal(actual, desired, decimal=2)
-    actual = ss[125, 75, :] / 1000
+    actual = ss[75, 75, :] / 1000
     desired = np.array([0, 0, 151]) / 1000
     # TODO: check what affects this
     # npt.assert_array_almost_equal(actual, desired, decimal=2)
@@ -183,24 +183,24 @@ def test_manifest_standard():
     material.manifest_standard(test_actor, diffuse_level=.5,
                                diffuse_color=(1, 0, 0))
     ss = window.snapshot(scene, size=(200, 200))
-    actual = ss[75, 100, :] / 1000
+    actual = ss[125, 100, :] / 1000
     desired = np.array([0, 0, 101]) / 1000
     npt.assert_array_almost_equal(actual, desired, decimal=2)
-    actual = ss[125, 75, :] / 1000
+    actual = ss[75, 75, :] / 1000
     npt.assert_array_almost_equal(actual, desired, decimal=2)
-    actual = ss[125, 125, :] / 1000
+    actual = ss[75, 125, :] / 1000
     desired = np.array([0, 0, 74]) / 1000
     npt.assert_array_almost_equal(actual, desired, decimal=2)
 
     # Test specular level
     material.manifest_standard(test_actor, specular_level=1)
     ss = window.snapshot(scene, size=(200, 200))
-    actual = ss[75, 100, :] / 1000
+    actual = ss[125, 100, :] / 1000
     desired = np.array([201, 201, 255]) / 1000
     npt.assert_array_almost_equal(actual, desired, decimal=2)
-    actual = ss[125, 75, :] / 1000
+    actual = ss[75, 75, :] / 1000
     npt.assert_array_almost_equal(actual, desired, decimal=2)
-    actual = ss[125, 125, :] / 1000
+    actual = ss[75, 125, :] / 1000
     desired = np.array([147, 147, 255]) / 1000
     npt.assert_array_almost_equal(actual, desired, decimal=2)
 
@@ -208,12 +208,12 @@ def test_manifest_standard():
     material.manifest_standard(test_actor, specular_level=1,
                                specular_power=5)
     ss = window.snapshot(scene, size=(200, 200))
-    actual = ss[75, 100, :] / 1000
+    actual = ss[125, 100, :] / 1000
     desired = np.array([78, 78, 255]) / 1000
     npt.assert_array_almost_equal(actual, desired, decimal=2)
-    actual = ss[125, 75, :] / 1000
+    actual = ss[75, 75, :] / 1000
     npt.assert_array_almost_equal(actual, desired, decimal=2)
-    actual = ss[125, 125, :] / 1000
+    actual = ss[75, 125, :] / 1000
     desired = np.array([16, 16, 163]) / 1000
     npt.assert_array_almost_equal(actual, desired, decimal=2)
 
@@ -221,12 +221,12 @@ def test_manifest_standard():
     material.manifest_standard(test_actor, specular_level=1,
                                specular_color=(1, 0, 0), specular_power=5)
     ss = window.snapshot(scene, size=(200, 200))
-    actual = ss[75, 100, :] / 1000
+    actual = ss[125, 100, :] / 1000
     desired = np.array([78, 0, 201]) / 1000
     npt.assert_array_almost_equal(actual, desired, decimal=2)
-    actual = ss[125, 75, :] / 1000
+    actual = ss[75, 75, :] / 1000
     npt.assert_array_almost_equal(actual, desired, decimal=2)
-    actual = ss[125, 125, :] / 1000
+    actual = ss[75, 125, :] / 1000
     desired = np.array([16, 0, 147]) / 1000
     npt.assert_array_almost_equal(actual, desired, decimal=2)
 

--- a/fury/tests/test_transform.py
+++ b/fury/tests/test_transform.py
@@ -135,7 +135,8 @@ def test_rotate():
 
     report = window.analyze_snapshot(arr2)
     npt.assert_equal(report.objects, 1)
-    assert_greater(center_of_mass(arr2), center_of_mass(arr1))
+    # x coord of c.o.m of rotated cone should be greater
+    assert_greater(center_of_mass(arr2)[1], center_of_mass(arr1)[1])
 
 
 def test_transform_from_matrix():

--- a/fury/window.py
+++ b/fury/window.py
@@ -924,6 +924,7 @@ def record(scene=None, cam_pos=None, cam_focal=None, cam_view=None,
         w, h, _ = renderLarge.GetOutput().GetDimensions()
         components = renderLarge.GetOutput().GetNumberOfScalarComponents()
         arr = arr.reshape((h, w, components))
+        arr = np.flipud(arr)
         save_image(arr, filename)
 
         ang = +az_ang
@@ -1052,6 +1053,7 @@ def snapshot(scene, fname=None, size=(300, 300), offscreen=True,
     vtk_array = vtk_image.GetPointData().GetScalars()
     components = vtk_array.GetNumberOfComponents()
     arr = numpy_support.vtk_to_numpy(vtk_array).reshape(w, h, components).copy()
+    arr = np.flipud(arr)
 
     if fname is None:
         return arr


### PR DESCRIPTION
Fixes #642 and the following

- `window.save_image` saves flipped image. This code snippet should save black (top) to white (bottom) gradient, but did the inverse.
```py
image = np.reshape(np.tile(np.arange(0, 256).astype(np.uint8), (256*3,1)).T, (256,256,3))
print(image)
window.save_image(image, "image.png")
```
- `window.load_image` would load flipped image of the input file.

Seems like this was due to #521 https://github.com/fury-gl/fury/pull/521/commits/ecd3408d523507da27e77f324d2c12247931fa36. I reverted this and save/load was fixed. Now `window.record` was broken due to #521 https://github.com/fury-gl/fury/pull/521/commits/0e448af7e84476cc7ad12b57484844a5423e1af4 which I had to revert.

At this point basically all the changes of #521 were reverted which flipped images on save/load/record.
Now I had to fix #467 due to which #521 was opened.
That means I had to simply flip the image array before saving in `window.snapshot` as we do in `window.record`. This will hence fail some tests that were written with `window.snapshot` producing flipped image arrays.

Edit: Too late to notice #720, it wasn't mentioned anywhere...