### PR TITLE
update the deprecated get_data() to get_fdata in viz_roi_contour.py in the demo section.

### DIFF
--- a/docs/examples/viz_roi_contour.py
+++ b/docs/examples/viz_roi_contour.py
@@ -33,8 +33,8 @@ from fury.colormap import line_colors
 # Tutorial.
 
 hardi_img, gtab, labels_img = read_stanford_labels()
-data = hardi_img.get_data()
-labels = labels_img.get_data()
+data = hardi_img.get_fdata()
+labels = labels_img.get_fdata()
 affine = hardi_img.affine
 
 white_matter = (labels == 1) | (labels == 2)

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -10,7 +10,18 @@ Start by importing FURY.
     from fury import window, actor, ui, io, utils
 
 To import a model, use :py:func:`.io.load_polydata`. Currently supported formats include OBJ, VTK, FIB, PLY, STL and XML.
-Let us include the ``suzanne`` model used by Blender
+
+Here we are going to use ``suzanne`` model used by Blender. You can find more detail about `what is suzanne model <https://en.wikipedia.org/wiki/Blender_(software)#:~:text=A%20low-polygon%20model%20with%20only%20500%20faces%2C%20Suzanne,gives%20out%20an%20award%20called%20the%20Suzanne%20Award.).>`_.
+
+We can download the model by
+
+.. code-block:: python
+
+    from fury.data import fetch_viz_models
+    models = fetch_viz_models()
+
+Then the models will be downloaded in ``~/.fury/models``.
+To include the ``suzanne`` model used by Blender:
 
 .. code-block:: python
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -10,18 +10,7 @@ Start by importing FURY.
     from fury import window, actor, ui, io, utils
 
 To import a model, use :py:func:`.io.load_polydata`. Currently supported formats include OBJ, VTK, FIB, PLY, STL and XML.
-
-Here we are going to use ``suzanne`` model used by Blender. You can find more detail about `what is suzanne model <https://en.wikipedia.org/wiki/Blender_(software)#:~:text=A%20low-polygon%20model%20with%20only%20500%20faces%2C%20Suzanne,gives%20out%20an%20award%20called%20the%20Suzanne%20Award.).>`_.
-
-We can download the model by
-
-.. code-block:: python
-
-    from fury.data import fetch_viz_models
-    models = fetch_viz_models()
-
-Then the models will be downloaded in ``~/.fury/models``.
-To include the ``suzanne`` model used by Blender:
+Let us include the ``suzanne`` model used by Blender
 
 .. code-block:: python
 


### PR DESCRIPTION
update the deprecated get_data() to get_fdata() in docs/examples/viz_roi_contour.py