### PR TITLE
Changing color range from 0-255 o 0-1

### DIFF
--- a/fury/actor.py
+++ b/fury/actor.py
@@ -65,8 +65,6 @@ def actor_from_primitive(
 
     prim_count = len(centers)
 
-    big_colors = big_colors / 255.0
-
     if isinstance(opacity, (int, float)):
         if big_colors.shape[1] == 3:
             big_colors = np.hstack(

--- a/fury/primitive.py
+++ b/fury/primitive.py
@@ -198,7 +198,6 @@ def repeat_primitive(
     # update colors
     colors = normalize_input(colors, arr_name="colors")
     big_colors = np.repeat(colors, unit_verts_size, axis=0)
-    big_colors *= 255
 
     # update orientations
     directions = normalize_input(directions, arr_name="directions")

--- a/fury/tests/test_primitive.py
+++ b/fury/tests/test_primitive.py
@@ -260,6 +260,9 @@ def test_repeat_primitive():
         npt.assert_equal(big_vert_origin.max(), 0.5)
         npt.assert_equal(np.mean(big_vert_origin), 0)
 
+        npt.assert_equal(big_colors.min(), 0)
+        npt.assert_equal(big_colors.max(), 1)
+
 
 def test_repeat_primitive_function():
     # init variables


### PR DESCRIPTION
The normalized rgb color representation will be used instead of the standard 0-255 form.