### PR TITLE
Fixing `TextBlock2D` justification issue

### DIFF
--- a/fury/ui/core.py
+++ b/fury/ui/core.py
@@ -785,6 +785,9 @@ class TextBlock2D(UI):
             self.background.resize(size)
         scene.add(self.background, self.actor)
 
+        self.justification = self.justification
+        self.vertical_justification = self.vertical_justification
+
     @property
     def message(self):
         """Get message from the text.
@@ -904,8 +907,10 @@ class TextBlock2D(UI):
             text_property.SetJustificationToLeft()
         elif justification == 'center':
             text_property.SetJustificationToCentered()
+            self.actor.SetPosition(self.position + [self.background.size[0]//2, 0])
         elif justification == 'right':
             text_property.SetJustificationToRight()
+            self.actor.SetPosition(self.position + [self.background.size[0], 0])
         else:
             msg = 'Text can only be justified left, right and center.'
             raise ValueError(msg)
@@ -944,8 +949,10 @@ class TextBlock2D(UI):
             text_property.SetVerticalJustificationToBottom()
         elif vertical_justification == 'middle':
             text_property.SetVerticalJustificationToCentered()
+            self.actor.SetPosition(self.position + [0, self.background.size[1]//2])
         elif vertical_justification == 'top':
             text_property.SetVerticalJustificationToTop()
+            self.actor.SetPosition(self.position + [0, self.background.size[1]])
         else:
             msg = 'Vertical justification must be: bottom, middle or top.'
             raise ValueError(msg)


### PR DESCRIPTION
Fixing the issue of alignment in `TextBlock2D` when using the `justification`  and `vertical_justification` property as we can see below.
![image](https://github.com/fury-gl/fury/assets/64432063/30330be2-b529-47e9-850a-6e3a8bc03551)
![image](https://github.com/fury-gl/fury/assets/64432063/d62b66b2-2444-4c84-8d50-ccb133e51939)

This was happening because when we were updating the text justification it was with the reference of the current position of the UI element which is the bottom left corner of the element.

The fix proposed solve this issue as shown below.

![image](https://github.com/fury-gl/fury/assets/64432063/86f85d6c-f9df-4092-abdf-248b6ec77c5e)
![image](https://github.com/fury-gl/fury/assets/64432063/459b20be-9471-4809-acae-b1dcff6204d6)
