### PR TITLE
BF: Fixed package name for jupyter_rfb

### DIFF
--- a/fury/lib.py
+++ b/fury/lib.py
@@ -12,7 +12,7 @@ jupyter_pckg_msg = (
 )
 
 jupyter_rfb, have_jupyter_rfb, _ = optional_package(
-    "jupyter-rfb", trip_msg=jupyter_pckg_msg
+    "jupyter_rfb", trip_msg=jupyter_pckg_msg
 )
 
 if have_jupyter_rfb:


### PR DESCRIPTION
- The name was copied from the pip show list and had `jupyter-rfb`.
- While using it with optional_package the `jupyter_rfb works as how they register the base name with python.`