### PR TITLE
BF: Long key press event None fixed

### DIFF
--- a/fury/window.py
+++ b/fury/window.py
@@ -633,7 +633,7 @@ class ShowManager:
             self._key_long_press = asyncio.create_task(
                 self._handle_key_long_press(event)
             )
-        else:
+        elif self._key_long_press is not None:
             self._key_long_press.cancel()
             self._key_long_press = None
 


### PR DESCRIPTION
**PR Content**

Fix for the below error when clicked outside the canvas.

```
Error during handling key_up event
Traceback (most recent call last):
  File "/Users/maharshigor/miniforge3/envs/fury/lib/python3.11/site-packages/rendercanvas/_coreutils.py", line 41, in log_exception
    yield
  File "/Users/maharshigor/miniforge3/envs/fury/lib/python3.11/site-packages/pygfx/objects/_events.py", line 395, in handle_event
    callback(event)
  File "/Users/maharshigor/Desktop/GRG/fury/fury/window.py", line 637, in _set_key_long_press_event
    self._key_long_press.cancel()
```