### PR TITLE
MTN: release preparation for v2.0.0a1

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -56,6 +56,8 @@ Anand Shivam <anandshivam54321@gmail.com> Xtanion <anandshivam54321@gmail.com>
 Anand Shivam <anandshivam54321@gmail.com> Shivam Anand <74976752+xtanion@users.noreply.github.com>
 Meha Bhalodiya <mehabhalodiya@gmail.com> mehabhalodiya <mehabhalodiya@gmail.com>
 Mohamed Agour <mo.aggour@gmail.com> m-agour <mo.aggour@gmail.com>
+Mohamed Agour <mo.aggour@gmail.com> Mohamed Abouagour <mo.aggour@gmail.com>
+Mohamed Agour <mo.aggour@gmail.com> Mohamed Abouagour <63170874+m-agour@users.noreply.github.com>
 Mohamed Agour <mo.aggour@gmail.com>  Mohamed Agour <63170874+m-agour@users.noreply.github.com>
 Sreekar Chigurupati <chigurupatisreekar@gmail.com> sreekar chigurupati <chigurupatisreekar@gmail.com>
 Johny Daras <johnydaras@gmail.com> lej0hn <johnydaras@gmail.com>
@@ -68,3 +70,5 @@ Ishan Kamboj <ISHANKAMBOJ35@GMAIL.COM> Ishan Kamboj <67258435+IshanKamboj@users.
 Robin Roy <robinroy.work@gmail.com> Robin Roy <115863770+robinroy03@users.noreply.github.com>
 Robin Roy <robinroy.work@gmail.com> Robin <robinroy.work@gmail.com>
 Kaustav Deka <mailerdeka@gmail.com> Kaustav Deka <116963260+deka27@users.noreply.github.com>
+Manish Reddy Rakasi <manishreddyrakasi@gmail.com> Manish Reddy Rakasi <116704419+ManishReddyR@users.noreply.github.com>
+Maharshi Gor <gor.maharshi@gmail.com> maharshigor <gor.maharshi@gmail.com>

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,93 +15,93 @@ Core Development Team
 Contributors
 ------------
 
-* Serge Koudoro
-* Eleftherios Garyfallidis
-* Mohamed Agour
-* Praneeth Shetty
-* Javier Guaje
-* Anand Shivam
-* Bruno Messias
-* Soham Biswas
-* Sajag Swami
-* Antriksh Misri
-* Tania Castillo
-* Ranveer Aggarwal
-* Lenix Lobo
-* Joao Victor Dell Agli
-* Marc-Alexandre Côté
-* Melina Raglin
-* Ariel Rokem
-* Karan
-* maharshigor
-* Filipi Nascimento Silva
-* David Reagan
-* Nasim Anousheh
-* Prashil
-* Vivek Choudhary
-* Saransh Jain
-* Shreyas Bhujbal
-* Tushar
-* Wachiou BOURAÏMA
-* Zhiwen Shi
-* Charles Poirier
-* Ishan Kamboj
-* Matthew Brett
-* Frank Cerasoli
-* Sreekar Chigurupati
-* Francois Rheault
-* Naman Bansal
-* Robin Roy
-* Etienne St-Onge
-* Kesshi Jordan
-* Amit Chaudhari
-* Bago Amirbekian
-* Jon Haitz Legarreta Gorroño
-* Omar Ocegueda
-* ibrahimAnis
-* Kevin Sitek
-* Meha Bhalodiya
-* Sanjay Marreddi
-* sparshg
-* ChenCheng0630
-* Gregory R. Lee
-* Enes Albay
-* Liam Donohue
-* Rohit Kharsan
-* Shahnawaz Ahmed
-* Stefan van der Walt
-* Tingyi Wanyan
-* Dwij Raj Hari
-* Guillaume Favelier
-* Johny Daras
-* PrayasJ
-* Samuel St-Jean
-* Bishakh Ghosh
-* Gottipati Gautam
-* Hariharan Ayappane
-* Maharshi Gor
-* theaverageguy
+* Adam Rybinski
 * Aju100
 * Alexandre Gauvin
+* Aman Soni
+* Amit Chaudhari
+* Anand Shivam
+* Antriksh Misri
+* Ariel Rokem
+* Bago Amirbekian
+* Bishakh Ghosh
+* Bruno Messias
+* Charles Poirier
+* ChenCheng0630
 * Christopher Nguyen
+* Daniel S. Katz
+* David Reagan
+* Devanshu Modi
+* Dwij Raj Hari
+* Eleftherios Garyfallidis
+* Enes Albay
+* Etienne St-Onge
+* Filipi Nascimento Silva
+* Francois Rheault
+* Frank Cerasoli
+* Gauvin Alexandre
+* Gottipati Gautam
+* Gregory R. Lee
+* Guillaume Favelier
+* Gurdit Siyan
+* Hariharan Ayappane
+* Ian Nimmo-Smith
+* Ishan Kamboj
+* Jacob Wasserth
+* Javier Guaje
 * Jhalak Gupta
 * Jiri Borovec
-* Marssis
-* Sara Hamza
-* Scott Trinkle
-* Siddharth Gautam
-* dependabot[bot]
-* Adam Rybinski
-* Aman Soni
-* Daniel S. Katz
-* Devanshu Modi
-* Gauvin Alexandre
-* Gurdit Siyan
-* Ian Nimmo-Smith
-* Jacob Wasserth
+* Joao Victor Dell Agli
+* Johny Daras
+* Jon Haitz Legarreta Gorroño
+* Karan
 * Kaustav Deka
+* Kesshi Jordan
+* Kevin Sitek
+* Lenix Lobo
+* Liam Donohue
 * LoopThrough-i-j
 * MIHIR
+* Maharshi Gor
+* Manish Reddy Rakasi
+* Marc-Alexandre Côté
+* Marssis
+* Matthew Brett
+* Meha Bhalodiya
+* Melina Raglin
+* Mohamed Agour
+* Naman Bansal
+* Nasim Anousheh
+* Omar Ocegueda
 * Pietro Astolfi
+* Praneeth Shetty
+* Prashil
+* PrayasJ
+* Ranveer Aggarwal
+* Robin Roy
+* Rohit Kharsan
+* Sajag Swami
+* Samuel St-Jean
+* Sanjay Marreddi
+* Sara Hamza
+* Saransh Jain
+* Scott Trinkle
+* Serge Koudoro
+* Shahnawaz Ahmed
+* Shreyas Bhujbal
+* Siddharth Gautam
+* Soham Biswas
+* Sreekar Chigurupati
+* Stefan van der Walt
+* Tania Castillo
+* Tingyi Wanyan
+* Tushar
+* Vivek Choudhary
+* Wachiou BOURAÏMA
 * Yaroslav Halchenko
+* Zhiwen Shi
+* dependabot[bot]
+* ibrahimAnis
 * sailesh
+* sparshg
+* theaverageguy

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2024, FURY - Free Unified Rendering in Python. All rights reserved.
+Copyright (c) 2014–2025, FURY - Free Unified Rendering in Python. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/docs/source/ext/github_tools.py
+++ b/docs/source/ext/github_tools.py
@@ -499,9 +499,11 @@ def github_stats(**kwargs):
         print()
         print(
             "==============================\n"
-            f" Release notes v{version}\n  ()"
+            f" Release notes v{version}\n"
             "=============================="
         )
+        print("\nQuick Overview\n--------------\n\n")
+        print("\nDetails\n--------\n\n")
 
     # By default, search one month back
     tag = kwargs.get("tag", None)

--- a/docs/source/posts/2025/2025-06-19-release-announcement.rst
+++ b/docs/source/posts/2025/2025-06-19-release-announcement.rst
@@ -1,0 +1,49 @@
+
+FURY 2.0.0a1 Released
+====================
+
+.. post:: June 19, 2025
+   :author: skoudoro
+   :tags: fury
+   :category: release
+
+
+The FURY project is happy to announce the release of FURY 2.0.0a1!
+FURY is a free and open source software library for scientific visualization and 3D animations.
+
+You can show your support by `adding a star <https://github.com/fury-gl/fury/stargazers>`_ on FURY github project.
+
+This Release is mainly a maintenance release. The **major highlights** of this release are:
+
+.. include:: ../../release_notes/releasev2.0.0a1.rst
+    :start-after: --------------
+    :end-before: Details
+
+.. note:: The complete release notes are available :ref:`here <releasev2.0.0a1>`
+
+**To upgrade or install FURY**
+
+Run the following command in your terminal::
+
+    pip install --upgrade fury
+
+or::
+
+    conda install -c conda-forge fury
+
+
+**Questions or suggestions?**
+
+For any questions go to http://fury.gl, or send an e-mail to fury@python.org
+We can also join our `discord community <https://discord.gg/6btFPPj>`_
+
+We would like to thanks to :ref:`all contributors <community>` for this release:
+
+.. include:: ../../release_notes/releasev2.0.0a1.rst
+    :start-after: commits.
+    :end-before: We closed
+
+
+On behalf of the :ref:`FURY developers <community>`,
+
+Serge K.

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -7,6 +7,7 @@ For a full list of the features implemented in the most recent release cycle, ch
 .. toctree::
    :maxdepth: 1
 
+   release_notes/releasev2.0.0a1
    release_notes/releasev0.11.0
    release_notes/releasev0.10.0
    release_notes/releasev0.9.0

--- a/docs/source/release_notes/releasev2.0.0a1.rst
+++ b/docs/source/release_notes/releasev2.0.0a1.rst
@@ -1,0 +1,146 @@
+.. _releasev2.0.0a1:
+
+==============================
+ Release notes v2.0.0a1
+==============================
+
+Quick Overview
+--------------
+
+* Pre-release of the v2.0.0 version of the library.
+* Switched to `pygfx` for rendering instead of `vtk`.
+* Added support for various new actors including `VectorField`, `Slicer`, `Triangle`, `Disk`, `Ellipsoid`, `Line`, `Axes`, and more.
+* Introduced new primitives and utilities for actor creation.
+* Improved shader and material handling.
+* Enhanced documentation and test coverage.
+* Fixed various bugs and improved compatibility with existing code.
+
+Details
+--------
+
+
+
+GitHub stats for 2024/12/11 - 2025/06/19 (tag: v0.12.0)
+
+These lists are automatically generated, and may be incomplete or contain duplicates.
+
+The following 4 authors contributed 146 commits.
+
+* Maharshi Gor
+* Manish Reddy Rakasi
+* Mohamed Agour
+* Serge Koudoro
+
+
+We closed a total of 103 issues, 45 pull requests and 58 regular issues;
+this is the full list (generated with the script
+:file:`tools/github_stats.py`):
+
+Pull Requests (45):
+
+* :ghpull:`1006`: test: fix doctest issues
+* :ghpull:`1000`: ENH: Test cases and Tutorial for VectorField
+* :ghpull:`997`: NF: Surface actor introduced.
+* :ghpull:`1004`: BF: Long key press event None fixed
+* :ghpull:`1003`: doc: fix doc generation and docstring
+* :ghpull:`996`: NF: Volume slicer with affine
+* :ghpull:`1002`: build(deps): bump codecov/codecov-action from 5.0.2 to 5.4.3 in the actions group
+* :ghpull:`957`: Extra parameters for compatibility - StatefulSurface in Dipy
+* :ghpull:`995`: NF: VectorField with arrows and thick lines
+* :ghpull:`992`: NF: Vector field actor
+* :ghpull:`993`: BF: remove legacy VTK warning handling
+* :ghpull:`990`: RF: Added position argument for text actor and name fix.
+* :ghpull:`980`: NF: Slicer Actor
+* :ghpull:`991`: NF: Adding Triangle actor.
+* :ghpull:`988`: NF: Adding disk actor
+* :ghpull:`984`: NF: added `ellipsoid` actor
+* :ghpull:`989`: CI: integration of numpydoc in precommit
+* :ghpull:`983`: Fix `line` actor colors
+* :ghpull:`979`: Adding `line` actor
+* :ghpull:`981`: NF: Adding the axes actor
+* :ghpull:`970`: NF: Adding text actor and its requirements
+* :ghpull:`969`: NF: Qt support and window test cases.
+* :ghpull:`978`: Relying on `pygfx` shaders for non-shader geometries
+* :ghpull:`977`: BF: Fixed package name for jupyter_rfb
+* :ghpull:`968`: NF: Adding point actor and all its requirements.
+* :ghpull:`976`: fix: shader compatibility issue temp fix.
+* :ghpull:`967`: NF: All shape actors based on primitives
+* :ghpull:`963`: NF: Adding actor for frustum, TEST: Adding uni tests for frustum actor
+* :ghpull:`965`: Changing color range from 0-255 o 0-1
+* :ghpull:`962`: NF: actor_from_primitive
+* :ghpull:`964`: RF: install wgpu and mesa driver for ubuntu CI's
+* :ghpull:`959`: added actor for cylinder
+* :ghpull:`960`: NF: shaders and materials modifiable & added smooth/flat shading
+* :ghpull:`958`: Adding box actor
+* :ghpull:`956`: RF: Examples working properly
+* :ghpull:`954`: RF: Enable Test for v2 branch
+* :ghpull:`955`: RF: Flatten the window folder to the file
+* :ghpull:`946`: NF: Sphere, Geometry & Material
+* :ghpull:`953`: RF: Lib introduced to consolidate the pygfx imports
+* :ghpull:`950`: Adding utils.py and transform.py needed by prim_actors
+* :ghpull:`951`: CI: Remove old script
+* :ghpull:`952`: RF: Code Spell Fixed
+* :ghpull:`949`: Release 0.12.0 preparation
+* :ghpull:`947`: RF: update some settings files
+* :ghpull:`948`: CI:  pin vtk<9.4.0
+
+Issues (58):
+
+* :ghissue:`1005`: BF: Limit increased.
+* :ghissue:`1006`: test: fix doctest issues
+* :ghissue:`1000`: ENH: Test cases and Tutorial for VectorField
+* :ghissue:`997`: NF: Surface actor introduced.
+* :ghissue:`1004`: BF: Long key press event None fixed
+* :ghissue:`1003`: doc: fix doc generation and docstring
+* :ghissue:`985`: NF: Adding Image actor.
+* :ghissue:`996`: NF: Volume slicer with affine
+* :ghissue:`1002`: build(deps): bump codecov/codecov-action from 5.0.2 to 5.4.3 in the actions group
+* :ghissue:`957`: Extra parameters for compatibility - StatefulSurface in Dipy
+* :ghissue:`995`: NF: VectorField with arrows and thick lines
+* :ghissue:`992`: NF: Vector field actor
+* :ghissue:`993`: BF: remove legacy VTK warning handling
+* :ghissue:`986`: [WIP] NF: Peaks actor initial setup
+* :ghissue:`990`: RF: Added position argument for text actor and name fix.
+* :ghissue:`980`: NF: Slicer Actor
+* :ghissue:`991`: NF: Adding Triangle actor.
+* :ghissue:`988`: NF: Adding disk actor
+* :ghissue:`984`: NF: added `ellipsoid` actor
+* :ghissue:`989`: CI: integration of numpydoc in precommit
+* :ghissue:`983`: Fix `line` actor colors
+* :ghissue:`982`: Line Actor creates issue if not pass the colors
+* :ghissue:`979`: Adding `line` actor
+* :ghissue:`981`: NF: Adding the axes actor
+* :ghissue:`970`: NF: Adding text actor and its requirements
+* :ghissue:`969`: NF: Qt support and window test cases.
+* :ghissue:`978`: Relying on `pygfx` shaders for non-shader geometries
+* :ghissue:`942`: dipy has a problem calling fury
+* :ghissue:`977`: BF: Fixed package name for jupyter_rfb
+* :ghissue:`968`: NF: Adding point actor and all its requirements.
+* :ghissue:`976`: fix: shader compatibility issue temp fix.
+* :ghissue:`973`: Visualization not updating
+* :ghissue:`967`: NF: All shape actors based on primitives
+* :ghissue:`963`: NF: Adding actor for frustum, TEST: Adding uni tests for frustum actor
+* :ghissue:`966`: NF: Adding actor for tetrahedron, TEST: Adding uni tests for tetrahedron actor
+* :ghissue:`965`: Changing color range from 0-255 o 0-1
+* :ghissue:`962`: NF: actor_from_primitive
+* :ghissue:`964`: RF: install wgpu and mesa driver for ubuntu CI's
+* :ghissue:`961`: Restored actors visual tests
+* :ghissue:`959`: added actor for cylinder
+* :ghissue:`960`: NF: shaders and materials modifiable & added smooth/flat shading
+* :ghissue:`958`: Adding box actor
+* :ghissue:`956`: RF: Examples working properly
+* :ghissue:`954`: RF: Enable Test for v2 branch
+* :ghissue:`955`: RF: Flatten the window folder to the file
+* :ghissue:`946`: NF: Sphere, Geometry & Material
+* :ghissue:`953`: RF: Lib introduced to consolidate the pygfx imports
+* :ghissue:`950`: Adding utils.py and transform.py needed by prim_actors
+* :ghissue:`870`: Issue with Navbar in the documentation site
+* :ghissue:`872`: The dev version is not appropriate.
+* :ghissue:`951`: CI: Remove old script
+* :ghissue:`952`: RF: Code Spell Fixed
+* :ghissue:`949`: Release 0.12.0 preparation
+* :ghissue:`947`: RF: update some settings files
+* :ghissue:`948`: CI:  pin vtk<9.4.0
+* :ghissue:`875`: Make PyGLTFLib an optional dependency
+* :ghissue:`873`: Make PyGLTFLib an optional dependency
+* :ghissue:`941`: Fix: Resolve Documentation Generation HTTP Error

--- a/tools/prepare_release.py
+++ b/tools/prepare_release.py
@@ -1,0 +1,402 @@
+"""Script to automate the release preparation and execution steps for FURY.
+
+This script performs the following tasks:
+1. Checks the latest tag in the specified series.
+2. Updates the AUTHORS file with unique authors from git log.
+3. Checks and updates the LICENSE year.
+4. Updates the release history file with new release notes.
+5. Creates a release announcement blog post.
+6. Checks for deprecations.
+7. Runs tests and builds documentation.
+8. Prompts the user to confirm the completion of the release preparation.
+"""
+
+import datetime
+import os
+import platform
+import re
+import subprocess
+import sys
+
+
+def run(cmd, *, check=True):
+    """Run a shell command and print it to the console.
+
+    Parameters
+    ----------
+    cmd : str
+        The command to run.
+    check : bool, optional
+        If True, raises an exception if the command fails. Default is True.
+    """
+    print(f"$ {cmd}")
+    subprocess.run(cmd, shell=True, check=check)
+
+
+def get_latest_tag_from_series(*, series=None):
+    """Get the latest tag from the specified series.
+
+    Parameters
+    ----------
+    series : str, optional
+        The series to check for tags (e.g., "0.x", "1.x", "2.x").
+
+    Returns
+    -------
+    str
+        The latest tag in the specified series, or None if no tags are found.
+    """
+    series = series.lower().strip() if series else None
+    if not series or series not in ["0.x", "1.x", "2.x"]:
+        raise ValueError("Series must be one of: '0.x', '1.x', '2.x'.")
+
+    # Extract the initial series number
+    current_series = int(series.split(".")[0])
+
+    # Loop through each series from the given series down to 0
+    for i in range(current_series, -1, -1):
+        # Define the pattern to match the tags in the current series
+        pattern = rf"^v{i}\.\d+.\d+$"
+
+        try:
+            # Get the list of tags from the Git repository
+            tags = subprocess.check_output(["git", "tag"]).decode("utf-8").splitlines()
+
+            # Filter tags that match the pattern
+            series_tags = [tag for tag in tags if re.match(pattern, tag)]
+
+            if series_tags:
+                # Sort the tags in version order and get the latest one
+                series_tags.sort(key=lambda v: list(map(int, v.lstrip("v").split("."))))
+                return series_tags[-1]
+
+        except subprocess.CalledProcessError:
+            continue
+
+    return None
+
+
+def update_authors(*, file_path="AUTHORS.rst"):
+    """Update the AUTHORS.rst file with unique authors from git log.
+
+    Parameters
+    ----------
+    file_path : str, optional
+        The path to the AUTHORS.rst file. Default is "AUTHORS.rst".
+    """
+    print(f"--- Updating {file_path} file... ---")
+    # Read the content of the authors.rst file
+    with open(file_path, "r") as file:
+        lines = file.readlines()
+
+    # Find the index of the "Contributors" line
+    contributors_index = None
+    for i, line in enumerate(lines):
+        if line.strip() == "Contributors":
+            contributors_index = (
+                i + 2
+            )  # +2 to skip the "Contributors" line and the next empty line
+            break
+
+    if contributors_index is None:
+        raise ValueError("The 'Contributors' line was not found in the file.")
+
+    # Remove any existing lines after the "Contributors" line
+    lines = lines[: contributors_index + 1]
+
+    # Get the list of unique authors from git log
+    git_log_cmd = "git log --format='%aN' | sort -u"
+    try:
+        authors = (
+            subprocess.check_output(git_log_cmd, shell=True).decode("utf-8").split("\n")
+        )
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"Failed to execute git command: {e}") from e
+
+    # Filter out empty strings and format authors with indentation
+    authors = [f"* {author}\n" for author in authors if author]
+
+    # Insert the authors after the "Contributors" line
+    lines[contributors_index + 1 : contributors_index + 1] = authors
+
+    # Write the updated content back to the file
+    with open(file_path, "w") as file:
+        file.writelines(lines)
+
+    run("git diff AUTHORS.rst")
+
+
+def update_release_history(
+    *,
+    file_path="docs/source/release-history.rst",
+    notes_dir="docs/source/release_notes",
+):
+    """Update the release-history.rst file with new release notes.
+
+    Parameters
+    ----------
+    file_path : str, optional
+        The path to the release-history.rst file.
+    notes_dir : str, optional
+        The directory containing the release notes files.
+    """
+    print("--- Updating release-history.rst file... ---")
+    # Read the content of the release-history.rst file
+    with open(file_path, "r") as file:
+        lines = file.readlines()
+
+    # Find the index to insert the new version
+    insert_index = None
+    for i, line in enumerate(lines):
+        if ":maxdepth: 1" in line:
+            insert_index = (
+                i + 2
+            )  # +2 to skip the ":maxdepth: 1" line and the next empty line
+            break
+
+    if insert_index is None:
+        raise ValueError("The 'release' section was not found in the file.")
+
+    # Remove any existing lines after the "Contributors" line
+    lines = lines[:insert_index]
+    release_notes = [
+        f"   release_notes/{note.rstrip('.rst')}\n"
+        for note in os.listdir(notes_dir)
+        if note.startswith("releasev") and note.endswith(".rst")
+    ]
+
+    release_notes.sort(
+        key=lambda v: list(
+            map(int, re.search(r"v(\d+\.\d+\.\d+)", v).group(1).split("."))
+        ),
+        reverse=True,
+    )
+    print(release_notes)
+    # Insert the authors after the "Contributors" line
+    lines[insert_index:insert_index] = release_notes
+    # Write the updated content back to the file
+    with open(file_path, "w") as file:
+        file.writelines(lines)
+
+    run("git diff docs/source/release-history.rst")
+
+
+def check_license_year():
+    """Check and update the LICENSE file with the current year."""
+    print("--- Checking LICENSE year range... ---")
+    current_year = datetime.datetime.now().year
+    with open("LICENSE", "r") as f:
+        lines = f.readlines()
+    for i, line in enumerate(lines):
+        if "Copyright (c)" in line:
+            if str(current_year) not in line:
+                print(f"→ Updating LICENSE year to {current_year}")
+                lines[i] = (
+                    f"Copyright (c) 2014–{current_year}, FURY - Free Unified Rendering "
+                    "in Python. All rights reserved.\n"
+                )
+                with open("LICENSE", "w") as f_out:
+                    f_out.writelines(lines)
+                run("git diff LICENSE")
+            else:
+                print("→ LICENSE year is up to date.")
+            break
+
+
+def create_release_announcement(*, author="skoudoro", version="0.11.0"):
+    """Create a release announcement blog post.
+
+    Parameters
+    ----------
+    author : str, optional
+        The author of the blog post.
+    version : str, optional
+        The version of the release.
+    """
+    print("--- Creating release announcement blog post... ---")
+    username = input(f"Enter blog post author (e.g., {author}): ").strip()
+    if username:
+        author = username
+    today = datetime.date.today()
+    year = today.year
+    posts_dir = os.path.join("docs", "source", "posts")
+    year_dir = os.path.join(posts_dir, str(year))
+
+    if not os.path.exists(year_dir):
+        os.makedirs(year_dir)
+
+    file_name = f"{today.strftime('%Y-%m-%d')}-release-announcement.rst"
+    file_path = os.path.join(year_dir, file_name)
+
+    content = f"""
+FURY {version} Released
+====================
+
+.. post:: {today.strftime("%B %d, %Y")}
+   :author: {author}
+   :tags: fury
+   :category: release
+
+
+The FURY project is happy to announce the release of FURY {version}!
+FURY is a free and open source software library for scientific visualization and 3D animations.
+
+You can show your support by `adding a star <https://github.com/fury-gl/fury/stargazers>`_ on FURY github project.
+
+This Release is mainly a maintenance release. The **major highlights** of this release are:
+
+.. include:: ../../release_notes/releasev{version}.rst
+    :start-after: --------------
+    :end-before: Details
+
+.. note:: The complete release notes are available :ref:`here <releasev{version}>`
+
+**To upgrade or install FURY**
+
+Run the following command in your terminal::
+
+    pip install --upgrade fury
+
+or::
+
+    conda install -c conda-forge fury
+
+
+**Questions or suggestions?**
+
+For any questions go to http://fury.gl, or send an e-mail to fury@python.org
+We can also join our `discord community <https://discord.gg/6btFPPj>`_
+
+We would like to thanks to :ref:`all contributors <community>` for this release:
+
+.. include:: ../../release_notes/releasev{version}.rst
+    :start-after: commits.
+    :end-before: We closed
+
+
+On behalf of the :ref:`FURY developers <community>`,
+
+Serge K.
+"""  # noqa
+
+    with open(file_path, "w") as f:
+        f.write(content)
+
+    print(f"→ Created blog post at {file_path}")
+
+
+def get_new_version(default_version):
+    """Prompt the user for a new version number.
+
+    Parameters
+    ----------
+    default_version : str
+        The default version to suggest if the user does not provide input.
+
+    Returns
+    -------
+    str
+        The new version number entered by the user, or the default version if no input
+        is provided.
+    """
+    while True:
+        new_version = input(f"Enter new version (e.g., {default_version}): ").strip()
+        if not new_version:
+            return default_version
+        if not new_version.startswith("v"):
+            print("Version must start with 'v'.")
+            continue
+        if not re.match(r"^v\d+\.\d+\.\d+[a-zA-Z0-9]*$", new_version):
+            print(
+                "Version must follow semantic versioning (e.g., v0.13.0 or v.0.13.0a1)."
+            )
+            continue
+        return new_version
+
+
+def main():
+    """Main function to prepare the release."""
+    series = input("Enter the FURY series (e.g. 0.x or 2.x): ").strip()
+    if os.getcwd().endswith("fury"):
+        _ = os.getcwd()
+    else:
+        print("Error: run this from the 'fury' directory", file=sys.stderr)
+        sys.exit(1)
+
+    # 1. Find last tag and show changes
+    last = get_latest_tag_from_series(series=series)
+    print(f"Last tag: {last}")
+    # print("--- Update .mailmap file ---")
+    # input("please, check duplicated and unknown names, then update the .mailmap file."
+    #       " okay? Press Enter to continue...")
+    # run(f"git shortlog -nse {last}..HEAD")
+
+    # # 2. Update AUTHORS file
+    # update_authors()
+
+    # # 3. Check LICENSE year
+    # check_license_year()
+
+    # # 4. Generate release notes
+    last_version_parts = last.lstrip("v").split(".")
+    major, minor, patch = map(int, last_version_parts)
+    proposed_version = f"v{major}.{minor + 1}.0"
+
+    new_version_v = get_new_version(proposed_version)
+    new_version = new_version_v.lstrip("v")
+    # print(f"--- Generating release notes for {new_version_v} ---")
+    # run(f"python docs/source/ext/github_tools.py --tag={last} "
+    #     f"--save --version={new_version}")
+    # print("→ Release notes created")
+    # print(f"Please, go to docs/release_notes/release{new_version_v}.rst and update"
+    #       " 'Quick overview' section.")
+    # input("Press Enter when done...")
+
+    # 5. Remind to update release-history.rst
+    update_release_history()
+
+    # 6. Prepare blog post
+    create_release_announcement(version=new_version)
+
+    # 7.  Check deprecations
+    print("--- Deprecation cycles ---")
+    while True:
+        answer = input(
+            "Have you checked deprecated functions/modules [yes/no]: "
+        ).strip()
+        if answer.lower() in ["yes", "y"]:
+            break
+        elif answer.lower() in ["no", "n"]:
+            print("Please, check deprecated functions/modules before proceeding.")
+            continue
+        else:
+            print("Invalid input. Please answer with 'yes' or 'no'.")
+
+    # 7. Run tests and build docs
+    while True:
+        if platform.system().lower() == "windows":
+            run("set FURY_OFFSCREEN=1 && pytest -svv --doctest-modules fury")
+            run(
+                "cd docs && make.bat clean && set FURY_OFFSCREEN=1 && make.bat -C . html && cd .."  # noqa
+            )
+        else:
+            run("FURY_OFFSCREEN=1 pytest -svv --doctest-modules fury")
+            run("cd docs && make clean && FURY_OFFSCREEN=1 make -C . html && cd ..")
+
+        answer = input("Have you checked the generated docs [yes/no]: ").strip()
+        if answer.lower() in ["yes", "y"]:
+            break
+        elif answer.lower() in ["no", "n"]:
+            print("Please, check tutorials, docs and figures before proceeding.")
+            continue
+        else:
+            print("Invalid input. Please answer with 'yes' or 'no'.")
+
+    print(
+        "✅ Release preparation complete. \n"
+        "You can create a PR now. Then, merge it and create a tag."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Summary

Preparation for 2.0.0a1 release, targeting, June 19th, 20245 

Just a note that any PR can block the release. If they are not in, it will be for the next release in
March.

# Release checklist
- [x] add release_notes 2.0.0a1 and update release-history.rst
- [x] Update .mailmap
- [x] Check the copyright years in LICENSE
- [x] Check documentation
- [x] Check Tutorial
- [x] Update index.rst
- [x] Add a blog post
- [x] Update website
- [x] Update deprecation cycle : delete if expired since 3 releases.