### PR TITLE
fix: gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,8 +59,8 @@ docs/source/generated/
 docs/source/api
 docs/source/auto_examples
 docs/source/auto_tutorials
-docs/source/sg_execution_times.rst
 docs/source/reference
+docs/source/sg_execution_times.rst
 docs/examples/*.png
 docs/examples/*.vtk
 docs/examples/*.gif

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ docs/source/generated/
 docs/source/api
 docs/source/auto_examples
 docs/source/auto_tutorials
+docs/source/sg_execution_times.rst
 docs/source/reference
 docs/examples/*.png
 docs/examples/*.vtk


### PR DESCRIPTION
`docs/source/sg_execution_times.rst` is generated during sphinx doc generation. This should be git ignored.