### PR TITLE
Remove initialize

### DIFF
--- a/docs/source/fury-pybullet.rst
+++ b/docs/source/fury-pybullet.rst
@@ -177,7 +177,6 @@ A ``window.ShowManager`` and ``itertools.count`` instance must be created before
   showm = window.ShowManager(scene,
                           size=(900, 768), reset_camera=False,
                           order_transparent=True)
-  showm.initialize()
   # Counter iterator for tracking simulation steps.
   counter = itertools.count()
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -42,7 +42,6 @@ Anything that has to be rendered needs to be added to the scene so let's create 
 We set the window scene variables e.g. (width, height)::
 
     showm = window.ShowManager(scene, size=(1024,720), reset_camera=False)
-    showm.initialize()
 
 We add a text block to add some information::
 

--- a/docs/tutorials/01_introductory/viz_gltf_animated.py
+++ b/docs/tutorials/01_introductory/viz_gltf_animated.py
@@ -18,7 +18,6 @@ scene = window.Scene()
 showm = window.ShowManager(
     scene, size=(900, 768), reset_camera=False, order_transparent=True
 )
-showm.initialize()
 
 
 ##############################################################################

--- a/docs/tutorials/01_introductory/viz_morphing.py
+++ b/docs/tutorials/01_introductory/viz_morphing.py
@@ -45,7 +45,6 @@ showm = window.ShowManager(
     scene, size=(900, 768), reset_camera=True, order_transparent=True
 )
 
-showm.initialize()
 scene.add(animation)
 
 ##############################################################################

--- a/docs/tutorials/01_introductory/viz_multithread.py
+++ b/docs/tutorials/01_introductory/viz_multithread.py
@@ -10,31 +10,29 @@ rotates the camera, thread B prints a counter, and thread C
 adds and removes elements from the scene.
 """
 
-from fury import window, actor, ui
-from threading import Thread
-import numpy as np
 import time
+from threading import Thread
 
+import numpy as np
+
+from fury import actor, ui, window
 
 # Preparing to draw some spheres
-xyz = 10 * (np.random.random((100, 3))-0.5)
+xyz = 10 * (np.random.random((100, 3)) - 0.5)
 colors = np.random.random((100, 4))
 radii = np.random.random(100) + 0.5
 
 scene = window.Scene()
-sphere_actor = actor.sphere(centers=xyz,
-                            colors=colors,
-                            radii=radii,
-                            use_primitive=False)
+sphere_actor = actor.sphere(
+    centers=xyz, colors=colors, radii=radii, use_primitive=False
+)
 scene.add(sphere_actor)
 
 
 # Preparing the show manager as usual
-showm = window.ShowManager(scene,
-                           size=(900, 768), reset_camera=False,
-                           order_transparent=True)
-
-# showm.initialize()
+showm = window.ShowManager(
+    scene, size=(900, 768), reset_camera=False, order_transparent=True
+)
 
 # Creating a text block to show a message and reset the camera
 tb = ui.TextBlock2D(bold=True)
@@ -44,16 +42,17 @@ scene.ResetCamera()
 
 # Create a function to print a counter to the console
 def print_counter():
-    print("")
+    print('')
     for i in range(100):
-        print("\rCounter: %d" % i, end="")
-        message = "Let's count up to 100 and exit :" + str(i+1)
+        print('\rCounter: %d' % i, end='')
+        message = "Let's count up to 100 and exit :" + str(i + 1)
         tb.message = message
         time.sleep(0.05)
         if showm.is_done():
             break
     showm.exit()
-    print("")
+    print('')
+
 
 # Create a function to rotate the camera
 
@@ -66,6 +65,7 @@ def rotate_camera():
             time.sleep(0.05)
         else:
             break
+
 
 # Create a function to add or remove the axes and increase its scale
 

--- a/docs/tutorials/01_introductory/viz_skinning.py
+++ b/docs/tutorials/01_introductory/viz_skinning.py
@@ -47,7 +47,6 @@ scene = window.Scene()
 showm = window.ShowManager(
     scene, size=(900, 768), reset_camera=True, order_transparent=True
 )
-showm.initialize()
 scene.add(animation)
 
 ##############################################################################

--- a/docs/tutorials/05_animation/viz_hierarchical_animation.py
+++ b/docs/tutorials/05_animation/viz_hierarchical_animation.py
@@ -15,7 +15,6 @@ scene = window.Scene()
 showm = window.ShowManager(
     scene, size=(900, 768), reset_camera=False, order_transparent=True
 )
-showm.initialize()
 
 ###############################################################################
 # Creating the road

--- a/docs/tutorials/05_animation/viz_interpolators.py
+++ b/docs/tutorials/05_animation/viz_interpolators.py
@@ -66,7 +66,6 @@ scene = window.Scene()
 showm = window.ShowManager(
     scene, size=(900, 768), reset_camera=False, order_transparent=True
 )
-showm.initialize()
 
 arrow = actor.arrow(np.array([[0, 0, 0]]), (0, 0, 0), (1, 0, 1), scales=6)
 

--- a/docs/tutorials/05_animation/viz_introduction.py
+++ b/docs/tutorials/05_animation/viz_introduction.py
@@ -64,7 +64,6 @@ from fury.animation import Animation
 scene = window.Scene()
 
 showm = window.ShowManager(scene, size=(900, 768))
-showm.initialize()
 
 
 ###############################################################################

--- a/docs/tutorials/05_animation/viz_robot_arm_animation.py
+++ b/docs/tutorials/05_animation/viz_robot_arm_animation.py
@@ -16,7 +16,6 @@ scene = window.Scene()
 showm = window.ShowManager(
     scene, size=(900, 768), reset_camera=False, order_transparent=True
 )
-showm.initialize()
 
 
 ###############################################################################

--- a/docs/tutorials/05_animation/viz_timeline.py
+++ b/docs/tutorials/05_animation/viz_timeline.py
@@ -27,7 +27,6 @@ from fury.animation import Animation, Timeline
 scene = window.Scene()
 
 showm = window.ShowManager(scene, size=(900, 768))
-showm.initialize()
 
 ###############################################################################
 # Creating a ``Timeline``

--- a/fury/tests/test_gltf.py
+++ b/fury/tests/test_gltf.py
@@ -188,7 +188,6 @@ def test_simple_animation():
     timeline.add_animation(animation)
     scene = window.Scene()
     showm = window.ShowManager(scene, size=(900, 768))
-    showm.initialize()
 
     scene.add(timeline)
 
@@ -255,7 +254,6 @@ def test_skinning():
 
     scene = window.Scene()
     showm = window.ShowManager(scene, size=(900, 768))
-    showm.initialize()
 
     scene.add(timeline)
     timeline.seek(1.0)
@@ -329,7 +327,6 @@ def test_morphing():
 
     scene = window.Scene()
     showm = window.ShowManager(scene, size=(900, 768))
-    showm.initialize()
 
     timeline_1 = Timeline()
     timeline_1.add_animation(anim_1)

--- a/fury/tests/test_thread.py
+++ b/fury/tests/test_thread.py
@@ -1,11 +1,12 @@
-
 import time
 from threading import Thread
-from fury.utils import rotate, update_actor, vertices_from_actor
+
 import numpy as np
 import numpy.testing as npt
 import pytest
+
 from fury import actor, window
+from fury.utils import rotate, update_actor, vertices_from_actor
 
 
 def test_multithreading():
@@ -14,19 +15,15 @@ def test_multithreading():
     radii = np.random.random(100) + 0.5
 
     scene = window.Scene()
-    sphere_actor = actor.sphere(centers = xyz,
-                                colors = colors,
-                                radii = radii,
-                                use_primitive = False)
+    sphere_actor = actor.sphere(
+        centers=xyz, colors=colors, radii=radii, use_primitive=False
+    )
     scene.add(sphere_actor)
 
     # Preparing the show manager as usual
-    showm = window.ShowManager(scene,
-                               size = (900, 768),
-                               reset_camera = False,
-                               order_transparent = True)
-
-    # showm.initialize()
+    showm = window.ShowManager(
+        scene, size=(900, 768), reset_camera=False, order_transparent=True
+    )
 
     vsa = vertices_from_actor(sphere_actor)
 
@@ -48,11 +45,10 @@ def test_multithreading():
         #     showm.exit()
         #     npt.assert_equal(np.sum(arr) > 1, True)
 
-
-    thread_a = Thread(target = callback1)
+    thread_a = Thread(target=callback1)
     thread_a.start()
 
-    showm.start(multithreaded = True)
+    showm.start(multithreaded=True)
     thread_a.join()
 
 

--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -606,7 +606,6 @@ def test_opengl_state_add_remove_and_check():
 
 def test_add_animation_to_show_manager():
     showm = window.ShowManager()
-    showm.initialize()
 
     cube = actor.cube(np.array([[2, 2, 3]]))
 

--- a/fury/ui/core.py
+++ b/fury/ui/core.py
@@ -176,7 +176,8 @@ class UI(object, metaclass=abc.ABCMeta):
                 raise TypeError(msg)
 
             if callback[0] == self._scene:
-
+                if not iren.GetInitialized():
+                    iren.Initialize()
                 iren.add_callback(iren, callback[1], callback[2], args=[self])
             else:
                 iren.add_callback(*callback, args=[self])

--- a/fury/window.py
+++ b/fury/window.py
@@ -535,8 +535,8 @@ class ShowManager:
             else:
                 self.window.SetWindowName(self.title)
             if multithreaded:
-                if not iren.GetInitialized():
-                    iren.Initialize()
+                if not self.iren.GetInitialized():
+                    self.iren.Initialize()
                 while self.iren.GetDone() is False:
                     start_time = time.perf_counter()
                     self.lock()

--- a/fury/window.py
+++ b/fury/window.py
@@ -535,6 +535,8 @@ class ShowManager:
             else:
                 self.window.SetWindowName(self.title)
             if multithreaded:
+                if not iren.GetInitialized():
+                    iren.Initialize()
                 while self.iren.GetDone() is False:
                     start_time = time.perf_counter()
                     self.lock()


### PR DESCRIPTION
- Small PR to remove initialize everywhere. 
- in `UI` module, `iren.initialize()` needs to be called since we add an Observer sometimes 