### PR TITLE
[TYPO] Typo fix in code

### DIFF
--- a/fury/gltf.py
+++ b/fury/gltf.py
@@ -813,8 +813,8 @@ class glTF:
         if bone_id in self.animation_channels[channel_name]:
             transforms = self.animation_channels[channel_name][bone_id]
             timestamps = transforms["timestamps"]
-            metrices = transforms["matrix"]
-            for time, matrix in zip(timestamps, metrices):
+            matrices = transforms["matrix"]
+            for time, matrix in zip(timestamps, matrices):
                 animation.set_keyframe("transform", time[0], matrix)
         else:
             animation.set_keyframe("transform", 0.0, orig_transform)
@@ -934,10 +934,10 @@ class glTF:
                 weights = self.morph_weights[i]
                 animation = Animation()
                 timestamps = transforms["timestamps"]
-                metrices = transforms["matrix"]
-                metrices = np.array(metrices).reshape(-1, len(weights))
+                matrices = transforms["matrix"]
+                matrices = np.array(matrices).reshape(-1, len(weights))
 
-                for time, weights in zip(timestamps, metrices):
+                for time, weights in zip(timestamps, matrices):
                     animation.set_keyframe("morph", time[0], weights)
                 root_animation.add(animation)
 

--- a/fury/tests/test_stream.py
+++ b/fury/tests/test_stream.py
@@ -667,7 +667,7 @@ def test_circular_queue():
 
 def test_queue_and_webserver():
     """Check if the correct
-    envent ids and the data are stored in the
+    event ids and the data are stored in the
     correct positions
     """
     max_size = 3


### PR DESCRIPTION
Typo fixes in `fury/gltf.py` and `fury/tests/test_stream.py`.

`codespell` was flagging them while making GSoC blogs.

This CI in `codespell` is flagging a typo which I've fixed inside #890