### PR TITLE
NF: Slicer Actor

### DIFF
--- a/docs/examples/viz_slicer.py
+++ b/docs/examples/viz_slicer.py
@@ -1,0 +1,39 @@
+import numpy as np
+from fury import actor, window
+from dipy.data import read_mni_template
+
+###############################################################################
+# Let's read the 3D data from dipy
+
+nifti = read_mni_template()
+data = np.asarray(nifti.dataobj)
+print(data.shape)
+
+###############################################################################
+# Create slice actor to visualize the 3D data as XY, YZ and XZ slices.
+
+slicer_actor = actor.slicer(data)
+scene = window.Scene()
+scene.add(slicer_actor)
+
+
+def handle_pick_event(event):
+    info = event.pick_info
+    intensity = np.asarray(info["rgba"].rgb).mean()
+    print(f"Voxel {info['index']}: {intensity:.2f}")
+
+
+def handle_wheel_event(event):
+    position = slicer_actor.get_slices()
+    position += event.dy // 20
+    position = np.maximum(np.zeros((3,)), position)
+    position = np.minimum(np.asarray(data.shape), position)
+    slicer_actor.show_slices(position)
+
+
+slicer_actor.add_event_handler(handle_pick_event, "pointer_down")
+slicer_actor.add_event_handler(handle_wheel_event, "wheel")
+
+if __name__ == "__main__":
+    show_m = window.ShowManager(scene=scene, title="FURY 2.0: Slicer Example")
+    show_m.start()

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1,9 +1,11 @@
 import numpy as np
 
 from fury.geometry import buffer_to_geometry, create_mesh, create_point
+from fury.lib import Geometry, Group, Texture, Volume, VolumeSliceMaterial
 from fury.material import (
     _create_mesh_material,
     _create_points_material,
+    validate_opacity,
 )
 import fury.primitive as fp
 
@@ -1269,4 +1271,146 @@ def marker(
     )
 
     obj = create_point(geo, mat)
+    return obj
+
+
+def slicer(
+    data,
+    *,
+    value_range=None,
+    opacity=1.0,
+    interpolation="linear",
+    visibility=(True, True, True),
+    initial_slices=None,
+):
+    """Visualize a 3D volume data as a slice.
+
+    Parameters
+    ----------
+    data : ndarray, shape (X, Y, Z) or (X, Y, Z, 3)
+        The 3D volume data to be sliced.
+    value_range : tuple, optional
+        The minimum and maximum values for the color mapping.
+        If None, the range is determined from the data.
+    opacity : float, optional
+        The opacity of the slice. Takes values from 0 (fully transparent) to 1 (opaque).
+    interpolation : str, optional
+        The interpolation method for the slice. Options are 'linear' and 'nearest'.
+    visibility : tuple, optional
+        A tuple of three boolean values indicating the visibility of the slices
+        in the x, y, and z dimensions, respectively.
+    initial_slices : tuple, optional
+        A tuple of three initial slice positions in the x, y, and z dimensions,
+        respectively. If None, the slices are initialized to the middle of the volume.
+
+    Returns
+    -------
+    slicer_actor : Group
+        An actor containing the generated slice with the specified properties.
+    """
+
+    if value_range is None:
+        value_range = (np.min(data), np.max(data))
+
+    if visibility is None:
+        visibility = (True, True, True)
+
+    if data.ndim < 3 or data.ndim > 4:
+        raise ValueError(
+            "Input data must be 3-dimensional or "
+            "4-dimensional with last dimension of size 3."
+        )
+    elif data.ndim == 4 and data.shape[-1] != 3:
+        raise ValueError("Last dimension must be of size 3.")
+
+    opacity = validate_opacity(opacity)
+    data = data.astype(np.float32)
+
+    data = np.swapaxes(data, 0, 2)
+
+    data_shape = data.shape
+    if initial_slices is None:
+        initial_slices = (
+            data_shape[2] // 2,
+            data_shape[1] // 2,
+            data_shape[0] // 2,
+        )
+
+    texture = Texture(data, dim=3)
+
+    slices = []
+    for dim in [0, 1, 2]:  # XYZ
+        abcd = [0, 0, 0, 0]
+        abcd[dim] = -1
+        abcd[-1] = data_shape[2 - dim] // 2
+        mat = VolumeSliceMaterial(
+            abcd,
+            clim=value_range,
+            interpolation=interpolation,
+            opacity=opacity,
+            pick_write=True,
+        )
+        geo = Geometry(grid=texture)
+        plane = Volume(geo, mat)
+        slices.append(plane)
+
+    class Slicer(Group):
+        def __init__(
+            self,
+            *,
+            visible=True,
+        ):
+            super().__init__(visible=visible, name="Slicer")
+
+        def show_slices(self, position):
+            """Show the slices at the specified position.
+
+            Parameters
+            ----------
+            position : tuple
+                A tuple containing the positions of the slices in the 3D space.
+            """
+            for i, child in enumerate(self.children):
+                a, b, c, _ = child.material.plane
+                child.material.plane = (a, b, c, position[i])
+
+        def set_opacity(self, opacity):
+            """Set the opacity of the slices.
+
+            Parameters
+            ----------
+            opacity : float
+                The opacity value to set for the slices,
+                ranging from 0 (fully transparent) to 1 (opaque).
+            """
+            for child in self.children:
+                child.material.opacity = opacity
+
+        def set_visibility(self, visibility):
+            """Set the visibility of the slices.
+
+            Parameters
+            ----------
+            visibility : tuple
+                A tuple of three boolean values indicating the visibility of the slices
+                in the x, y, and z dimensions, respectively.
+            """
+            for i, child in enumerate(self.children):
+                child.visible = visibility[i]
+
+        def get_slices(self):
+            """Get the current positions of the slices.
+
+            Returns
+            -------
+            position : ndarray
+                An array containing the current positions of the slices.
+            """
+            return np.asarray([child.material.plane[-1] for child in self.children])
+
+    obj = Slicer()
+    obj.add(*slices)
+    obj.set_visibility(visibility)
+    obj.show_slices(initial_slices)
+
     return obj

--- a/fury/lib.py
+++ b/fury/lib.py
@@ -19,6 +19,9 @@ if have_jupyter_rfb:
     from wgpu.gui.jupyter import WgpuCanvas as JupyterWgpuCanvas
 
 Texture = gfx.Texture
+VolumeSliceMaterial = gfx.VolumeSliceMaterial
+Group = gfx.Group
+Volume = gfx.Volume
 AmbientLight = gfx.AmbientLight
 Background = gfx.Background
 BackgroundSkyboxMaterial = gfx.BackgroundSkyboxMaterial

--- a/fury/tests/test_actor.py
+++ b/fury/tests/test_actor.py
@@ -1,8 +1,10 @@
 from PIL import Image
 import numpy as np
 import numpy.testing as npt
+import pytest
 
 from fury import actor, window
+from fury.lib import Group
 
 
 def validate_actors(centers, colors, actor_type="actor_name"):
@@ -233,3 +235,67 @@ def test_marker():
     assert mean_g == 0 and mean_b == 0
 
     scene.remove(marker_actor_1)
+
+
+def test_valid_3d_data():
+    """Test valid 3D input with default parameters (Test Case 1)."""
+    data = np.random.rand(10, 20, 30)
+    slicer_obj = actor.slicer(data)
+
+    # Verify object type and visibility
+    assert isinstance(slicer_obj, Group)
+    assert slicer_obj.visible
+    assert len(slicer_obj.children) == 3
+    assert all(child.visible for child in slicer_obj.children)
+
+
+def test_invalid_4d_data():
+    """Test invalid 4D data shape (Test Case 4)."""
+    data = np.random.rand(10, 20, 30, 4)  # Last dim ≠ 3
+    with pytest.raises(ValueError) as excinfo:
+        actor.slicer(data)
+    assert "Last dimension must be of size 3" in str(excinfo.value)
+
+
+def test_opacity_validation():
+    """Test opacity validation raises errors for out-of-bounds values"""
+    data = np.random.rand(10, 20, 30)
+
+    # Test valid values
+    for valid_opacity in [0, 0.5, 1]:
+        slicer_obj = actor.slicer(data, opacity=valid_opacity)
+        for child in slicer_obj.children:
+            assert child.material.opacity == valid_opacity
+
+    # Test invalid values
+    for invalid_opacity in [-0.1, 1.1, 2.0]:
+        with pytest.raises(ValueError) as excinfo:
+            actor.slicer(data, opacity=invalid_opacity)
+        assert "Opacity must be between 0 and 1" in str(excinfo.value)
+
+
+def test_custom_initial_slices():
+    """Test custom initial slice positions (Test Case 10)."""
+    data = np.random.rand(10, 20, 30)
+    slicer_obj = actor.slicer(data, initial_slices=(5, 10, 15))
+
+    # Verify slice positions match input
+    assert np.array_equal(slicer_obj.get_slices(), [5, 10, 15])
+
+    # Verify positions update correctly
+    slicer_obj.show_slices((2, 4, 6))
+    assert np.array_equal(slicer_obj.get_slices(), [2, 4, 6])
+
+
+def test_visibility_control():
+    """Test visibility settings through methods (Test Case 13)."""
+    data = np.random.rand(10, 20, 30)
+    slicer_obj = actor.slicer(data, visibility=(True, True, True))
+
+    # Verify initial visibility
+    assert all(child.visible for child in slicer_obj.children)
+
+    # Update and verify new visibility
+    slicer_obj.set_visibility((False, True, False))
+    visibilities = [child.visible for child in slicer_obj.children]
+    assert visibilities == [False, True, False]


### PR DESCRIPTION
- Slicer actor works on 3D volumes, respresenting it in XY, YZ, ZX slices.
- Test cases for slicer actor introduced.
- Rgb support enabled for slicer actor.
- Example written for Slicer Actor.

![Screenshot from 2025-04-11 15-18-49](https://github.com/user-attachments/assets/9a94760b-b56c-49e0-aecb-7497306d6d22)
![Screenshot from 2025-04-11 15-18-40](https://github.com/user-attachments/assets/9a3583a4-d641-4099-957d-0317ec896b86)

The example covers the picking and scrolling to check all the slices in the template.