### PR TITLE
CI: remove 3.8 add 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', 3.11]
+        python-version: [3.9, '3.10', 3.11, 3.12]
         os: [ubuntu-latest, macos-latest, windows-latest]
         platform: [x64]
         install-type: [pip, ]  # conda]
@@ -34,13 +34,13 @@ jobs:
         use-pre: [false]
         include:
           - os: macos-latest # ubuntu-latest
-            python-version: '3.10'
+            python-version: 3.11
             install-type: pip
             depends: OPTIONAL_DEPS
             coverage: true
             use-pre: false
           - os: ubuntu-latest
-            python-version: '3.10'
+            python-version: 3.12
             install-type: pip
             depends: OPTIONAL_DEPS
             coverage: false


### PR DESCRIPTION
Python 3.8 is deprecated so removing this CI and adding 3.12