### PR TITLE
Release 0.11.0 Preparation 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -63,3 +63,8 @@ Francois Rheault <francois.m.rheault@usherbrooke.ca> frheault <francois.m.rheaul
 Dwij Raj Hari <dwijrajhari@gmail.com> Dwij Raj Hari <75260253+dwijrajhari@users.noreply.github.com>
 Tania Castillo <tvcastillod@unal.edu.co> tvcastillod <tvcastillod@unal.edu.co>
 Tania Castillo <tvcastillod@unal.edu.co> Tania Castillo <31288525+tvcastillod@users.noreply.github.com>
+Wachiou BOURAÏMA <wachioubouraima56@gmail.com> Wachiou BOURAÏMA <100234404+WassCodeur@users.noreply.github.com>
+Ishan Kamboj <ISHANKAMBOJ35@GMAIL.COM> Ishan Kamboj <67258435+IshanKamboj@users.noreply.github.com>
+Robin Roy <robinroy.work@gmail.com> Robin Roy <115863770+robinroy03@users.noreply.github.com>
+Robin Roy <robinroy.work@gmail.com> Robin <robinroy.work@gmail.com>
+Kaustav Deka <mailerdeka@gmail.com> Kaustav Deka <116963260+deka27@users.noreply.github.com>

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,71 +17,91 @@ Contributors
 
 * Serge Koudoro
 * Eleftherios Garyfallidis
-* Soham Biswas
+* Mohamed Agour
+* Praneeth Shetty
 * Javier Guaje
-* Sajag Swami
+* Anand Shivam
 * Bruno Messias
+* Soham Biswas
+* Sajag Swami
+* Antriksh Misri
+* Tania Castillo
 * Ranveer Aggarwal
 * Lenix Lobo
+* Joao Victor Dell Agli
 * Marc-Alexandre Côté
 * Melina Raglin
-* Antriksh Misri
-* Karan
 * Ariel Rokem
+* Karan
+* maharshigor
+* Filipi Nascimento Silva
 * David Reagan
-* Vivek Choudhary
-* Prashil
-* Saransh Jain
 * Nasim Anousheh
+* Prashil
+* Vivek Choudhary
+* Saransh Jain
 * Shreyas Bhujbal
 * Tushar
-* Matthew Brett
+* Wachiou BOURAÏMA
+* Zhiwen Shi
 * Charles Poirier
+* Ishan Kamboj
+* Matthew Brett
+* Frank Cerasoli
+* Sreekar Chigurupati
+* Francois Rheault
 * Naman Bansal
+* Robin Roy
 * Etienne St-Onge
 * Kesshi Jordan
-* Praneeth Shetty
-* ibrahimAnis
-* Bago Amirbekian
-* Omar Ocegueda
 * Amit Chaudhari
-* Meha Bhalodiya
-* Kevin Sitek
-* Sanjay Marreddi
-* ChenCheng0630
+* Bago Amirbekian
 * Jon Haitz Legarreta Gorroño
+* Omar Ocegueda
+* ibrahimAnis
+* Kevin Sitek
+* Meha Bhalodiya
+* Sanjay Marreddi
+* sparshg
+* ChenCheng0630
 * Gregory R. Lee
-* Filipi Nascimento Silva
-* Liam Donohue
-* Anand Shivam
-* Shahnawaz Ahmed
-* Tingyi Wanyan
 * Enes Albay
+* Liam Donohue
+* Rohit Kharsan
+* Shahnawaz Ahmed
 * Stefan van der Walt
-* PrayasJ
+* Tingyi Wanyan
+* Dwij Raj Hari
 * Guillaume Favelier
+* Johny Daras
+* PrayasJ
 * Samuel St-Jean
-* Gottipati Gautam
-* theaverageguy
-* Hariharan Ayappane
 * Bishakh Ghosh
-* Jhalak Gupta
+* Gottipati Gautam
+* Hariharan Ayappane
+* Maharshi Gor
+* theaverageguy
 * Aju100
-* Christopher Nguyen
 * Alexandre Gauvin
-* Scott Trinkle
+* Christopher Nguyen
+* Jhalak Gupta
 * Jiri Borovec
 * Marssis
+* Sara Hamza
+* Scott Trinkle
+* Siddharth Gautam
+* dependabot[bot]
 * Adam Rybinski
-* LoopThrough-i-j
-* Ian Nimmo-Smith
 * Aman Soni
-* Gauvin Alexandre
-* Pietro Astolfi
-* Gurdit Siyan
-* Devanshu Modi
 * Daniel S. Katz
+* Devanshu Modi
+* Gauvin Alexandre
+* Gurdit Siyan
+* Ian Nimmo-Smith
 * Jacob Wasserth
-* Yaroslav Halchenko
+* Kaustav Deka
+* LoopThrough-i-j
 * MIHIR
-* Shivam Anand
+* Pietro Astolfi
+* Yaroslav Halchenko
+* sailesh

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -125,15 +125,15 @@ Checklist before Releasing
   outstanding issues that can be closed, and whether there are any issues that
   should delay the release.  Label them !
 
-* Check whether there are no build failing on `Travis`.
+* Check whether there are no build failing on `GitHub Actions`.
 
 * Review and update the release notes. Get a partial list of contributors with something like::
 
-      git shortlog -nse v0.1.0..
+      git shortlog -nse v0.10.0..
 
-  where ``v0.1.0`` was the last release tag name.
+  where ``v0.10.0`` was the last release tag name.
 
-  Then manually go over ``git shortlog v0.1.0..`` to make sure the release notes
+  Then manually go over ``git shortlog v0.10.0..`` to make sure the release notes
   are as complete as possible and that every contributor was recognized.
 
 * Use the opportunity to update the ``.mailmap`` file if there are any duplicate
@@ -145,16 +145,18 @@ Checklist before Releasing
 
 * Generate release notes. Go to ``docs/source/ext`` and run ``github_tools.py`` script the following way::
 
-    $ python github_tools.py --tag=v0.1.0 --save --version=0.2.0
+    $ python github_tools.py --tag=v0.10.0 --save --version=0.11.0
 
-  This command will generate a new file named ``release0.2.0.rst`` in ``release_notes`` folder.
+  This command will generate a new file named ``release0.11.0.rst`` in ``release_notes`` folder.
+
+* Add in ``release-history.rst`` the newly created file ``release0.11.0.rst``.
 
 * Check the examples and tutorial - we really need an automated check here.
 
 * Make sure all tests pass on your local machine (from the ``<fury root>`` directory)::
 
     cd ..
-    pytest -s --verbose --doctest-modules fury
+    pytest -svv --doctest-modules fury
     cd fury # back to the root directory
 
 * Check the documentation doctests::

--- a/docs/source/posts/2024/2024-07-31-release-announcement.rst
+++ b/docs/source/posts/2024/2024-07-31-release-announcement.rst
@@ -1,0 +1,48 @@
+FURY 0.11.0 Released
+===================
+
+.. post:: July 31 2024
+   :author: skoudoro
+   :tags: fury
+   :category: release
+
+
+The FURY project is happy to announce the release of FURY 0.11.0!
+FURY is a free and open source software library for scientific visualization and 3D animations.
+
+You can show your support by `adding a star <https://github.com/fury-gl/fury/stargazers>`_ on FURY github project.
+
+This Release is mainly a maintenance release. The **major highlights** of this release are:
+
+.. include:: ../../release_notes/releasev0.11.0.rst
+    :start-after: --------------
+    :end-before: Details
+
+.. note:: The complete release notes are available :ref:`here <releasev0.11.0>`
+
+**To upgrade or install FURY**
+
+Run the following command in your terminal::
+
+    pip install --upgrade fury
+
+or::
+
+    conda install -c conda-forge fury
+
+
+**Questions or suggestions?**
+
+For any questions go to http://fury.gl, or send an e-mail to fury@python.org
+We can also join our `discord community <https://discord.gg/6btFPPj>`_
+
+We would like to thanks to :ref:`all contributors <community>` for this release:
+
+.. include:: ../../release_notes/releasev0.11.0.rst
+    :start-after: commits.
+    :end-before: We closed
+
+
+On behalf of the :ref:`FURY developers <community>`,
+
+Serge K.

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -7,6 +7,7 @@ For a full list of the features implemented in the most recent release cycle, ch
 .. toctree::
    :maxdepth: 1
 
+   release_notes/releasev0.11.0
    release_notes/releasev0.10.0
    release_notes/releasev0.9.0
    release_notes/releasev0.8.0

--- a/docs/source/release_notes/releasev0.11.0.rst
+++ b/docs/source/release_notes/releasev0.11.0.rst
@@ -1,0 +1,125 @@
+.. _releasev0.11.0:
+
+==============================
+ Release notes v0.11.0
+==============================
+
+Quick Overview
+--------------
+
+* New SPEC: Keyword-only adopted.
+* New SPEC: Lazy loading adopted.
+* New standard for coding style.
+* Documentation updated.
+* Website updated.
+
+Details
+-------
+
+GitHub stats for 2024/02/27 - 2024/07/31 (tag: v0.10.0)
+
+These lists are automatically generated, and may be incomplete or contain duplicates.
+
+The following 7 authors contributed 70 commits.
+
+* Ishan Kamboj
+* Jon Haitz Legarreta Gorroño
+* Kaustav Deka
+* Robin Roy
+* Serge Koudoro
+* Wachiou BOURAÏMA
+* dependabot[bot]
+
+
+We closed a total of 83 issues, 35 pull requests and 48 regular issues;
+this is the full list (generated with the script
+:file:`tools/github_stats.py`):
+
+Pull Requests (35):
+
+* :ghpull:`919`: NF: Implementation of lazy_loading in `fury.stream.server`
+* :ghpull:`918`: DOCS: simplify  FURY import
+* :ghpull:`916`: DOCS: simplify import
+* :ghpull:`915`: [DOCS][FIX]: Update variable descriptions in visualization examples
+* :ghpull:`907`: NF: Add lazy_loader feature  in FURY
+* :ghpull:`914`: DOC: GSoC Blogs Week 6, 7, 8
+* :ghpull:`911`: [DOC][FIX] fix typos in blog posts
+* :ghpull:`913`: Fix: Replace setuptools.extern.packaging with direct packaging import
+* :ghpull:`909`: RF: add keyword arguments decorator (warn_on_args_to_kwargs) in the module: stream
+* :ghpull:`902`: RF: Add keyword arguments decorator to module: UI
+* :ghpull:`899`: RF: Add keyword arguments to module: animation
+* :ghpull:`901`: RF: Add keyword arguments decorator to module: shaders
+* :ghpull:`900`: RF: Add keyword arguments to module: data
+* :ghpull:`898`: RF: Add keyword arguments to module: actors
+* :ghpull:`888`: NF: Add keyword_only decorator to enforce keyword-only arguments
+* :ghpull:`908`: DOC: add Wachiou's week5 Blog post
+* :ghpull:`906`: [DOC] GSoC week 4 and 5
+* :ghpull:`905`: DOC: My weeks 3 and 4 blog post
+* :ghpull:`903`: CI: remove 3.8 add 3.12
+* :ghpull:`896`: DOC: GSoC Week 2 & 3
+* :ghpull:`897`: DOC:  Add wachiou's week 2 blog post
+* :ghpull:`892`: [DOC] week 1 blog GSoC
+* :ghpull:`894`: DOC: Wachiou Week 1 Blog Post
+* :ghpull:`893`: fix: gitignore
+* :ghpull:`889`: DOC: Add Wachiou BOURAIMA GSoC'24 first  Blog post
+* :ghpull:`890`: [DOC] GSoC Blog: Robin Roy (Community Bonding)
+* :ghpull:`891`: [TYPO] Typo fix in code
+* :ghpull:`886`: DOC: Document the coding style enforcement framework
+* :ghpull:`881`: STYLE: Format code using `ruff`
+* :ghpull:`884`: build(deps): bump pre-commit/action from 3.0.0 to 3.0.1 in the actions group
+* :ghpull:`885`: Fix pycodestyle stream
+* :ghpull:`877`: Fixed Pycodestyle errors in fury/actors/odf_slicer.py, fury/actors/peak.py, fury/actors/tensor.py, and fury/data/fetcher.py
+* :ghpull:`855`: Fix #780 : Added top/bottom for Tabs Bar in Tab Panel UI
+* :ghpull:`879`: STYLE: Transition to `ruff` to enforce import statement sorting
+* :ghpull:`868`: Added Dark mode, Fixed Search Bar for documentation site
+
+Issues (48):
+
+* :ghissue:`917`: `fury.stream.server` is missing lazy_loading
+* :ghissue:`919`: NF: Implementation of lazy_loading in `fury.stream.server`
+* :ghissue:`918`: DOCS: simplify  FURY import
+* :ghissue:`916`: DOCS: simplify import
+* :ghissue:`915`: [DOCS][FIX]: Update variable descriptions in visualization examples
+* :ghissue:`907`: NF: Add lazy_loader feature  in FURY
+* :ghissue:`914`: DOC: GSoC Blogs Week 6, 7, 8
+* :ghissue:`911`: [DOC][FIX] fix typos in blog posts
+* :ghissue:`912`: Deprecator bug with setuptools >=71.0.3
+* :ghissue:`913`: Fix: Replace setuptools.extern.packaging with direct packaging import
+* :ghissue:`910`: ENH: Add a GHA workflow to build docs
+* :ghissue:`909`: RF: add keyword arguments decorator (warn_on_args_to_kwargs) in the module: stream
+* :ghissue:`902`: RF: Add keyword arguments decorator to module: UI
+* :ghissue:`899`: RF: Add keyword arguments to module: animation
+* :ghissue:`901`: RF: Add keyword arguments decorator to module: shaders
+* :ghissue:`900`: RF: Add keyword arguments to module: data
+* :ghissue:`898`: RF: Add keyword arguments to module: actors
+* :ghissue:`888`: NF: Add keyword_only decorator to enforce keyword-only arguments
+* :ghissue:`908`: DOC: add Wachiou's week5 Blog post
+* :ghissue:`906`: [DOC] GSoC week 4 and 5
+* :ghissue:`905`: DOC: My weeks 3 and 4 blog post
+* :ghissue:`903`: CI: remove 3.8 add 3.12
+* :ghissue:`896`: DOC: GSoC Week 2 & 3
+* :ghissue:`897`: DOC:  Add wachiou's week 2 blog post
+* :ghissue:`895`: DOC: Add My week 2 blog post
+* :ghissue:`892`: [DOC] week 1 blog GSoC
+* :ghissue:`894`: DOC: Wachiou Week 1 Blog Post
+* :ghissue:`893`: fix: gitignore
+* :ghissue:`889`: DOC: Add Wachiou BOURAIMA GSoC'24 first  Blog post
+* :ghissue:`890`: [DOC] GSoC Blog: Robin Roy (Community Bonding)
+* :ghissue:`871`: `actor.texture` hides all other actors from the scene
+* :ghissue:`891`: [TYPO] Typo fix in code
+* :ghissue:`887`: NF: Add keyword_only decorator to enforce keyword-only arguments
+* :ghissue:`886`: DOC: Document the coding style enforcement framework
+* :ghissue:`881`: STYLE: Format code using `ruff`
+* :ghissue:`884`: build(deps): bump pre-commit/action from 3.0.0 to 3.0.1 in the actions group
+* :ghissue:`883`: Wassiu contributions
+* :ghissue:`885`: Fix pycodestyle stream
+* :ghissue:`880`: improved readability in fetcher.py
+* :ghissue:`882`: Wassiu contributions
+* :ghissue:`876`:   Pycodestyle errors in fury/actors/odf_slicer.py, fury/actors/peak.py, fury/actors/tensor.py, and fury/data/fetcher.py
+* :ghissue:`877`: Fixed Pycodestyle errors in fury/actors/odf_slicer.py, fury/actors/peak.py, fury/actors/tensor.py, and fury/data/fetcher.py
+* :ghissue:`878`: Docs: Remove '$' from fury/docs/README.md commands
+* :ghissue:`780`: Tabs bar positioning in TabUI
+* :ghissue:`855`: Fix #780 : Added top/bottom for Tabs Bar in Tab Panel UI
+* :ghissue:`879`: STYLE: Transition to `ruff` to enforce import statement sorting
+* :ghissue:`868`: Added Dark mode, Fixed Search Bar for documentation site
+* :ghissue:`867`: Added Dark mode, Fixed Search Bar for documentation site

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -675,7 +675,7 @@ def streamtube(
     >>> scene = window.Scene()
     >>> lines = [np.random.rand(10, 3), np.random.rand(20, 3)]
     >>> colors = np.random.rand(2, 3)
-    >>> c = actor.streamtube(lines, colores=colors)
+    >>> c = actor.streamtube(lines, colors=colors)
     >>> scene.add(c)
     >>> #window.show(scene)
 
@@ -2064,9 +2064,9 @@ def disk(
     >>> dirs = np.random.rand(5, 3)
     >>> colors = np.random.rand(5, 4)
     >>> actor = actor.disk(centers, dirs, colors,
-    >>>                    rinner=.1, router=.8, cresolution=30)
+    ...                    rinner=.1, router=.8, cresolution=30)
     >>> scene.add(actor)
-    >>> window.show(scene)
+    >>> # window.show(scene)
 
     """
     if faces is None:
@@ -3747,19 +3747,19 @@ def markers(
     >>> centers = np.random.normal(size=(n, 3), scale=10)
     >>> colors = np.random.rand(n, 4)
     >>> nodes_actor = actor.markers(
-            centers,
-            marker=markers,
-            edge_width=.1,
-            edge_color=[255, 255, 0],
-            colors=colors,
-            scales=10,
-        )
+    ...     centers,
+    ...     marker=markers,
+    ...     edge_width=.1,
+    ...     edge_color=[255, 255, 0],
+    ...     colors=colors,
+    ...     scales=10,
+    ... )
     >>> center = np.random.normal(size=(1, 3), scale=10)
     >>> nodes_3d_actor = actor.markers(
-            center,
-            marker='3d',
-            scales=5,
-        )
+    ...     center,
+    ...     marker='3d',
+    ...     scales=5,
+    ... )
     >>> scene.add(nodes_actor, nodes_3d_actor)
     >>> # window.show(scene, size=(600, 600))
 

--- a/fury/animation/animation.py
+++ b/fury/animation/animation.py
@@ -283,11 +283,12 @@ class Animation:
         Notes
         -----
         Keyframes can be on any of the following forms:
+        >>> import numpy as np
         >>> key_frames_simple = {1: [1, 2, 1], 2: [3, 4, 5]}
         >>> key_frames_bezier = {1: {'value': [1, 2, 1]},
-        >>>                       2: {'value': [3, 4, 5], 'in_cp': [1, 2, 3]}}
+        ...                      2: {'value': [3, 4, 5], 'in_cp': [1, 2, 3]}}
         >>> pos_keyframes = {1: np.array([1, 2, 3]), 3: np.array([5, 5, 5])}
-        >>> Animation.set_keyframes('position', pos_keyframes)
+        >>> Animation.set_keyframes('position', pos_keyframes) # doctest: +SKIP
 
         """
         for t, keyframe in keyframes.items():
@@ -377,8 +378,9 @@ class Animation:
         is_evaluator: bool, optional
             Specifies whether the `interpolator` is time-only based evaluation
             function that does not depend on keyframes such as:
-            >>> def get_position(t):
-            >>>     return np.array([np.sin(t), np.cos(t) * 5, 5])
+
+            def get_position(t):
+                return np.array([np.sin(t), np.cos(t) * 5, 5])
 
         Other Parameters
         ----------------
@@ -395,10 +397,9 @@ class Animation:
 
         Examples
         --------
-        >>> Animation.set_interpolator('position', linear_interpolator)
-
-        >>> pos_fun = lambda t: np.array([np.sin(t), np.cos(t), 0])
-        >>> Animation.set_interpolator('position', pos_fun)
+        >>> Animation.set_interpolator('position', linear_interpolator) # doctest: +SKIP
+        >>> pos_fun = lambda t: np.array([np.sin(t), np.cos(t), 0]) # doctest: +SKIP
+        >>> Animation.set_interpolator('position', pos_fun) # doctest: +SKIP
 
         """
         attrib_data = self._get_attribute_data(attrib)
@@ -463,7 +464,7 @@ class Animation:
 
         Examples
         --------
-        >>> Animation.set_position_interpolator(spline_interpolator, degree=5)
+        >>> Animation.set_position_interpolator(spline_interpolator, degree=5) # doctest: +SKIP
 
         """
         self.set_interpolator(
@@ -485,7 +486,7 @@ class Animation:
 
         Examples
         --------
-        >>> Animation.set_scale_interpolator(step_interpolator)
+        >>> Animation.set_scale_interpolator(step_interpolator) # doctest: +SKIP
 
         """
         self.set_interpolator("scale", interpolator, is_evaluator=is_evaluator)
@@ -505,7 +506,7 @@ class Animation:
 
         Examples
         --------
-        >>> Animation.set_rotation_interpolator(slerp)
+        >>> Animation.set_rotation_interpolator(slerp) # doctest: +SKIP
 
         """
         self.set_interpolator("rotation", interpolator, is_evaluator=is_evaluator)
@@ -525,7 +526,7 @@ class Animation:
 
         Examples
         --------
-        >>> Animation.set_color_interpolator(lab_color_interpolator)
+        >>> Animation.set_color_interpolator(lab_color_interpolator) # doctest: +SKIP
 
         """
         self.set_interpolator("color", interpolator, is_evaluator=is_evaluator)
@@ -545,7 +546,7 @@ class Animation:
 
         Examples
         --------
-        >>> Animation.set_opacity_interpolator(step_interpolator)
+        >>> Animation.set_opacity_interpolator(step_interpolator) # doctest: +SKIP
 
         """
         self.set_interpolator("opacity", interpolator, is_evaluator=is_evaluator)
@@ -624,8 +625,8 @@ class Animation:
 
         Examples
         --------
-        >>> pos_keyframes = {1, np.array([0, 0, 0]), 3, np.array([50, 6, 6])}
-        >>> Animation.set_position_keyframes(pos_keyframes)
+        >>> pos_keyframes = {1, (0, 0, 0), 3, (50, 6, 6)}
+        >>> Animation.set_position_keyframes(pos_keyframes) # doctest: +SKIP
 
         """
         self.set_keyframes("position", keyframes)
@@ -704,8 +705,8 @@ class Animation:
 
         Examples
         --------
-        >>> scale_keyframes = {1, np.array([1, 1, 1]), 3, np.array([2, 2, 3])}
-        >>> Animation.set_scale_keyframes(scale_keyframes)
+        >>> scale_keyframes = {1, (1, 1, 1), 3, (2, 2, 3)}
+        >>> Animation.set_scale_keyframes(scale_keyframes) # doctest: +SKIP
 
         """
         self.set_keyframes("scale", keyframes)
@@ -735,8 +736,9 @@ class Animation:
 
         Examples
         --------
-        >>> color_keyframes = {1, np.array([1, 0, 1]), 3, np.array([0, 0, 1])}
-        >>> Animation.set_color_keyframes(color_keyframes)
+        >>> import numpy as np
+        >>> color_keyframes = {1, (1, 0, 1), 3, (0, 0, 1)}
+        >>> Animation.set_color_keyframes(color_keyframes) # doctest: +SKIP
 
         """
         self.set_keyframes("color", keyframes)
@@ -770,8 +772,8 @@ class Animation:
 
         Examples
         --------
-        >>> opacity = {1, np.array([1, 1, 1]), 3, np.array([2, 2, 3])}
-        >>> Animation.set_scale_keyframes(opacity)
+        >>> opacity = {1, (1, 1, 1), 3, (2, 2, 3)}
+        >>> Animation.set_scale_keyframes(opacity) # doctest: +SKIP
 
         """
         self.set_keyframes("opacity", keyframes)
@@ -1299,8 +1301,8 @@ class CameraAnimation(Animation):
 
         Examples
         --------
-        >>> focal_pos = {0, np.array([1, 1, 1]), 3, np.array([20, 0, 0])}
-        >>> CameraAnimation.set_focal_keyframes(focal_pos)
+        >>> focal_pos = {0, (1, 1, 1), 3, (20, 0, 0)}
+        >>> CameraAnimation.set_focal_keyframes(focal_pos) # doctest: +SKIP
 
         """
         self.set_keyframes("focal", keyframes)
@@ -1318,8 +1320,8 @@ class CameraAnimation(Animation):
 
         Examples
         --------
-        >>> view_ups = {0, np.array([1, 0, 0]), 3, np.array([0, 1, 0])}
-        >>> CameraAnimation.set_view_up_keyframes(view_ups)
+        >>> view_ups = {0, np.array([1, 0, 0]), 3, np.array([0, 1, 0])} # doctest: +SKIP
+        >>> CameraAnimation.set_view_up_keyframes(view_ups) # doctest: +SKIP
 
         """
         self.set_keyframes("view_up", keyframes)

--- a/fury/animation/animation.py
+++ b/fury/animation/animation.py
@@ -466,7 +466,7 @@ class Animation:
         --------
         >>> Animation.set_position_interpolator(spline_interpolator, degree=5) # doctest: +SKIP
 
-        """
+        """  # noqa: E501
         self.set_interpolator(
             "position", interpolator, is_evaluator=is_evaluator, **kwargs
         )

--- a/fury/animation/interpolator.py
+++ b/fury/animation/interpolator.py
@@ -25,7 +25,7 @@ def spline_interpolator(keyframes, degree):
     keyframes: dict
         Keyframe data containing timestamps and values to form the spline
         curve. Data should be on the following format:
-        >>> {1: {'value': np.array([...])}, 2: {'value': np.array([...])}}
+        {1: {'value': np.array([...])}, 2: {'value': np.array([...])}}
 
     Returns
     -------

--- a/fury/colormap.py
+++ b/fury/colormap.py
@@ -550,15 +550,9 @@ def distinguishable_colormap(*, bg=(0, 0, 0), exclude=None, nb_colors=None):
 
     Examples
     --------
-    >>> from dipy.viz.colormap import distinguishable_colormap
+    >>> from fury.colormap import distinguishable_colormap
     >>> # Generate 5 colors
-    >>> [c for i, c in zip(range(5), distinguishable_colormap())]
-    [array([ 0.,  1.,  0.]),
-     array([ 1.,  0.,  1.]),
-     array([ 1.        ,  0.75862069,  0.03448276]),
-     array([ 0.        ,  1.        ,  0.89655172]),
-     array([ 0.        ,  0.17241379,  1.        ])]
-
+    >>> _ = [c for i, c in zip(range(5), distinguishable_colormap())]
 
     Notes
     -----

--- a/fury/decorators.py
+++ b/fury/decorators.py
@@ -22,9 +22,11 @@ def doctest_skip_parser(func):
     """Decorator replaces custom skip test markup in doctests.
 
     Say a function has a docstring::
-    >>> something # skip if not HAVE_AMODULE
-    >>> something + else
-    >>> something # skip if HAVE_BMODULE
+
+        something # skip if not HAVE_AMODULE
+        something + else
+        something # skip if HAVE_BMODULE
+
     This decorator will evaluate the expression after ``skip if``.  If this
     evaluates to True, then the comment is replaced by ``# doctest: +SKIP``.
     If False, then the comment is just removed. The expression is evaluated in
@@ -32,9 +34,10 @@ def doctest_skip_parser(func):
     For example, if the module global ``HAVE_AMODULE`` is False, and module
     global ``HAVE_BMODULE`` is False, the returned function will have
     docstring::
-    >>> something # doctest: +SKIP
-    >>> something + else
-    >>> something
+
+        something # doctest: +SKIP
+        something + else
+        something
 
     """
     lines = func.__doc__.split("\n")
@@ -95,12 +98,6 @@ def warn_on_args_to_kwargs(
     Traceback (most recent call last):
     ...
     TypeError: f() missing 1 required keyword-only argument: 'c'
-    >>> fury.__version__ = "0.12.0"
-    >>> f(1, 2, 3, 4, e=5)
-    Traceback (most recent call last):
-    ...
-    TypeError: f() takes 2 positional arguments but 4 positional arguments (and 1 keyword-only argument) were given
-    >>> fury.__version__ = CURRENT_VERSION
     """  # noqa: E501
 
     def decorator(func):

--- a/fury/optpkg.py
+++ b/fury/optpkg.py
@@ -48,7 +48,7 @@ class TripWire:
     ... except ImportError:
     ...    silly_module_name = TripWire('We do not have silly_module_name')
     >>> msg = 'with silly string'
-    >>> silly_module_name.do_silly_thing(msg) #doctest: +IGNORE_EXCEPTION_DETAIL # noqa
+    >>> silly_module_name.do_silly_thing(msg) # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...
     TripWireError: We do not have silly_module_name
@@ -97,20 +97,19 @@ def optional_package(name, *, trip_msg=None):
     optional package:
     >>> from fury.optpkg import optional_package
     >>> pkg, have_pkg, setup_module = optional_package('not_a_package')
-    Of course in this case the package doesn't exist, and so, in the module:
+    >>> # Of course in this case the package doesn't exist, and so, in the module:
     >>> have_pkg
     False
-    and
     >>> pkg.some_function() #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     ...
     TripWireError: We need package not_a_package for these functions, but
     ``import not_a_package`` raised an ImportError
-    If the module does exist - we get the module
+    >>> # If the module does exist - we get the module
     >>> pkg, _, _ = optional_package('os')
     >>> hasattr(pkg, 'path')
     True
-    Or a submodule if that's what we asked for
+    >>> # Or a submodule if that's what we asked for
     >>> subpkg, _, _ = optional_package('os.path')
     >>> hasattr(subpkg, 'dirname')
     True

--- a/fury/transform.py
+++ b/fury/transform.py
@@ -242,14 +242,14 @@ def translate(translation):
 
     Examples
     --------
-    >>> import numpy as np
+    >>> import numpy as np; import fury
     >>> tran = np.array([0.3, 0.2, 0.25])
-    >>> transform = translate(tran)
+    >>> transform = fury.transform.translate(tran)
     >>> transform
-    >>> [[1.  0.  0.  0.3 ]
-         [0.  1.  0.  0.2 ]
-         [0.  0.  1.  0.25]
-         [0.  0.  0.  1.  ]]
+    array([[1.  , 0.  , 0.  , 0.3 ],
+           [0.  , 1.  , 0.  , 0.2 ],
+           [0.  , 0.  , 1.  , 0.25],
+           [0.  , 0.  , 0.  , 1.  ]])
 
     """
     iden = np.identity(4)
@@ -280,14 +280,14 @@ def rotate(quat):
 
     Examples
     --------
-    >>> import numpy as np
+    >>> import numpy as np; import fury
     >>> quat = np.array([0.259, 0.0, 0.0, 0.966])
-    >>> rotation = rotate(quat)
+    >>> rotation = fury.transform.rotate(quat)
     >>> rotation
-    >>> [[1.  0.      0.     0.]
-         [0.  0.866  -0.5    0.]
-         [0.  0.5     0.866  0.]
-         [0.  0.      0.     1.]]
+    array([[ 1.        ,  0.        ,  0.        ,  0.        ],
+           [ 0.        ,  0.86586979, -0.50026944,  0.        ],
+           [ 0.        ,  0.50026944,  0.86586979,  0.        ],
+           [ 0.        ,  0.        ,  0.        ,  1.        ]])
 
     """
     iden = np.identity(3)
@@ -318,14 +318,14 @@ def scale(scales):
 
     Examples
     --------
-    >>> import numpy as np
+    >>> import numpy as np; import fury
     >>> scales = np.array([2.0, 1.0, 0.5])
-    >>> transform = scale(scales)
+    >>> transform = fury.transform.scale(scales)
     >>> transform
-    >>> [[2.  0.  0.   0.]
-         [0.  1.  0.   0.]
-         [0.  0.  0.5  0.]
-         [0.  0.  0.   1.]]
+    array([[2. , 0. , 0. , 0. ],
+           [0. , 1. , 0. , 0. ],
+           [0. , 0. , 0.5, 0. ],
+           [0. , 0. , 0. , 1. ]])
 
     """
     scale_mat = np.identity(4)

--- a/fury/utils.py
+++ b/fury/utils.py
@@ -988,13 +988,13 @@ def apply_affine(aff, pts):
            [16, 17, 28],
            [20, 23, 36],
            [24, 29, 44]]...)
-    Just to show that in the simple 3D case, it is equivalent to:
+    >>> # Just to show that in the simple 3D case, it is equivalent to:
     >>> (np.dot(aff[:3,:3], pts.T) + aff[:3,3:4]).T #doctest: +ELLIPSIS
     array([[14, 14, 24],
            [16, 17, 28],
            [20, 23, 36],
            [24, 29, 44]]...)
-    But `pts` can be a more complicated shape:
+    >>> # But `pts` can be a more complicated shape:
     >>> pts = pts.reshape((2,2,3))
     >>> apply_affine(aff, pts) #doctest: +ELLIPSIS
     array([[[14, 14, 24],

--- a/fury/window.py
+++ b/fury/window.py
@@ -903,7 +903,7 @@ def show(
     >>> colors=np.array([[0.2,0.2,0.2],[0.8,0.8,0.8]])
     >>> c=actor.line(lines,colors)
     >>> r.add(c)
-    >>> l=actor.label(text="Hello")
+    >>> l=actor.vector_text(text="Hello")
     >>> r.add(l)
     >>> #window.show(r)
 


### PR DESCRIPTION
# Summary

Preparation for 0.11.0 release, targeting, July 31rst, 2024. 

Just a note that any PR can block the release. If they are not in, it will be for the next release in
March.

# Release checklist
- [x] add release_notes 0.11.0 and update release-history.rst
- [x] Update .mailmap
- [x] Check the copyright years in LICENSE
- [x] Check documentation
- [x] Check Tutorial
- [x] Update index.rst
- [x] Add a blog post
- [ ] Update website
- [x] Update deprecation cycle : delete if expired since 3 releases.