### PR TITLE
remove object keyword from class

### DIFF
--- a/docs/source/ext/apigen.py
+++ b/docs/source/ext/apigen.py
@@ -28,7 +28,7 @@ from types import BuiltinFunctionType, FunctionType
 DEBUG = True
 
 
-class ApiDocWriter(object):
+class ApiDocWriter:
     """Class for automatic detection and parsing of API docs
     to Sphinx-parsable reST format."""
 

--- a/docs/source/ext/scrap.py
+++ b/docs/source/ext/scrap.py
@@ -6,7 +6,7 @@ import time
 from sphinx_gallery.scrapers import figure_rst
 
 
-class ImageFileScraper(object):
+class ImageFileScraper:
     def __init__(self):
         """Scrape image files that are already present in current folder."""
         self.embedded_images = {}

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -2960,7 +2960,7 @@ def text_3d(
     return text_actor
 
 
-class Container(object):
+class Container:
     """Provides functionalities for grouping multiple actors using a given
     layout.
 

--- a/fury/interactor.py
+++ b/fury/interactor.py
@@ -15,7 +15,7 @@ from fury.lib import (
 )
 
 
-class Event(object):
+class Event:
     """Event class."""
 
     def __init__(self):

--- a/fury/layout.py
+++ b/fury/layout.py
@@ -5,7 +5,7 @@ import numpy as np
 from fury.utils import get_bounding_box_sizes, get_grid_cells_position, is_ui
 
 
-class Layout(object):
+class Layout:
     """Provide functionalities for laying out actors in a 3D scene."""
 
     def apply(self, actors):

--- a/fury/optpkg.py
+++ b/fury/optpkg.py
@@ -34,7 +34,7 @@ def is_tripwire(obj):
     return False
 
 
-class TripWire(object):
+class TripWire:
     """Class raising error if used.
 
     Standard use is to proxy modules that we could not import

--- a/fury/shaders/tests/test_base.py
+++ b/fury/shaders/tests/test_base.py
@@ -192,7 +192,7 @@ def test_add_shader_callback():
 
     showm = window.ShowManager(scene)
 
-    class Timer(object):
+    class Timer:
         idx = 0.0
 
     timer = Timer()

--- a/fury/testing.py
+++ b/fury/testing.py
@@ -62,7 +62,7 @@ def assert_arrays_equal(arrays1, arrays2):
         assert_array_equal(arr1, arr2)
 
 
-class EventCounter(object):
+class EventCounter:
     def __init__(
         self,
         events_names=[

--- a/fury/ui/tests/test_elements_callback.py
+++ b/fury/ui/tests/test_elements_callback.py
@@ -70,7 +70,7 @@ def test_frame_rate_and_anti_aliasing():
     scene.reset_camera_tight()
     scene.zoom(5)
 
-    class FrameRateHolder(object):
+    class FrameRateHolder:
         fpss = []
 
     frh = FrameRateHolder()

--- a/fury/window.py
+++ b/fury/window.py
@@ -286,7 +286,7 @@ class Scene(OpenGLRenderer):
         self.SetUseFXAA(False)
 
 
-class ShowManager(object):
+class ShowManager:
     """Class interface between the scene, the window and the interactor."""
 
     def __init__(
@@ -1131,7 +1131,7 @@ def snapshot(
 
 
 def analyze_scene(scene):
-    class ReportScene(object):
+    class ReportScene:
         bg_color = None
         collection = None
         actors = None
@@ -1181,7 +1181,7 @@ def analyze_snapshot(
     if isinstance(im, basestring):
         im = load_image(im)
 
-    class ReportSnapshot(object):
+    class ReportSnapshot:
         objects = None
         labels = None
         colors_found = False


### PR DESCRIPTION
In python 3, we do not need `object` keyword to define a class. this is required only for python 2. 

So this PR clean up