### PR TITLE
[FIX][DOC] fix broken link in Shivam's GSoC final report blog post

### DIFF
--- a/docs/source/posts/2023/2023-01-29-final-report-shivam.rst
+++ b/docs/source/posts/2023/2023-01-29-final-report-shivam.rst
@@ -252,7 +252,7 @@ GSoC weekly blogs
 *****************
 
 -  My blog posts can be found on the `FURY
-   website <https://fury.gl/latest/blog/author/Shivam-Anand.html>`__
+   website <https://fury.gl/latest/blog/author/shivam-anand.html>`__
    and the `Python GSoC
    blog <https://blogs.python-gsoc.org/en/xtanions-blog/>`__.
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c787a189-54cf-4454-ace9-c59155e4d982)

this link is broken https://fury.gl/latest/blog/author/Shivam-Anand.html

it supposed to https://fury.gl/latest/blog/author/shivam-anand.html