### PR TITLE
BF: Updated the line_buffer_separator

### DIFF
--- a/fury/actor/core.py
+++ b/fury/actor/core.py
@@ -290,30 +290,18 @@ def line(
     >>> show_manager.start()
     """
 
-    lines_positions, lines_colors = line_buffer_separator(
-        lines, color=colors, color_mode="auto"
-    )
+    lines_positions, lines_colors = line_buffer_separator(lines, color=colors)
 
     geo = buffer_to_geometry(
         positions=lines_positions.astype("float32"),
-        colors=lines_colors.astype("float32")
-        if lines_colors is not None
-        else np.empty_like(lines_positions),
+        colors=lines_colors.astype("float32"),
     )
-
-    if lines_colors is None:
-        material_mode = "auto"
-        material_colors = None
-    else:
-        material_mode = "vertex"
-        material_colors = lines_colors
 
     mat = _create_line_material(
         material=material,
         enable_picking=enable_picking,
-        mode=material_mode,
+        mode="vertex",
         opacity=opacity,
-        color=material_colors,
     )
 
     obj = create_line(geometry=geo, material=mat)

--- a/fury/tests/test_geometry.py
+++ b/fury/tests/test_geometry.py
@@ -43,16 +43,24 @@ def test_line_buffer_separator():
     npt.assert_array_equal(positions[:2], line_vertices[0])
     assert np.all(np.isnan(positions[2]))
     npt.assert_array_equal(positions[3:], line_vertices[1])
-    assert colors is None
+    expected_colors = np.array(
+        [
+            [1, 1, 1, 1],
+            [1, 1, 1, 1],
+            [np.nan, np.nan, np.nan, np.nan],
+            [1, 1, 1, 1],
+            [1, 1, 1, 1],
+        ],
+        dtype=np.float32,
+    )
+    npt.assert_array_equal(colors, expected_colors)
 
     line_vertices = [
         np.array([[0, 0, 0], [1, 1, 1]], dtype=np.float32),
         np.array([[2, 2, 2], [3, 3, 3]], dtype=np.float32),
     ]
     color = np.array([[1.0, 0, 0], [0.0, 1.0, 0.0]], dtype=np.float32)
-    positions, colors = geometry.line_buffer_separator(
-        line_vertices, color=color, color_mode="line"
-    )
+    positions, colors = geometry.line_buffer_separator(line_vertices, color=color)
     expected_colors = np.array(
         [
             [1, 0, 0],
@@ -70,9 +78,7 @@ def test_line_buffer_separator():
         np.array([[2, 2, 2], [3, 3, 3]], dtype=np.float32),
     ]
     color = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1], [1, 1, 0]], dtype=np.float32)
-    positions, colors = geometry.line_buffer_separator(
-        line_vertices, color=color, color_mode="vertex_flattened"
-    )
+    positions, colors = geometry.line_buffer_separator(line_vertices, color=color)
     expected_colors = np.array(
         [
             [1, 0, 0],
@@ -148,18 +154,23 @@ def test_line_buffer_separator():
     ]
     color = np.array([1, 0, 0], dtype=np.float32)  # valid color now
 
-    geometry.line_buffer_separator(line_vertices, color=color, color_mode="auto")
+    geometry.line_buffer_separator(line_vertices, color=color)
 
     line_vertices = [np.array([[0, 0, 0], [1, 1, 1]], dtype=np.float32)]
     positions, colors = geometry.line_buffer_separator(line_vertices)
     npt.assert_array_equal(positions, line_vertices[0])
-    assert colors is None
+    expected_colors = np.array(
+        [
+            [1, 1, 1, 1],
+            [1, 1, 1, 1],
+        ],
+        dtype=np.float32,
+    )
+    npt.assert_array_equal(colors, expected_colors)
 
     line_vertices = [np.array([[0, 0, 0], [1, 1, 1]], dtype=np.float32)]
     color = np.array([[1, 0, 0]], dtype=np.float32)
-    positions, colors = geometry.line_buffer_separator(
-        line_vertices, color=color, color_mode="line"
-    )
+    positions, colors = geometry.line_buffer_separator(line_vertices, color=color)
     expected_colors = np.array([[1, 0, 0], [1, 0, 0]], dtype=np.float32)
     npt.assert_array_equal(colors, expected_colors)
 


### PR DESCRIPTION
### BF: Updated the line_buffer_separator

**PR Contents**

- removed redundant `color_mode` parameter from the function
- updated it to expected behavior on single color.
- updated test cases to the expected behavior.
- updated line actor to use the latest updated function.

**Code to try out: same as number of lines**
```
def simulated_bundle(no_streamlines=10, waves=False):
    t = np.linspace(20, 80, 200)
    # parallel waves or parallel lines
    bundle = []
    for i in np.linspace(-5, 5, no_streamlines):
        if waves:
            pts = np.vstack((np.cos(t), t, i * np.ones(t.shape))).T
        else:
            pts = np.vstack((np.zeros(t.shape), t, i * np.ones(t.shape))).T
        bundle.append(pts)

    return np.asarray(bundle)


scene = window.Scene()
bundle = simulated_bundle(no_streamlines=3, waves=False)
print(f"Number of streamlines: {bundle.shape}")
slines_actor = actor.line(np.array(bundle), colors=[(1, 0, 0), (0, 1, 0), (0, 0, 1)])
scene.add(slines_actor)
window.show(actors=[slines_actor])
```

**Code to try out: single color**
```
slines_actor = actor.line(np.array(bundle), colors=(1, 0, 0))
```

**Code to try out: No color**
```
slines_actor = actor.line(np.array(bundle))
```

**Code to try out: same as all vertices but in the fashion that lines are provided**
```
slines_actor = actor.line(np.array(bundle), colors=np.random.rand(*bundle.shape))
```

**Code to try out: same as all vertices in flatten format**
```
slines_actor = actor.line(
    np.array(bundle), colors=np.random.rand(np.prod(bundle.shape[:2]), 3)
)
```