### PR TITLE
RF: update star primitive

### DIFF
--- a/fury/primitive.py
+++ b/fury/primitive.py
@@ -696,12 +696,12 @@ def prim_rhombicuboctahedron():
 
 
 def prim_star(*, dim=2):
-    """Return vertices and triangles for star geometry.
+    """Return vertices and triangles for a 5-pointed star (2D or 3D).
 
     Parameters
     ----------
     dim : int, optional
-        Dimension of the star (2 or 3).
+        Dimension of the star, either 2 or 3.
 
     Returns
     -------
@@ -710,87 +710,48 @@ def prim_star(*, dim=2):
     triangles : ndarray
         Triangles that compose the star.
     """
+    outer_radius = 1 / 2
+    inner_radius = 1 / 5
+    z_height = 1 / 10
+
+    if dim not in (2, 3):
+        raise ValueError("prim_star supports only dim=2 or dim=3")
+
+    pi = math.pi
+    angles = [pi / 2 + i * 2 * pi / 5 for i in range(5)]
+    inner_angles = [ang + pi / 5 for ang in angles]
+
+    base = []
+    for i in range(5):
+        a = angles[i]
+        ia = inner_angles[i]
+        base.append([outer_radius * math.cos(a), outer_radius * math.sin(a), 0])
+        base.append([inner_radius * math.cos(ia), inner_radius * math.sin(ia), 0])
+
+    faces = [
+        [0, 1, 9],
+        [1, 2, 3],
+        [3, 4, 5],
+        [5, 6, 7],
+        [7, 8, 9],
+        [1, 3, 5],
+        [1, 5, 7],
+        [1, 7, 9],
+    ]
+
     if dim == 2:
-        vert = np.array(
-            [
-                [-2.0, -3.0, 0.0],
-                [0.0, -2.0, 0.0],
-                [3.0, -3.0, 0.0],
-                [2.0, -1.0, 0.0],
-                [3.0, 1.0, 0.0],
-                [1.0, 1.0, 0.0],
-                [0.0, 3.0, 0.0],
-                [-1.0, 1.0, 0.0],
-                [-3.0, 1.0, 0.0],
-                [-2.0, -1.0, 0.0],
-            ]
-        )
+        vertices = np.array(base, dtype=float)
+        return vertices, np.array(faces, dtype=int)
 
-        triangles = np.array(
-            [
-                [1, 9, 0],
-                [1, 2, 3],
-                [3, 4, 5],
-                [5, 6, 7],
-                [7, 8, 9],
-                [1, 9, 3],
-                [3, 7, 9],
-                [3, 5, 7],
-            ],
-            dtype="i8",
-        )
+    vertices = base + [[0, 0, z_height], [0, 0, -z_height]]
+    top_idx, bot_idx = 10, 11
+    for i in range(10):
+        j = (i + 1) % 10
+        faces.append([i, j, top_idx])
+        faces.append([j, i, bot_idx])
 
-    if dim == 3:
-        vert = np.array(
-            [
-                [-2.0, -3.0, 0.0],
-                [0.0, -2, 0.0],
-                [3.0, -3.0, 0.0],
-                [2.0, -1.0, 0.0],
-                [3.0, 0.5, 0.0],
-                [1.0, 0.5, 0.0],
-                [0, 3.0, 0.0],
-                [-1.0, 0.5, 0.0],
-                [-3.0, 0.5, 0.0],
-                [-2.0, -1.0, 0.0],
-                [0.0, 0.0, 0.5],
-                [0.0, 0.0, -0.5],
-            ]
-        )
-        triangles = np.array(
-            [
-                [1, 9, 0],
-                [1, 2, 3],
-                [3, 4, 5],
-                [5, 6, 7],
-                [7, 8, 9],
-                [1, 9, 3],
-                [3, 7, 9],
-                [3, 5, 7],
-                [1, 0, 10],
-                [0, 9, 10],
-                [10, 9, 8],
-                [7, 8, 10],
-                [6, 7, 10],
-                [5, 6, 10],
-                [5, 10, 4],
-                [10, 3, 4],
-                [3, 10, 2],
-                [10, 1, 2],
-                [1, 0, 11],
-                [0, 9, 11],
-                [11, 9, 8],
-                [7, 8, 10],
-                [6, 7, 11],
-                [5, 6, 11],
-                [5, 10, 4],
-                [11, 3, 4],
-                [3, 11, 2],
-                [11, 1, 2],
-            ],
-            dtype="i8",
-        )
-    return vert, triangles
+    vertices = np.array(vertices, dtype=float)
+    return vertices, np.array(faces, dtype=int)
 
 
 def prim_triangularprism():

--- a/fury/tests/test_primitive.py
+++ b/fury/tests/test_primitive.py
@@ -14,7 +14,7 @@ def test_vertices_primitives():
         (fp.prim_box, (24, 3), -0.5, 0.5, 0, {"detailed": True}),
         (fp.prim_box, (8, 3), -0.5, 0.5, 0, {"detailed": False}),
         (fp.prim_tetrahedron, (4, 3), -0.5, 0.5, 0, {}),
-        (fp.prim_star, (10, 3), -3, 3, -0.0666666666, {}),
+        (fp.prim_star, (10, 3), -0.47552825814757677, 1 / 2, 0, {}),
         (fp.prim_rhombicuboctahedron, (24, 3), -0.5, 0.5, 0, {}),
         (fp.prim_frustum, (8, 3), -0.5, 0.5, 0, {}),
     ]
@@ -28,9 +28,10 @@ def test_vertices_primitives():
 
     vertices, _ = fp.prim_star(dim=3)
     npt.assert_equal(vertices.shape, (12, 3))
-    npt.assert_almost_equal(abs(np.mean(vertices)), 0.11111111)
-    npt.assert_equal(vertices.min(), -3)
-    npt.assert_equal(vertices.max(), 3)
+    npt.assert_almost_equal(np.mean(vertices), 0, decimal=7)
+    # Ensure no coordinate exceeds the specified outer radius
+    npt.assert_(vertices.min() >= -1 / 2)
+    npt.assert_equal(vertices.max(), 1 / 2)
 
 
 def test_vertices_primitives_icosahedron():


### PR DESCRIPTION
this PR fix #1016

as explained, the star actor was not symmetrical which is not the case anymore (see screenshot and code)

```python
from fury import window, actor
import numpy as np

scene = window.Scene()
centers = np.zeros((1, 3))
colors = np.random.rand(1, 3)
star_actor = actor.star(dim=2, centers=centers, colors=colors)
_ = scene.add(star_actor, actor.axes())
show_manager = window.ShowManager(scene=scene, size=(600, 600))
show_manager.start()
```

<img width="592" height="624" alt="image" src="https://github.com/user-attachments/assets/1d329314-701b-41a2-8929-f65e22e846f8" />

<img width="595" height="620" alt="image" src="https://github.com/user-attachments/assets/b27ed895-067e-4d51-b2a7-47734092805e" />



