### PR TITLE
[DOCS][FIX][RF] fix docstring formatting warning  and refactor the apigen.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,12 +40,12 @@ needs_sphinx = "4.3"
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "numpydoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.githubpages",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
-    "sphinx.ext.napoleon",
     "IPython.sphinxext.ipython_directive",
     "IPython.sphinxext.ipython_console_highlighting",
     "matplotlib.sphinxext.plot_directive",

--- a/fury/actors/peak.py
+++ b/fury/actors/peak.py
@@ -28,40 +28,54 @@ class PeakActor(Actor):
 
     Parameters
     ----------
-    directions : ndarray
-        Peak directions. The shape of the array should be (X, Y, Z, D, 3).
-    indices : tuple
-        Indices given in tuple(x_indices, y_indices, z_indices)
-        format for mapping 2D ODF array to 3D voxel grid.
-    values : ndarray, optional
-        Peak values. The shape of the array should be (X, Y, Z, D).
-    affine : array, optional
-        4x4 transformation array from native coordinates to world coordinates.
-    colors : None or string ('rgb_standard') or tuple (3D or 4D) or
-             array/ndarray (N, 3 or 4) or array/ndarray (K, 3 or 4) or
-             array/ndarray(N, ) or array/ndarray (K, )
-        If None a standard orientation colormap is used for every line.
-        If one tuple of color is used. Then all streamlines will have the same
-        color.
-        If an array (N, 3 or 4) is given, where N is equal to the number of
-        points. Then every point is colored with a different RGB(A) color.
-        If an array (K, 3 or 4) is given, where K is equal to the number of
-        lines. Then every line is colored with a different RGB(A) color.
-        If an array (N, ) is given, where N is the number of points then these
-        are considered as the values to be used by the colormap.
-        If an array (K,) is given, where K is the number of lines then these
-        are considered as the values to be used by the colormap.
-    lookup_colormap : vtkLookupTable, optional
-        Add a default lookup table to the colormap. Default is None which calls
-        :func:`fury.actor.colormap_lookup_table`.
-    linewidth : float, optional
-        Line thickness. Default is 1.
-    symmetric: bool, optional
-        If True, peaks are drawn for both peaks_dirs and -peaks_dirs. Else,
-        peaks are only drawn for directions given by peaks_dirs. Default is
-        True.
 
-    """
+    directions : ndarray
+
+      Peak directions. The shape of the array should be (X, Y, Z, D, 3).
+
+    indices : tuple
+
+      Indices given in tuple(x_indices, y_indices, z_indices)
+      format for mapping 2D ODF array to 3D voxel grid.
+
+    values : ndarray, optional
+
+      Peak values. The shape of the array should be (X, Y, Z, D).
+
+    affine : array, optional
+
+      4x4 transformation array from native coordinates to world coordinates.
+
+    colors : None or string ('rgb_standard') or tuple (3D or 4D) or array/ndarray (N, 3 or 4) or array/ndarray (K, 3 or 4) or array/ndarray(N, ) or array/ndarray (K, )
+
+      If None a standard orientation colormap is used for every line.
+      If one tuple of color is used. Then all streamlines will have the same
+      color.
+      If an array (N, 3 or 4) is given, where N is equal to the number of
+      points. Then every point is colored with a different RGB(A) color.
+      If an array (K, 3 or 4) is given, where K is equal to the number of
+      lines. Then every line is colored with a different RGB(A) color.
+      If an array (N, ) is given, where N is the number of points then these
+      are considered as the values to be used by the colormap.
+      If an array (K,) is given, where K is the number of lines then these
+      are considered as the values to be used by the colormap.
+
+    lookup_colormap : vtkLookupTable, optional
+
+      Add a default lookup table to the colormap. Default is None which calls
+      :func:`fury.actor.colormap_lookup_table`.
+
+    linewidth : float, optional
+
+      Line thickness. Default is 1.
+
+    symmetric: bool, optional
+
+      If True, peaks are drawn for both peaks_dirs and -peaks_dirs. Else,
+      peaks are only drawn for directions given by peaks_dirs. Default is
+      True.
+
+    """  # noqa: E501
 
     @warn_on_args_to_kwargs()
     def __init__(

--- a/fury/actors/tensor.py
+++ b/fury/actors/tensor.py
@@ -400,18 +400,22 @@ def main_dir_uncertainty(evals, evecs, signal, sigma, b_matrix):
     ----------
     evals : ndarray (3, ) or (N, 3)
         Eigenvalues.
+
     evecs : ndarray (3, 3) or (N, 3, 3)
         Eigenvectors.
+
     signal : 3D or 4D ndarray
         Predicted signal.
+
     sigma : ndarray
         Standard deviation of the noise.
+
     b_matrix : array (N, 7)
         Design matrix for DTI.
 
     Returns
     -------
-    angles: array
+    angles : array
 
     Notes
     -----
@@ -421,12 +425,12 @@ def main_dir_uncertainty(evals, evecs, signal, sigma, b_matrix):
     directly from estimated D and its estimated covariance matrix
     :math:`\\Delta D` (see [2]_, equation 4). The angle :math:`\\Theta`
     between the perturbed principal eigenvector of D,
-    :math:`\\epsilon_1+\\Delta\\epsilon_1`, and the estimated eigenvector
+    :math:`\\epsilon_1 + \\Delta\\epsilon_1`, and the estimated eigenvector
     :math:`\\epsilon_1`, measures the angular deviation of the main fiber
     direction and can be approximated by:
 
     .. math::
-        \\Theta=tan^{-1}(\\|\\Delta\\epsilon_1\\|)
+        \\Theta = tan^{-1}(\\|\\Delta \\ epsilon_1\\|)
 
     Giving way to a graphical construct for displaying both the main
     eigenvector of D and its associated uncertainty, with the so-called
@@ -435,13 +439,13 @@ def main_dir_uncertainty(evals, evecs, signal, sigma, b_matrix):
     References
     ----------
     .. [1] Basser, P. J. (1997). Quantifying errors in fiber direction and
-    diffusion tensor field maps resulting from MR noise. In 5th Scientific
-    Meeting of the ISMRM (Vol. 1740).
+        diffusion tensor field maps resulting from MR noise. In 5th Scientific
+        Meeting of the ISMRM (Vol. 1740).
 
     .. [2] Chang, L. C., Koay, C. G., Pierpaoli, C., & Basser, P. J. (2007).
-    Variance of estimated DTI-derived parameters via first-order perturbation
-    methods. Magnetic Resonance in Medicine: An Official Journal of the
-    International Society for Magnetic Resonance in Medicine, 57(1), 141-149.
+        Variance of estimated DTI-derived parameters via first-order perturbation
+        methods. Magnetic Resonance in Medicine: An Official Journal of the
+        International Society for Magnetic Resonance in Medicine, 57(1), 141-149.
 
     """
     angles = np.ones(evecs.shape[0])

--- a/fury/colormap.py
+++ b/fury/colormap.py
@@ -893,9 +893,13 @@ def get_xyz_coords(illuminant, observer):
     Notes
     -----
     Original Implementation from scikit-image package.
-    it can be found at:
+    it can be found here:
     https://github.com/scikit-image/scikit-image/blob/main/skimage/color/colorconv.py
     This implementation might have been modified.
+
+    References
+    ----------
+    .. [1] scikit-image, `colorconv.py` source code
 
     """
     illuminant = illuminant.upper()

--- a/fury/gltf.py
+++ b/fury/gltf.py
@@ -1450,8 +1450,7 @@ def write_accessor(
     ----------
     gltf: GLTF2
         Pygltflib GLTF2 objecomp_type
-
-                      bufferview: int
+    bufferview: int
         BufferView Index
     byte_offset: int
         ByteOffset of the accessor
@@ -1467,6 +1466,7 @@ def write_accessor(
         Minimum elements of an array
 
     """
+
     accessor = gltflib.Accessor()
     accessor.bufferView = bufferview
     accessor.byteOffset = byte_offset

--- a/fury/lib.py
+++ b/fury/lib.py
@@ -245,8 +245,7 @@ PolyVertex = cdmvtk.vtkPolyVertex
 UnstructuredGrid = cdmvtk.vtkUnstructuredGrid
 #: class for Polygon
 Polygon = cdmvtk.vtkPolygon
-#: class for DataObject
-DataObject = cdmvtk.vtkDataObject
+
 #: class for Molecule
 Molecule = cdmvtk.vtkMolecule
 #: class for DataSetAttributes

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,7 @@
 # These are dependencies of various sphinx extensions for documentation.
 sphinx>=5.0.0
 ipython
+numpydoc
 matplotlib
 sphinx-copybutton
 sphinx-gallery>=0.10.0


### PR DESCRIPTION
This PR fixes the formatting warnings in several functions across different modules:

- `actors`
- `colormap`

, specifically addressing the "Explicit markup ends without a blank line; unexpected unindent" issue in their docstrings. Additionally, the `apigen.py`  file has been refactored to fix warnings.