### PR TITLE
[WIP] Tutorial on using ellipsoid actor to visualize tensor ellipsoids for DTI

### DIFF
--- a/docs/examples/viz_dt_ellipsoids.py
+++ b/docs/examples/viz_dt_ellipsoids.py
@@ -14,7 +14,172 @@ import numpy as np
 
 from dipy.io.image import load_nifti
 
-from fury.actor import _fa, _color_fa
+from fury import window, actor
+#from fury.actor import _fa, _color_fa
 from fury.data import fetch_viz_dmri, read_viz_dmri
+from fury.primitive import prim_sphere
 
+# Now, we fetch and load the data needed to display the Diffusion Tensor
+# Images.
 
+fetch_viz_dmri()
+
+# The tensor ellipsoids are expressed as eigen values and eigen vectors
+# which are the decomposition of the diffusion tensor that describes the water
+# diffusion within a voxel.
+
+evecs, _ = load_nifti(read_viz_dmri('slice_evecs.nii.gz'))
+evals, _ = load_nifti(read_viz_dmri('slice_evals.nii.gz'))
+roi_evecs, _ = load_nifti(read_viz_dmri('roi_evecs.nii.gz'))
+roi_evals, _ = load_nifti(read_viz_dmri('roi_evals.nii.gz'))
+#whole_brain_evecs, _ = load_nifti(read_viz_dmri('whole_brain_evecs.nii.gz'))
+#whole_brain_evals, _ = load_nifti(read_viz_dmri('whole_brain_evals.nii.gz'))
+
+interactive = True
+
+###############################################################################
+# Using tensor_slicer actor
+# =========================
+#
+
+affine = np.eye(4)
+
+data_shape = evals.shape[:3]
+mask = np.ones(data_shape).astype(bool)
+vertices, faces = prim_sphere('repulsion100', True)
+# vertices, faces = prim_sphere('repulsion200', True)
+# vertices, faces = prim_sphere('repulsion724', True)
+class Sphere:
+    vertices = None
+    faces = None
+
+sphere = Sphere()
+sphere.vertices = vertices
+sphere.faces = faces
+
+tensor_slicer_actor = actor.tensor_slicer(
+    evals, evecs, affine=affine, mask=mask, sphere=sphere, scale=.3)
+tensor_slicer_actor.display_extent(
+    0, data_shape[0], 0, data_shape[1], 0, data_shape[2])
+
+scene = window.Scene()
+scene.add(tensor_slicer_actor)
+
+scene.reset_camera()
+scene.reset_clipping_range()
+
+if interactive:
+    window.show(scene)
+
+scene.clear()
+
+###############################################################################
+# Using ellipsoid actor
+# =====================
+#
+
+'''
+valid_mask = np.abs(evecs).max(axis=(-2, -1)) > 0
+indices = np.nonzero(valid_mask)
+
+centers = np.asarray(indices).T
+
+num_centers = centers.shape[0]
+
+dofs_vecs = evecs[indices]
+dofs_vals = evals[indices]
+
+colors = [_color_fa(_fa(dofs_vals[i, :]), dofs_vecs[i, ...])
+          for i in range(num_centers)]
+colors = np.asarray(colors)
+
+tensors = actor.ellipsoid(
+    centers, colors=colors, axes=dofs_vecs, lengths=dofs_vals, scales=.6)
+scene.add(tensors)
+
+if interactive:
+    window.show(scene)
+
+scene.clear()
+'''
+
+###############################################################################
+# Visualize a larger amount of data
+# =================================
+# With tensor_slicer is possible to visualize more than one slice using
+# display_extent(). Here we can see an example of a region of interest (ROI)
+# using a sphere of 100 vertices.
+
+data_shape = roi_evals.shape[:3]
+mask = np.ones(data_shape).astype(bool)
+
+tensor_roi = actor.tensor_slicer(
+    roi_evals, roi_evecs, affine=affine, mask=mask, sphere=sphere, scale=.3)
+tensor_roi.display_extent(
+    0, data_shape[0], 0, data_shape[1], 0, data_shape[2])
+
+scene = window.Scene()
+scene.add(tensor_roi)
+
+if interactive:
+    window.show(scene)
+
+scene.clear()
+
+# We can do it also with a sphere of 200 vertices, but if we try to do it with
+# one of 724 the visualization can no longer be rendered. In contrast, we can
+# visualize the ROI with the ellipsoid actor without compromising the quality
+# of the visualization.
+
+'''
+valid_mask = np.abs(roi_evecs).max(axis=(-2, -1)) > 0
+indices = np.nonzero(valid_mask)
+
+centers = np.asarray(indices).T
+
+num_centers = centers.shape[0]
+
+dofs_vecs = roi_evecs[indices]
+dofs_vals = roi_evals[indices]
+
+colors = [_color_fa(_fa(dofs_vals[i, :]), dofs_vecs[i, ...])
+          for i in range(num_centers)]
+colors = np.asarray(colors)
+
+tensors = actor.ellipsoid(
+    centers, colors=colors, axes=dofs_vecs, lengths=dofs_vals, scales=.6)
+scene.add(tensors)
+
+if interactive:
+    window.show(scene)
+
+scene.clear()
+'''
+
+# In fact, although with a low performance, this actor allows us to visualize
+# the whole brain, which contains a much larger amount of data.
+
+'''
+valid_mask = np.abs(whole_brain_evecs).max(axis=(-2, -1)) > 0
+indices = np.nonzero(valid_mask)
+
+centers = np.asarray(indices).T
+
+num_centers = centers.shape[0]
+
+dofs_vecs = whole_brain_evecs[indices]
+dofs_vals = whole_brain_evals[indices]
+
+colors = [_color_fa(_fa(dofs_vals[i, :]), dofs_vecs[i, ...])
+          for i in range(num_centers)]
+colors = np.asarray(colors)
+
+tensors = actor.ellipsoid(
+    centers, colors=colors, axes=dofs_vecs, lengths=dofs_vals, scales=.6)
+scene.add(tensors)
+
+if interactive:
+    window.show(scene)
+
+scene.clear()
+'''

--- a/docs/examples/viz_dt_ellipsoids.py
+++ b/docs/examples/viz_dt_ellipsoids.py
@@ -1,0 +1,20 @@
+"""
+===============================================================================
+Display Tensor Ellipsoids for DTI using tensor_slicer vs ellipsoid actor
+===============================================================================
+This tutorial is intended to show two ways of displaying diffusion tensor
+ellipsoids for DTI visualization. The first is using the basic tensor_slicer
+that allows us to slice many tensors as ellipsoids. The second is the generic
+ellipsoid actor that can be used to display different amount of tensors.
+
+We start by importing the necessary modules:
+"""
+
+import numpy as np
+
+from dipy.io.image import load_nifti
+
+from fury.actor import _fa, _color_fa
+from fury.data import fetch_viz_dmri, read_viz_dmri
+
+

--- a/fury/data/fetcher.py
+++ b/fury/data/fetcher.py
@@ -514,9 +514,19 @@ fetch_viz_dmri = _make_fetcher(
     "fetch_viz_dmri",
     pjoin(fury_home, "dmri"),
     DMRI_DATA_URL,
-    ['fodf.nii.gz'],
-    ['fodf.nii.gz'],
-    ['767ca3e4cd296e78421d83c32201b30be2d859c332210812140caac1b93d492b']
+    ['fodf.nii.gz', 'slice_evecs.nii.gz', 'slice_evals.nii.gz',
+     'roi_evecs.nii.gz', 'roi_evals.nii.gz', 'whole_brain_evecs.nii.gz',
+     'whole_brain_evals.nii.gz'],
+    ['fodf.nii.gz', 'slice_evecs.nii.gz', 'slice_evals.nii.gz',
+     'roi_evecs.nii.gz', 'roi_evals.nii.gz', 'whole_brain_evecs.nii.gz',
+     'whole_brain_evals.nii.gz'],
+    ['767ca3e4cd296e78421d83c32201b30be2d859c332210812140caac1b93d492b',
+     '8843ECF3224CB8E3315B7251D1E303409A17D7137D3498A8833853C4603C6CC2',
+     '3096B190B1146DD0EADDFECC0B4FBBD901F4933692ADD46A83F637F28B22122D',
+     '89E569858A897E72C852A8F05BBCE0B21C1CA726E55508087A2DA5A38C212A17',
+     'F53C68CCCABF97F1326E93840A8B5CE2E767D66D692FFD955CA747FFF14EC781',
+     '8A894F6AB404240E65451FA6D10FB5D74E2D0BDCB2A56AD6BEA38215BF787248',
+     '47A73BBE68196381ED790F80F48E46AC07B699B506973FFA45A95A33023C7A77']
 )
 
 fetch_viz_textures = _make_fetcher(


### PR DESCRIPTION
This PR consists of a tutorial that is intended to show two ways of displaying diffusion tensor ellipsoids for DTI visualization. The first is using the basic `tensor_slicer` actor which allows us to slice many tensors as ellipsoids, and the second with the generic `ellipsoid` actor I'm currently working on (fury-gl/fury#791), which can be used to display different amounts of ellipsoids. The idea is to show the use that can be made of the ellipsoid actor in the visualization of diffusion tensor ellipsoids, compared to the tensor_slicer actor, contrasting visual quality and the amount of data that can be rendered.

I still working on this, it is not ready for review yet.