### PR TITLE
add one condition in `repeat_primitive` to handle direction [-1, 0, 0], issue #770

### DIFF
--- a/fury/primitive.py
+++ b/fury/primitive.py
@@ -203,11 +203,18 @@ def repeat_primitive(
             dirs = dirs / dir_abs
             v = np.cross(normal, dirs)
             c = np.dot(normal, dirs)
+
             v1, v2, v3 = v
-            h = 1 / (1 + c)
+
             Vmat = np.array([[0, -v3, v2], [v3, 0, -v1], [-v2, v1, 0]])
 
-            rotation_matrix = np.eye(3, dtype=np.float64) + Vmat + (Vmat.dot(Vmat) * h)
+            if c == -1.0:
+                rotation_matrix = -np.eye(3, dtype=np.float64)
+            else:
+                h = 1 / (1 + c)
+                rotation_matrix = np.eye(3, dtype=np.float64) + \
+                    Vmat + (Vmat.dot(Vmat) * h)
+
         else:
             rotation_matrix = np.identity(3)
 

--- a/fury/tests/test_primitive.py
+++ b/fury/tests/test_primitive.py
@@ -225,36 +225,38 @@ def test_repeat_primitive():
     dirs = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 1]])
     colors = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1.0]])
 
-    res = fp.repeat_primitive(
-        vertices=verts, faces=faces, centers=centers, directions=dirs, colors=colors
-    )
+    for i in [-1, 1]:
+        dirs = dirs * i
+        res = fp.repeat_primitive(
+            vertices=verts, faces=faces, centers=centers, directions=dirs, colors=colors
+        )
 
-    big_verts, big_faces, big_colors, big_centers = res
+        big_verts, big_faces, big_colors, big_centers = res
 
-    npt.assert_equal(big_verts.shape[0], verts.shape[0] * centers.shape[0])
-    npt.assert_equal(big_faces.shape[0], faces.shape[0] * centers.shape[0])
-    npt.assert_equal(big_colors.shape[0], verts.shape[0] * centers.shape[0])
-    npt.assert_equal(big_centers.shape[0], verts.shape[0] * centers.shape[0])
+        npt.assert_equal(big_verts.shape[0], verts.shape[0] * centers.shape[0])
+        npt.assert_equal(big_faces.shape[0], faces.shape[0] * centers.shape[0])
+        npt.assert_equal(big_colors.shape[0], verts.shape[0] * centers.shape[0])
+        npt.assert_equal(big_centers.shape[0], verts.shape[0] * centers.shape[0])
 
-    npt.assert_equal(
-        np.unique(np.concatenate(big_faces, axis=None)).tolist(),
-        list(range(len(big_verts))),
-    )
+        npt.assert_equal(
+            np.unique(np.concatenate(big_faces, axis=None)).tolist(),
+            list(range(len(big_verts))),
+        )
 
-    # translate the squares primitives centers to be the origin
-    big_vert_origin = big_verts - np.repeat(centers, 4, axis=0)
+        # translate the squares primitives centers to be the origin
+        big_vert_origin = big_verts - np.repeat(centers, 4, axis=0)
 
-    # three repeated primitives
-    sq1, sq2, sq3 = big_vert_origin.reshape([3, 12])
+        # three repeated primitives
+        sq1, sq2, sq3 = big_vert_origin.reshape([3, 12])
 
-    #  primitives directed toward different directions must not be the same
-    np.testing.assert_equal(np.any(np.not_equal(sq1, sq2)), True)
-    np.testing.assert_equal(np.any(np.not_equal(sq1, sq3)), True)
-    np.testing.assert_equal(np.any(np.not_equal(sq2, sq3)), True)
+        #  primitives directed toward different directions must not be the same
+        npt.assert_equal(np.any(np.not_equal(sq1, sq2)), True)
+        npt.assert_equal(np.any(np.not_equal(sq1, sq3)), True)
+        npt.assert_equal(np.any(np.not_equal(sq2, sq3)), True)
 
-    np.testing.assert_equal(big_vert_origin.min(), -0.5)
-    np.testing.assert_equal(big_vert_origin.max(), 0.5)
-    np.testing.assert_equal(np.mean(big_vert_origin), 0)
+        npt.assert_equal(big_vert_origin.min(), -0.5)
+        npt.assert_equal(big_vert_origin.max(), 0.5)
+        npt.assert_equal(np.mean(big_vert_origin), 0)
 
 
 def test_repeat_primitive_function():


### PR DESCRIPTION
Fix the issue #770.

The cause is `directions = np.array([1, 0 ,0 ])`, which is a (3, ) 1 dimension array.
It is ok for `repeat_primitive()` to use 1d array, it will be processed to `np.ndarray` in the function.
But for VTK method, directions parameter has to be `np.ndarry(N,3)`

Issue 1 can be resolved by modify the directions to `directions = np.array([[1, 0, 0]])` as a (1,3) ndarray.

For Issue 2, I have add a condition to cover the case directions = [-1, 0, 0]

<img width="548" alt="image" src="https://user-images.githubusercontent.com/110199757/227365749-6890f402-e80a-497d-9ead-2b0589da3694.png">

Code to reproduce:
```python
from fury import window, actor
import numpy as np

scene = window.Scene()
showm = window.ShowManager(scene,size=(1024, 720), reset_camera=False)
showm.initialize()

centers = np.array([[0, 0, 0]])
directions = np.array([[1, 0 ,0 ]])
colors_primitive = np.array([1,0,0])
colors_no_primitive = np.array([0,1,0])

for i in range(35):
    
    centers = centers + np.array([[1.2, 0, 0]])

    theta_rad = np.deg2rad(10)
    rotation_z = np.array([[np.cos(theta_rad), -np.sin(theta_rad), 0],
                           [np.sin(theta_rad),  np.cos(theta_rad), 0],
                           [0,  0, 1]])

    
    directions = np.dot(rotation_z, directions.T).T
    
    arrow_primitive = actor.arrow(centers, directions, colors_primitive, repeat_primitive=True)
    
    centers_2 = centers + np.array([[0, 1.2, 0]])

    arrow_no_primitive = actor.arrow(centers_2, directions, colors_no_primitive, repeat_primitive=False)

    scene.add(arrow_primitive,arrow_no_primitive)

showm.start()
```
