### PR TITLE
[WIP] SSAA Implementation - Window.py -> Scene

### DIFF
--- a/fury/lib.py
+++ b/fury/lib.py
@@ -157,6 +157,16 @@ ScalarBarActor = ravtk.vtkScalarBarActor
 OpenGLRenderer = roglvtk.vtkOpenGLRenderer
 #: class for Shader
 Shader = roglvtk.vtkShader
+#: class for RenderPassCollection
+RenderPassCollection = roglvtk.vtkRenderPassCollection
+#: class for DefaultRenderPass
+DefaultRenderPass = roglvtk.vtkDefaultPass
+#: class for SequencePass
+SequencePass = roglvtk.vtkSequencePass
+#: class for SSAAPass
+SSAAPass = roglvtk.vtkSSAAPass
+#: class for CameraPass
+CameraPass = roglvtk.vtkCameraPass
 
 ##############################################################
 #  vtkInteractionStyle Module

--- a/fury/window.py
+++ b/fury/window.py
@@ -285,6 +285,26 @@ class Scene(OpenGLRenderer):
     def fxaa_off(self):
         self.SetUseFXAA(False)
 
+    def ssaa_on(self):
+        """Turn SSAA (Screen Space Anti Aliasing pass) on. Uses VTK Render/Sequence Pass, and SSAA Pass."""
+        collection_pass = RenderPassCollection()
+        collection_pass.AddItem(DefaultRenderPass())
+
+        sequence_pass = SequencePass()
+        sequence_pass.SetPasses(collection_pass)
+
+        camera_pass = CameraPass()
+        camera_pass.SetDelegatePass(sequence_pass)
+
+        ssaa_pass = SSAAPass()
+        ssaa_pass.SetDelegatePass(camera_pass)
+
+        self.SetPass(ssaa_pass)
+
+    def msaa(self):
+        """Turn MSAA on. Uses VTK Render/Sequence Pass, and MSAA Pass."""
+        # TODO: Add support for MSAA, OpenGLrenderer does not have SetPass method for MSAA pass.
+
 
 class ShowManager:
     """Class interface between the scene, the window and the interactor."""

--- a/fury/window.py
+++ b/fury/window.py
@@ -291,7 +291,7 @@ class Scene(OpenGLRenderer):
         self.SetUseFXAA(False)
 
     def enable_ssaa(self):
-        """Turn SSAA (Screen Space Anti Aliasing pass) on. Uses VTK Render/Sequence Pass, and SSAA Pass."""
+        """Turn SSAA on. Uses render passes."""
         collection_pass = RenderPassCollection()
         collection_pass.AddItem(DefaultRenderPass())
 
@@ -308,7 +308,7 @@ class Scene(OpenGLRenderer):
 
     def msaa(self):
         """Turn MSAA on. Uses VTK Render/Sequence Pass, and MSAA Pass."""
-        # TODO: Could be useful to add MSAA here too for continuity, but lacking RenderWindow()
+        # TODO: Add MSAA to Scene()
 
 
 class ShowManager:

--- a/fury/window.py
+++ b/fury/window.py
@@ -25,6 +25,11 @@ from fury.lib import (
     Skybox,
     Volume,
     WindowToImageFilter,
+    RenderPassCollection,
+    DefaultRenderPass,
+    SequencePass,
+    SSAAPass,
+    CameraPass,
     colors,
     numpy_support,
 )
@@ -285,7 +290,7 @@ class Scene(OpenGLRenderer):
     def fxaa_off(self):
         self.SetUseFXAA(False)
 
-    def ssaa_on(self):
+    def enable_ssaa(self):
         """Turn SSAA (Screen Space Anti Aliasing pass) on. Uses VTK Render/Sequence Pass, and SSAA Pass."""
         collection_pass = RenderPassCollection()
         collection_pass.AddItem(DefaultRenderPass())
@@ -303,7 +308,7 @@ class Scene(OpenGLRenderer):
 
     def msaa(self):
         """Turn MSAA on. Uses VTK Render/Sequence Pass, and MSAA Pass."""
-        # TODO: Add support for MSAA, OpenGLrenderer does not have SetPass method for MSAA pass.
+        # TODO: Could be useful to add MSAA here too for continuity, but lacking RenderWindow()
 
 
 class ShowManager:


### PR DESCRIPTION
Added implementation of SSAA (Screen-Space Anti-Aliasing) to Scene in window.py, and added the necessary OpenGL classes in lib.py.

SSAA can be more computationally expensive than other forms of anti-aliasing, but gives an improvement to visual quality. There is potential for future improvement. Since SSAA is implemented in Scene alongside FXAA, we propose that MSAA be moved to Scene as well if possible.

One currently known issue is with line rendering, which is especially prevalent with wireframes. In some scenes, wireframe objects did not render when SSAA was turned on, and it may potentially thin other lines regardless of set line width. Will look into further.

As a side note, when testing we ran into a weird bug with wireframe rendering. It is an issue with the VTK shader implementation that made it compile improperly on some GPUs, and has been fixed in the most recent version of VTK (9.3) in case someone else runs into the problem as well.

Contributors: Luke Nargang and Sparsh Nair