### PR TITLE
Updating broken links in the Scientific Domain Section

### DIFF
--- a/docs/source/_templates/home.html
+++ b/docs/source/_templates/home.html
@@ -174,7 +174,7 @@
                         vertex or a pixel. Vertex shaders describe the attributes (position, texture coordinates,
                         colors, etc.) of a vertex, while pixel shaders describe the traits (color, z-depth and alpha
                         value) of a pixel.</div>
-                    </div>
+                </div>
                 <div class="gallery-box-content gallery-underline">
                     <div class="gallery-box-title">Physically based rendering</div>
                     <img src="_static/images/physical.gif" alt="">
@@ -187,7 +187,7 @@
                         preferably combined with one or several 'maps' in a multiview display. The main view displays a
                         selected part in details, while the 'maps' provide the user with information about the position
                         of the part inside the network.</div>
-                    </div>
+                </div>
             </div>
         </div>
     </section>
@@ -200,10 +200,10 @@
         <header id="banner" class="wrapper">
             <div class="inner">
                 <h1 id="banner-title">Install FURY And Start Using It!</h1>
-                    <div id="banner-start">
-                        <span id="banner-start-command" class="txt-rotate" data-period="2000"
-                            data-rotate='["pip install fury", "conda install -c conda-forge fury"]'></span>
-                    </div>
+                <div id="banner-start">
+                    <span id="banner-start-command" class="txt-rotate" data-period="2000"
+                        data-rotate='["pip install fury", "conda install -c conda-forge fury"]'></span>
+                </div>
             </div>
         </header>
     </div>
@@ -267,7 +267,8 @@
                                     <p class="h-card__content">FURY is a powerful tool for engineers and visualisation experts. It allows them to create high-quality visualisations quickly and easily, without the need for extensive programming knowledge. Its functional programming paradigm and support for large data sets make it an ideal tool for visualising complex systems and data, such as those used in engineering and scientific research.
                                     </p>
 
-                                    <a class="h-card__button" href="auto_tutorials/05_animation/viz_robot_arm_animation.html">
+
+                                    <a class="h-card__button" href="auto_examples/10_animation/viz_robot_arm_animation.html">
                                         View More
                                         <i class="fas fa-external-link-alt"></i>
                                     </a>
@@ -287,7 +288,7 @@
                                     <p class="h-card__content">FURY's ability to create stunning visualisations of complex physical phenomena. For example, FURY can be used to create detailed visualisations of fluid dynamics, such as the flow of water or gas. It can also be used to visualise the motion of particles in a simulation.
                                     </p>
 
-                                    <a class="h-card__button" href="auto_examples/viz_brownian_motion.html">
+                                    <a class="h-card__button" href="auto_examples/04_demos/viz_brownian_motion.html">
                                         View More
                                         <i class="fas fa-external-link-alt"></i>
                                     </a>
@@ -307,7 +308,7 @@
                                     <p class="h-card__content">FURY can be used to create detailed visualisations of the structure of molecules, including their bonding and interactions. It can also be used to visualise the motion of atoms and molecules in a simulation, such as the motion of atoms and molecules in a material.
                                     </p>
 
-                                    <a class="h-card__button" href="auto_examples/collision-particles.html">
+                                    <a class="h-card__button" href="auto_examples/04_demos/collision-particles.html">
                                         View More
                                         <i class="fas fa-external-link-alt"></i>
                                     </a>
@@ -327,7 +328,7 @@
                                     <p class="h-card__content">FURY can be used to create detailed visualisations of the structure of galaxies, including the distribution of stars, gas, and dust. It can also be used to visualise the motion of celestial bodies in a simulation, such as the motion of stars and planets in a solar system.
                                     </p>
 
-                                    <a class="h-card__button" href="auto_examples/viz_tesseract.html">
+                                    <a class="h-card__button" href="auto_examples/04_demos/viz_tesseract.html">
                                         View More
                                         <i class="fas fa-external-link-alt"></i>
                                     </a>
@@ -347,7 +348,7 @@
                                     <p class="h-card__content">FURY can easily create 3D visualizations of aerodynamic simulations, which can help engineers understand the performance of an aircraft in different flight conditions. This can be done by importing the simulation data into FURY and then using the library's built-in functions to create 3D models of the aircraft, along with visualizations of the airflow patterns and other important parameters.
                                     </p>
 
-                                    <a class="h-card__button" href="auto_tutorials/01_introductory/viz_texture.html">
+                                    <a class="h-card__button" href="auto_examples/01_introductory/viz_texture.html">
                                         View More
                                         <i class="fas fa-external-link-alt"></i>
                                     </a>
@@ -367,7 +368,7 @@
                                     <p class="h-card__content">With FURY, researchers can create detailed models of cells and organelles, such as the mitochondria, ribosomes, and endoplasmic reticulum. This allows for a more in-depth understanding of the structure and function of these important cellular components.
                                     </p>
 
-                                    <a class="h-card__button" href="auto_examples/viz_bundles.html">
+                                    <a class="h-card__button" href="auto_examples/04_demos/viz_bundles.html">
                                         View More
                                         <i class="fas fa-external-link-alt"></i>
                                     </a>
@@ -387,7 +388,7 @@
                                     <p class="h-card__content">One of the key features of FURY is its ability to handle large amounts of data. This makes it perfect for data scientists who need to work with large datasets, as well as for visualizers who need to create interactive and engaging visualizations.
                                     </p>
 
-                                    <a class="h-card__button" href="auto_tutorials/01_introductory/viz_morphing.html">
+                                    <a class="h-card__button" href="auto_examples/01_introductory/viz_morphing.html">
                                         View More
                                         <i class="fas fa-external-link-alt"></i>
                                     </a>
@@ -407,7 +408,7 @@
                                     <p class="h-card__content">One of the key features of FURY is its ability to handle large and complex networks. It can handle millions of nodes and edges, and can display the network in a variety of different ways, including node-link diagrams, matrix plots, and force-directed layouts. This allows users to explore their networks in a variety of different ways, and to find the best way to visualize their data.
                                     </p>
 
-                                    <a class="h-card__button" href="auto_examples/viz_network_animated.html">
+                                    <a class="h-card__button" href="auto_examples/04_demos/viz_network_animated.html">
                                         View More
                                         <i class="fas fa-external-link-alt"></i>
                                     </a>
@@ -427,7 +428,7 @@
                                     <p class="h-card__content">FURY allows users to easily visualise complex mathematical data in a way that is easy to understand. For example, a mathematician studying a complex equation could use FURY to create a 3D plot of the equation's solutions, which would make it much easier to understand the behaviour of the equation.
                                     </p>
 
-                                    <a class="h-card__button" href="auto_examples/viz_animated_surfaces.html">
+                                    <a class="h-card__button" href="auto_examples/04_demos/viz_animated_surfaces.html">
                                         View More
                                         <i class="fas fa-external-link-alt"></i>
                                     </a>
@@ -645,7 +646,7 @@
                             <li class="link-list"><a class="footer-link" href="installation.html"><i class="fa fa-angle-double-right"></i>
                                 Download
                             </a></li>
-                            <li class="link-list"><a class="footer-link" href="auto_tutorials/index.html"><i class="fa fa-angle-double-right"></i>
+                            <li class="link-list"><a class="footer-link" href="auto_examples/index.html"><i class="fa fa-angle-double-right"></i>
                                 Tutorials
                             </a></li>
                         </ul>

--- a/docs/source/_templates/home.html
+++ b/docs/source/_templates/home.html
@@ -174,7 +174,7 @@
                         vertex or a pixel. Vertex shaders describe the attributes (position, texture coordinates,
                         colors, etc.) of a vertex, while pixel shaders describe the traits (color, z-depth and alpha
                         value) of a pixel.</div>
-                </div>
+                    </div>
                 <div class="gallery-box-content gallery-underline">
                     <div class="gallery-box-title">Physically based rendering</div>
                     <img src="_static/images/physical.gif" alt="">
@@ -187,7 +187,7 @@
                         preferably combined with one or several 'maps' in a multiview display. The main view displays a
                         selected part in details, while the 'maps' provide the user with information about the position
                         of the part inside the network.</div>
-                </div>
+                    </div>
             </div>
         </div>
     </section>
@@ -200,10 +200,10 @@
         <header id="banner" class="wrapper">
             <div class="inner">
                 <h1 id="banner-title">Install FURY And Start Using It!</h1>
-                <div id="banner-start">
-                    <span id="banner-start-command" class="txt-rotate" data-period="2000"
-                        data-rotate='["pip install fury", "conda install -c conda-forge fury"]'></span>
-                </div>
+                    <div id="banner-start">
+                        <span id="banner-start-command" class="txt-rotate" data-period="2000"
+                            data-rotate='["pip install fury", "conda install -c conda-forge fury"]'></span>
+                    </div>
             </div>
         </header>
     </div>

--- a/docs/source/_templates/home.html
+++ b/docs/source/_templates/home.html
@@ -267,7 +267,6 @@
                                     <p class="h-card__content">FURY is a powerful tool for engineers and visualisation experts. It allows them to create high-quality visualisations quickly and easily, without the need for extensive programming knowledge. Its functional programming paradigm and support for large data sets make it an ideal tool for visualising complex systems and data, such as those used in engineering and scientific research.
                                     </p>
 
-
                                     <a class="h-card__button" href="auto_examples/10_animation/viz_robot_arm_animation.html">
                                         View More
                                         <i class="fas fa-external-link-alt"></i>


### PR DESCRIPTION
After the #769 PR all the demos and examples were merged into a single folder called `auto_examples`. This hampered the path that were used in Scientific Domain Section. Redirecting these links according to the update.