### PR TITLE
Fixed Pycodestyle errors in fury/actors/odf_slicer.py, fury/actors/peak.py, fury/actors/tensor.py, and fury/data/fetcher.py

### DIFF
--- a/fury/actors/odf_slicer.py
+++ b/fury/actors/odf_slicer.py
@@ -118,7 +118,7 @@ class OdfSlicerActor(Actor):
         (inclusive).
         """
         mask = np.zeros(self.grid_shape, dtype=bool)
-        mask[x1 : x2 + 1, y1 : y2 + 1, z1 : z2 + 1] = True
+        mask[x1: x2 + 1, y1: y2 + 1, z1: z2 + 1] = True
         self.mask = mask
 
         self._update_mapper()
@@ -173,7 +173,10 @@ class OdfSlicerActor(Actor):
         """Dynamically change the sphere used for SH to SF projection.
         """
         if self.B is None:
-            raise ValueError("Can't update sphere when using " 'SF coefficients.')
+            raise ValueError(
+                "Can't update sphere when using "
+                'SF coefficients.'
+                )
         self.vertices = vertices
         if self.affine is not None:
             self.w_verts = self.vertices.dot(self.affine[:3, :3])
@@ -242,8 +245,9 @@ class OdfSlicerActor(Actor):
         if self.radial_scale:
             # apply SF amplitudes to all sphere
             # directions and offset each voxel
-            return np.tile(sph_dirs, (len(offsets), 1)) * sf.reshape(-1, 1) + np.repeat(
-                offsets, len(sph_dirs), axis=0
+            return (
+                np.tile(sph_dirs, (len(offsets), 1)) * sf.reshape(-1, 1)
+                + np.repeat(offsets, len(sph_dirs), axis=0)
             )
         # return scaled spheres offsetted by `offsets`
         return np.tile(sph_dirs, (len(offsets), 1)) * self.scale + np.repeat(
@@ -271,7 +275,8 @@ class OdfSlicerActor(Actor):
                 range_sf = sf.max(axis=-1) - sf.min(axis=-1)
                 rescaled = sf - sf.min(axis=-1, keepdims=True)
                 rescaled[range_sf > 0] /= range_sf[range_sf > 0][..., None]
-                all_colors = create_colormap(rescaled.ravel(), self.colormap) * 255
+                all_colors = create_colormap(rescaled.ravel(), self.colormap) \
+                    * 255
             else:
                 all_colors = np.tile(
                     np.array(self.colormap).reshape(1, 3),

--- a/fury/actors/peak.py
+++ b/fury/actors/peak.py
@@ -91,9 +91,9 @@ class PeakActor(Actor):
                 xyz = np.asarray(center)
             else:
                 xyz = w_pos[idx, :]
-            valid_peaks = np.nonzero(np.abs(valid_dirs[idx, :, :]).max(axis=-1) > 0.0)[
-                0
-            ]
+            valid_peaks = np.nonzero(
+                    np.abs(valid_dirs[idx, :, :]).max(axis=-1) > 0.0
+                    )[0]
             for direction in valid_peaks:
                 if values is not None:
                     pv = values[center][direction]
@@ -152,14 +152,20 @@ class PeakActor(Actor):
             uniform vec3 lowRanges;
             uniform vec3 highRanges;
             """
-        orient_to_rgb = import_fury_shader(pjoin('utils', 'orient_to_rgb.glsl'))
+        orient_to_rgb = import_fury_shader(
+                pjoin('utils', 'orient_to_rgb.glsl')
+                )
         visible_cross_section = import_fury_shader(
             pjoin('interaction', 'visible_cross_section.glsl')
         )
-        visible_range = import_fury_shader(pjoin('interaction', 'visible_range.glsl'))
+        visible_range = import_fury_shader(
+                pjoin('interaction', 'visible_range.glsl')
+                )
 
         vs_dec = compose_shader([vs_var_dec, orient_to_rgb])
-        fs_dec = compose_shader([fs_var_dec, visible_cross_section, visible_range])
+        fs_dec = compose_shader(
+                [fs_var_dec, visible_cross_section, visible_range]
+                )
 
         vs_impl = """
             centerVertexMCVSOutput = center;
@@ -292,7 +298,7 @@ def _orientation_colors(points, cmap='rgb_standard'):
     """
     if cmap.lower() == 'rgb_standard':
         col_list = [
-            orient2rgb(points[i + 1] - points[i]) for i in range(0, len(points), 2)
+                orient2rgb(points[i + 1] - points[i]) for i in range(0, len(points), 2)
         ]
     elif cmap.lower() == 'boys_standard':
         col_list = [
@@ -359,7 +365,8 @@ def _peaks_colors_from_points(points, colors=None, points_per_line=2):
         if len(colors) == num_lines:
             pnts_colors = np.repeat(colors, points_per_line, axis=0)
             if colors.ndim == 1:  # Scalar per line
-                color_array = numpy_support.numpy_to_vtk(pnts_colors, deep=True)
+                color_array = \
+                        numpy_support.numpy_to_vtk(pnts_colors, deep=True)
                 colors_are_scalars = True
             elif colors.ndim == 2:  # RGB(A) color per line
                 global_opacity = 1 if colors.shape[1] == 3 else -1
@@ -409,12 +416,18 @@ def _points_to_vtk_cells(points, points_per_line=2):
     this actor the creation of this array requires a 2 points padding
     between indices.
     """
-    offset = np.asarray(list(range(0, num_pnts + 1, points_per_line)), dtype=int)
+    offset = np.asarray(
+            list(range(0, num_pnts + 1, points_per_line)), dtype=int
+            )
 
     vtk_array_type = numpy_support.get_vtk_array_type(connectivity.dtype)
     cell_array.SetData(
-        numpy_support.numpy_to_vtk(offset, deep=True, array_type=vtk_array_type),
-        numpy_support.numpy_to_vtk(connectivity, deep=True, array_type=vtk_array_type),
+        numpy_support.numpy_to_vtk(
+            offset, deep=True, array_type=vtk_array_type
+            ),
+        numpy_support.numpy_to_vtk(
+            connectivity, deep=True, array_type=vtk_array_type
+            ),
     )
 
     cell_array.SetNumberOfCells(num_cells)

--- a/fury/actors/tensor.py
+++ b/fury/actors/tensor.py
@@ -422,7 +422,7 @@ def main_dir_uncertainty(evals, evecs, signal, sigma, b_matrix):
     analysis described in [1]_. The idea is to estimate the variance of the
     main eigenvector which corresponds to the main direction of diffusion,
     directly from estimated D and its estimated covariance matrix
-    :math:`\Delta D` (see [2]_, equation 4). The angle :math:`\\Theta`
+    :math:`Delta D` (see [2]_, equation 4). The angle :math:`\\Theta`
     between the perturbed principal eigenvector of D,
     :math:`\\epsilon_1+\\Delta\\epsilon_1`, and the estimated eigenvector
     :math:`\\epsilon_1`, measures the angular deviation of the main fiber

--- a/fury/data/fetcher.py
+++ b/fury/data/fetcher.py
@@ -28,8 +28,10 @@ else:
 UW_RW_URL = \
     "https://digital.lib.washington.edu/researchworks/bitstream/handle/"
 
-NEW_ICONS_DATA_URL = \
-    "https://raw.githubusercontent.com/fury-gl/fury-data/master/icons/new_icons/"
+NEW_ICONS_DATA_URL = (
+    "https://raw.githubusercontent.com/fury-gl/fury-data/master/icons/"
+    "new_icons/"
+)
 
 CUBEMAP_DATA_URL = \
     "https://raw.githubusercontent.com/fury-gl/fury-data/master/cubemaps/"
@@ -183,7 +185,7 @@ def fetch_data(files, folder, data_size=None):
 
         Raises if the sha checksum of the file does not match the expected
         value. The downloaded file is not deleted when this error is raised.
-    
+
     """
     if not os.path.exists(folder):
         print("Creating new folder %s" % (folder))
@@ -318,7 +320,6 @@ async def _download(session, url, filename, size=None):
         Name of the downloaded file (e.g. BoxTextured.gltf)
     size : int, optional
         Length of the content in bytes
-    
     """
     if not os.path.exists(filename):
         print(f'Downloading: {filename}')
@@ -414,7 +415,7 @@ def fetch_gltf(name=None, mode='glTF'):
     -------
     filenames : tuple
         tuple of feteched filenames (list) and folder (str) path.
-    
+
     """
     if platform.system().lower() == "windows":
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
@@ -458,11 +459,13 @@ fetch_viz_new_icons = _make_fetcher(
     ["circle-pressed.png", "circle.png", "delete-pressed.png", "delete.png",
      "drawing-pressed.png", "drawing.png", "line-pressed.png", "line.png",
      "polyline-pressed.png", "polyline.png", "quad-pressed.png", "quad.png",
-     "resize-pressed.png", "resize.png", "selection-pressed.png", "selection.png"],
+     "resize-pressed.png", "resize.png", "selection-pressed.png",
+     "selection.png"],
     ["circle-pressed.png", "circle.png", "delete-pressed.png", "delete.png",
      "drawing-pressed.png", "drawing.png", "line-pressed.png", "line.png",
      "polyline-pressed.png", "polyline.png", "quad-pressed.png", "quad.png",
-     "resize-pressed.png", "resize.png", "selection-pressed.png", "selection.png"],
+     "resize-pressed.png", "resize.png", "selection-pressed.png",
+     "selection.png"],
     ["CD859F244DF1BA719C65C869C3FAF6B8563ABF82F457730ADBFBD7CA72DDB7BC",
      "5896BDC9FF9B3D1054134D7D9A854677CE9FA4E64F494F156BB2E3F0E863F207",
      "937C46C25BC38B62021B01C97A4EE3CDE5F7C8C4A6D0DB75BF4E4CACE2AF1226",
@@ -720,7 +723,7 @@ def read_viz_gltf(fname, mode='glTF'):
     -------
     path : str
         Complete path of models.
-    
+
     """
     folder = pjoin(fury_home, 'glTF')
     model = pjoin(folder, fname)
@@ -743,7 +746,7 @@ def list_gltf_sample_models():
     model_names : list
         Lists the name of glTF sample from
         https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0
-    
+
     """
     DATA_DIR = pjoin(dirname(__file__), 'files')
     with open(pjoin(DATA_DIR, 'KhronosGltfSamples.json'), 'r') as f:


### PR DESCRIPTION
This Pull Request corrects errors in fury/actors/odf_slicer.py, fury/actors/peak.py, fury/actors/tensor.py and fury/data/fetcher.py.

fix:  #876

The following changes have been made:

    Files: fury/actors/odf_slicer.py, fury/actors/peak.py and fury/data/fetcher.py
        White spaces correction
        error correction: E501 line too long

    File fury/actors/tensor.py:
           error correction: W605 invalid escape sequence '\D'

Tests:

I've run some tests to make sure the changes haven't affected the way the code works.

Coding conventions:

I have followed PEP8 coding conventions in this Pull Request.

Acknowledgements:

I thank the project contributors for their work and time.

I hope this Pull Request will be useful and that it will be integrated into the project.

Please don't hesitate to ask me questions if you need further information.

I'm still doing my best to fix the other pycodestyle errors in the other files.


