### PR TITLE
Triangle strips 2 Triangles

### DIFF
--- a/fury/actor.py
+++ b/fury/actor.py
@@ -54,6 +54,7 @@ from fury.lib import (
     TransformPolyDataFilter,
     TubeFilter,
     VectorText,
+    TriangleFilter,
     numpy_support,
 )
 from fury.shaders import (
@@ -595,6 +596,7 @@ def streamtube(
     lod_points_size=3,
     spline_subdiv=None,
     lookup_colormap=None,
+    replace_strips=False
 ):
     """Use streamtubes to visualize polylines.
 
@@ -642,6 +644,10 @@ def streamtube(
     lookup_colormap : vtkLookupTable, optional
         Add a default lookup table to the colormap. Default is None which calls
         :func:`fury.actor.colormap_lookup_table`.
+    replace_strips : bool, optional
+        If True it changes streamtube representation from triangle strips to
+        triangles. Useful with SelectionManager or PickingManager.
+        Default False.
 
     Examples
     --------
@@ -712,6 +718,12 @@ def streamtube(
 
     # Poly mapper
     poly_mapper = set_input(PolyDataMapper(), next_input)
+    if replace_strips:
+        triangle_filter = set_input(TriangleFilter(), next_input)
+        poly_mapper = set_input(PolyDataMapper(), triangle_filter.GetOutputPort())
+
+    else:
+        poly_mapper = set_input(PolyDataMapper(), next_input)
     poly_mapper.ScalarVisibilityOn()
     poly_mapper.SetScalarModeToUsePointFieldData()
     poly_mapper.SelectColorArray('colors')
@@ -738,6 +750,8 @@ def streamtube(
     actor.GetProperty().SetInterpolationToPhong()
     actor.GetProperty().BackfaceCullingOn()
     actor.GetProperty().SetOpacity(opacity)
+
+
 
     return actor
 

--- a/fury/lib.py
+++ b/fury/lib.py
@@ -118,6 +118,7 @@ PolyDataNormals = fcvtk.vtkPolyDataNormals
 ContourFilter = fcvtk.vtkContourFilter
 TubeFilter = fcvtk.vtkTubeFilter
 Glyph3D = fcvtk.vtkGlyph3D
+TriangleFilter = fcvtk.vtkTriangleFilter
 
 ##############################################################
 #  vtkFiltersGeneral Module

--- a/fury/tests/test_actors.py
+++ b/fury/tests/test_actors.py
@@ -360,6 +360,16 @@ def test_streamtube_and_line_actors():
 
     npt.assert_equal(c3.GetProperty().GetRenderLinesAsTubes(), True)
 
+    c4 = actor.streamtube(lines, colors, replace_strips=False)
+
+    c5 = actor.streamtube(lines, colors, replace_strips=True)
+
+    strips4 = c4.GetMapper().GetInput().GetStrips().GetData().GetSize()
+    strips5 = c5.GetMapper().GetInput().GetStrips().GetData().GetSize()
+
+    npt.assert_equal(strips4 > 0, True)
+    npt.assert_equal(strips5 == 0, True)
+
 
 def simulated_bundle(no_streamlines=10, waves=False):
     t = np.linspace(20, 80, 200)
@@ -1716,3 +1726,4 @@ def test_actors_primitives_count():
         primitives_count = test_case[2]
         act = act_func(**args)
         npt.assert_equal(primitives_count_from_actor(act), primitives_count)
+


### PR DESCRIPTION
Adds an option to change surface representation in streamtube from triangle strips to triangles. This makes life easy with the SelectionManager. This closes PR https://github.com/fury-gl/fury/pull/708 but I am also adding an issue to improve direct picking of triangle strip representations. See here https://github.com/fury-gl/fury/issues/757

In order to know if an actor is using triangle strips or not, you need to use something like
``actor.GetMapper().GetInput().GetStrips()``

