### PR TITLE
NF: Add keyword_only decorator to enforce keyword-only arguments

### DIFF
--- a/fury/tests/test_decorators.py
+++ b/fury/tests/test_decorators.py
@@ -2,7 +2,7 @@
 
 import numpy.testing as npt
 
-from fury.decorators import doctest_skip_parser
+from fury.decorators import doctest_skip_parser, keyword_only
 from fury.testing import assert_true
 
 HAVE_AMODULE = False
@@ -49,3 +49,20 @@ def test_skipper():
     del HAVE_AMODULE
     f.__doc__ = docstring
     npt.assert_raises(NameError, doctest_skip_parser, f)
+
+
+def test_keyword_only():
+    @keyword_only
+    def f(*, a, b):
+        return a + b
+
+    npt.assert_equal(f(a=1, b=2), 3)
+    npt.assert_raises(TypeError, f, a=1, b=2, c=2)
+    npt.assert_raises(TypeError, f, 1, 2)
+    npt.assert_raises(TypeError, f, 1, b=2)
+    npt.assert_raises(TypeError, f, a=1, b=2)
+    npt.assert_raises(
+        TypeError,
+        f,
+        a=1,
+    )


### PR DESCRIPTION
Description:

Added @keyword_only decorator to enforce keyword-only arguments in project functions.

Modification details:

   -  Creation of the @keyword_only decorator to ensure that functions can only be called with arguments specified solely by keyword.
   -  Full documentation of the new decorator, including usage examples and explanations of how it works.
   -  Added unit tests to ensure proper operation of the new decorator.

This contribution represents the first step towards applying the @keyword_only decorator to the appropriate functions in the project. Current modifications include the creation of the decorator, associated documentation and unit tests. The next step will be to identify and apply the decorator to relevant functions throughout the project. 