### PR TITLE
Shader-based Billboard actor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
         args: ["fury"]
         pass_filenames: false
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.1
+    rev: v0.14.2
     hooks:
       # Run the linter
     -   id: ruff

--- a/fury/actor/__init__.pyi
+++ b/fury/actor/__init__.pyi
@@ -42,10 +42,10 @@ __all__ = [
     "line_projection",
 ]
 
+from .billboard import billboard
 from .bio import peaks_slicer, volume_slicer
 from .core import actor_from_primitive, arrow, axes, line
 from .curved import cone, cylinder, ellipsoid, sphere, streamlines, streamtube
-from .billboard import billboard
 from .planar import (
     disk,
     image,

--- a/fury/actor/__init__.pyi
+++ b/fury/actor/__init__.pyi
@@ -28,6 +28,7 @@ __all__ = [
     "star",
     "text",
     "triangle",
+    "billboard",
     "sph_glyph",
     "vector_field",
     "vector_field_slicer",
@@ -44,6 +45,7 @@ __all__ = [
 from .bio import peaks_slicer, volume_slicer
 from .core import actor_from_primitive, arrow, axes, line
 from .curved import cone, cylinder, ellipsoid, sphere, streamlines, streamtube
+from .billboard import billboard
 from .planar import (
     disk,
     image,

--- a/fury/actor/billboard.py
+++ b/fury/actor/billboard.py
@@ -86,13 +86,12 @@ def billboard(
     sz = np.repeat(sizes, repeats, axis=0).astype(np.float32)
     indices = np.arange(pos.shape[0], dtype=np.uint32)
 
-    # Add dummy normals to avoid MeshShader pipeline issues
-    normals = np.tile([[0.0, 0.0, 1.0]], (pos.shape[0], 1)).astype(np.float32)
+    normals = np.zeros((pos.shape[0], 3), dtype=np.float32)
+    normals[:, 0:2] = sz
 
     geometry = buffer_to_geometry(
         positions=pos,
         colors=col,
-        texcoords=sz,
         normals=normals,
         indices=indices,
     )

--- a/fury/actor/billboard.py
+++ b/fury/actor/billboard.py
@@ -79,10 +79,14 @@ def billboard(
     sz = np.repeat(sizes, repeats, axis=0).astype(np.float32)
     indices = np.arange(pos.shape[0], dtype=np.uint32)
 
+    # Add dummy normals to avoid MeshShader pipeline issues
+    normals = np.tile([[0.0, 0.0, 1.0]], (pos.shape[0], 1)).astype(np.float32)
+
     geometry = buffer_to_geometry(
         positions=pos,
         colors=col,
         texcoords=sz,
+        normals=normals,
         indices=indices,
     )
 

--- a/fury/actor/billboard.py
+++ b/fury/actor/billboard.py
@@ -1,0 +1,105 @@
+"""Billboard actor module.
+
+Minimal isolated implementation of billboard support to reduce diffs in
+existing planar actor module. Provides a Mesh-based world object and a
+factory function plus shader registration.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from fury.geometry import buffer_to_geometry
+from fury.lib import Mesh, register_wgpu_render_function
+from fury.material import BillboardMaterial, validate_opacity
+
+
+class Billboard(Mesh):
+    """World object representing one or more billboards.
+
+    Geometry buffers are duplicated per 6 vertices (two triangles) per
+    billboard; vertex shader reconstructs quad via vertex_index math and
+    uses camera right/up vectors to orient.
+    """
+    pass
+
+
+def billboard(
+    centers,
+    *,
+    colors=(1, 1, 1),
+    sizes=(1, 1),
+    opacity=None,
+    enable_picking=True,
+):
+    """Create a billboard world object.
+
+    Parameters
+    ----------
+    centers : (N,3) array_like
+        Billboard positions.
+    colors : (N,3|4) array_like or single color
+        Per-billboard RGB(A) colors.
+    sizes : (N,2) | (2,) | float | (N,) array_like
+        Width/height per billboard. Scalar or single pair broadcast.
+    opacity : float, optional
+        Global opacity multiplier (0..1).
+    enable_picking : bool
+        Whether billboard is pickable.
+    """
+    centers = np.asarray(centers, dtype=np.float32)
+    if centers.ndim == 1:
+        centers = centers.reshape(1, 3)
+    n = len(centers)
+
+    colors = np.asarray(colors, dtype=np.float32)
+    if colors.ndim == 1:
+        colors = np.tile(colors, (n, 1))
+    elif colors.shape[0] != n:
+        colors = np.tile(colors[0], (n, 1))
+
+    sizes = np.asarray(sizes, dtype=np.float32)
+    if sizes.ndim == 0:
+        sizes = np.full((n, 2), float(sizes))
+    elif sizes.ndim == 1:
+        if sizes.size == 2:
+            sizes = np.tile(sizes, (n, 1))
+        elif sizes.size == n:  # per-billboard square
+            sizes = np.column_stack([sizes, sizes])
+        else:
+            sizes = np.full((n, 2), sizes.flat[0])
+    elif sizes.shape[0] != n:
+        sizes = np.tile(sizes[0], (n, 1))
+
+    opacity = validate_opacity(opacity)
+
+    repeats = 6  # 2 triangles per quad
+    pos = np.repeat(centers, repeats, axis=0).astype(np.float32)
+    col = np.repeat(colors, repeats, axis=0).astype(np.float32)
+    sz = np.repeat(sizes, repeats, axis=0).astype(np.float32)
+    indices = np.arange(pos.shape[0], dtype=np.uint32)
+
+    geometry = buffer_to_geometry(
+        positions=pos,
+        colors=col,
+        texcoords=sz,
+        indices=indices,
+    )
+
+    material = BillboardMaterial(
+        pick_write=enable_picking,
+        opacity=opacity,
+        color_mode="vertex",
+    )
+
+    obj = Billboard(geometry=geometry, material=material)
+    obj.billboard_count = n
+    obj.billboard_centers = centers.copy()
+    return obj
+
+
+@register_wgpu_render_function(Billboard, BillboardMaterial)
+def register_billboard_render_function(wobject):
+    from fury.shader import BillboardShader
+
+    return (BillboardShader(wobject),)

--- a/fury/actor/billboard.py
+++ b/fury/actor/billboard.py
@@ -18,9 +18,10 @@ class Billboard(Mesh):
     """World object representing one or more billboards.
 
     Geometry buffers are duplicated per 6 vertices (two triangles) per
-    billboard; vertex shader reconstructs quad via vertex_index math and
-    uses camera right/up vectors to orient.
+    billboard; the vertex shader reconstructs the quad via ``vertex_index``
+    math and uses camera right/up vectors to orient it.
     """
+
     pass
 
 
@@ -46,6 +47,12 @@ def billboard(
         Global opacity multiplier (0..1).
     enable_picking : bool
         Whether billboard is pickable.
+
+    Returns
+    -------
+    Billboard
+        Billboard world object configured with the provided geometry and
+        material.
     """
     centers = np.asarray(centers, dtype=np.float32)
     if centers.ndim == 1:
@@ -104,6 +111,18 @@ def billboard(
 
 @register_wgpu_render_function(Billboard, BillboardMaterial)
 def register_billboard_render_function(wobject):
+    """Build the render pipeline for ``Billboard`` instances.
+
+    Parameters
+    ----------
+    wobject : Billboard
+        Billboard world object to bind to the shader pipeline.
+
+    Returns
+    -------
+    tuple
+        Tuple containing the configured shader instance.
+    """
     from fury.shader import BillboardShader
 
     return (BillboardShader(wobject),)

--- a/fury/material.py
+++ b/fury/material.py
@@ -794,9 +794,8 @@ class StreamlinesMaterial(LineMaterial):
 
 
 class BillboardMaterial(MeshBasicMaterial):
-    """
-    A Billboard material for creating billboards that always face the camera.
-    
+    """Billboard material for creating quads that always face the camera.
+
     This material is designed to work with the BillboardShader to create
     rectangles that automatically rotate to face the camera while maintaining
     their 3D position.
@@ -808,4 +807,11 @@ class BillboardMaterial(MeshBasicMaterial):
     """
 
     def __init__(self, **kwargs):
+        """Initialize the material and forward arguments to the base class.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Additional keyword arguments forwarded to ``MeshBasicMaterial``.
+        """
         super().__init__(**kwargs)

--- a/fury/material.py
+++ b/fury/material.py
@@ -791,3 +791,21 @@ class StreamlinesMaterial(LineMaterial):
 
         self.uniform_buffer.data["outline_color"] = value
         self.uniform_buffer.update_full()
+
+
+class BillboardMaterial(MeshBasicMaterial):
+    """
+    A Billboard material for creating billboards that always face the camera.
+    
+    This material is designed to work with the BillboardShader to create
+    rectangles that automatically rotate to face the camera while maintaining
+    their 3D position.
+
+    Parameters
+    ----------
+    **kwargs : dict
+        Additional keyword arguments to pass to the MeshBasicMaterial constructor.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)

--- a/fury/shader.py
+++ b/fury/shader.py
@@ -479,7 +479,6 @@ class BillboardShader(MeshShader):
             The mesh object containing billboard data.
         """
         super().__init__(wobject)
-        # Billboard-specific parameters can be set here
         if hasattr(wobject, "billboard_count"):
             self["billboard_count"] = wobject.billboard_count
         else:

--- a/fury/shader.py
+++ b/fury/shader.py
@@ -7,6 +7,7 @@ from fury.lib import (
     Binding,
     Buffer,
     LineShader,
+    MeshShader,
     ThinLineSegmentShader,
     load_wgsl,
 )
@@ -458,3 +459,38 @@ class LineProjectionComputeShader(BaseShader):
             The WGSL code as a string.
         """
         return load_wgsl("line_projection_compute.wgsl", package_name="fury.wgsl")
+
+
+class BillboardShader(MeshShader):
+    """Shader for Billboard actor.
+
+    Parameters
+    ----------
+    wobject : Mesh
+        The mesh object containing billboard data.
+    """
+
+    def __init__(self, wobject):
+        """Initialize the BillboardShader with the given mesh object.
+
+        Parameters
+        ----------
+        wobject : Mesh
+            The mesh object containing billboard data.
+        """
+        super().__init__(wobject)
+        # Billboard-specific parameters can be set here
+        if hasattr(wobject, 'billboard_count'):
+            self["billboard_count"] = wobject.billboard_count
+        else:
+            self["billboard_count"] = 1
+
+    def get_code(self):
+        """Get the WGSL code for the billboard render shader.
+
+        Returns
+        -------
+        str
+            The WGSL code as a string.
+        """
+        return load_wgsl("billboard_render.wgsl", package_name="fury.wgsl")

--- a/fury/shader.py
+++ b/fury/shader.py
@@ -480,7 +480,7 @@ class BillboardShader(MeshShader):
         """
         super().__init__(wobject)
         # Billboard-specific parameters can be set here
-        if hasattr(wobject, 'billboard_count'):
+        if hasattr(wobject, "billboard_count"):
             self["billboard_count"] = wobject.billboard_count
         else:
             self["billboard_count"] = 1

--- a/fury/tests/test_billboard.py
+++ b/fury/tests/test_billboard.py
@@ -1,0 +1,116 @@
+"""Tests for billboard actor.
+
+Simple tests for billboard creation and basic rendering functionality.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import numpy as np
+import numpy.testing as npt
+
+from fury import actor, window
+
+
+def test_basic_billboard(interactive: bool = False):
+    """Test billboard creation, geometry, rendering, and camera facing behavior."""
+    # Test creation and geometry setup
+    centers = [[0, 0, 0], [1, 2, 3], [-2, 0.5, 4]]
+    colors = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    sizes = [[1.0, 2.0], [0.5, 0.5], [2.0, 1.0]]
+
+    bb = actor.billboard(centers, colors=colors, sizes=sizes, opacity=0.75)
+
+    # Check billboard count
+    assert hasattr(bb, "billboard_count")
+    npt.assert_equal(bb.billboard_count, 3)
+
+    # Check geometry (6 vertices per billboard)
+    geom = bb.geometry
+    npt.assert_equal(len(geom.positions.data), 18)
+    npt.assert_equal(len(geom.colors.data), 18)
+    npt.assert_equal(len(geom.texcoords.data), 18)
+    npt.assert_equal(len(geom.indices.data), 18)
+
+    # Check material opacity
+    assert np.isclose(bb.material.opacity, 0.75)
+
+    # Test scalar size
+    bb_scalar = actor.billboard(centers, colors=colors, sizes=0.4)
+    geom_scalar = bb_scalar.geometry
+    npt.assert_equal(len(geom_scalar.positions.data), 18)
+    npt.assert_equal(len(geom_scalar.texcoords.data), 18)
+
+    # Test basic rendering
+    scene = window.Scene()
+    scene.background = (0, 0, 0)
+
+    center = np.array([[0.0, 0.0, 0.0]])
+    color = np.array([[1.0, 0.0, 0.0]])  # red
+    bb_render = actor.billboard(center, colors=color, sizes=(1.0, 1.0))
+    scene.add(bb_render)
+
+    if interactive:  # pragma: no cover
+        window.show(scene)
+
+    # Test snapshot creation
+    tmp_file = tempfile.mktemp(suffix="_bb.png")
+    arr = window.snapshot(scene=scene, fname=tmp_file, return_array=True)
+
+    # Basic checks: array exists and has expected shape
+    assert arr is not None
+    assert arr.ndim == 3
+    assert arr.shape[-1] >= 3  # RGB or RGBA
+    
+    # Check that billboard is visible (has red pixels)
+    _assert_red_visible(arr)
+
+    scene.clear()
+    if tmp_file and os.path.exists(tmp_file):
+        os.remove(tmp_file)
+
+
+def test_billboard_camera_facing():
+    """Test that billboard faces camera from different viewpoints."""
+    scene = window.Scene()
+    scene.background = (0, 0, 0)
+
+    # Create a billboard at origin
+    center = np.array([[0.0, 0.0, 0.0]])
+    color = np.array([[0.0, 1.0, 0.0]])  # green
+    bb = actor.billboard(center, colors=color, sizes=(2.0, 2.0))
+    scene.add(bb)
+
+    # Test from default camera position
+    tmp_file1 = tempfile.mktemp(suffix="_bb_front.png")
+    arr1 = window.snapshot(scene=scene, fname=tmp_file1, return_array=True)
+
+    # Billboard should be visible from front view
+    data1 = np.asarray(arr1)
+    green_pixels1 = (np.sum(data1[..., 1] > data1[..., 0]) +
+                     np.sum(data1[..., 1] > data1[..., 2]))
+
+    # Move camera to side (if we had camera controls, but we test basic visibility)
+    # Since we can't move camera easily, just test that billboard is rendered
+    assert arr1 is not None
+    assert green_pixels1 > 0, "Billboard should be visible with green pixels"
+
+    # Cleanup
+    scene.clear()
+    for tmp_file in [tmp_file1]:
+        if tmp_file and os.path.exists(tmp_file):
+            os.remove(tmp_file)
+
+
+def _assert_red_visible(image):
+    """Check if red pixels exist in image."""
+    data = np.asarray(image)
+    if data.ndim != 3 or data.shape[-1] < 3:
+        raise AssertionError("Invalid image format")
+
+    red = data[..., 0]
+    has_red = np.any(red > 0)
+    if not has_red:
+        raise AssertionError("No red pixels found")

--- a/fury/tests/test_billboard.py
+++ b/fury/tests/test_billboard.py
@@ -63,7 +63,7 @@ def test_basic_billboard(interactive: bool = False):
     assert arr is not None
     assert arr.ndim == 3
     assert arr.shape[-1] >= 3  # RGB or RGBA
-    
+
     # Check that billboard is visible (has red pixels)
     _assert_red_visible(arr)
 
@@ -89,8 +89,9 @@ def test_billboard_camera_facing():
 
     # Billboard should be visible from front view
     data1 = np.asarray(arr1)
-    green_pixels1 = (np.sum(data1[..., 1] > data1[..., 0]) +
-                     np.sum(data1[..., 1] > data1[..., 2]))
+    green_pixels1 = np.sum(data1[..., 1] > data1[..., 0]) + np.sum(
+        data1[..., 1] > data1[..., 2]
+    )
 
     # Move camera to side (if we had camera controls, but we test basic visibility)
     # Since we can't move camera easily, just test that billboard is rendered

--- a/fury/wgsl/billboard_render.wgsl
+++ b/fury/wgsl/billboard_render.wgsl
@@ -11,75 +11,75 @@ fn vs_main(in: VertexInput) -> Varyings {
     // Each billboard uses 6 vertices (2 triangles to form a quad)
     let billboard_index = i32(in.index) / 6;
     let vertex_in_quad = i32(in.index) % 6;
-    
+
     // Quad vertices in local space (counter-clockwise winding)
     var local_pos: vec2<f32>;
     switch vertex_in_quad {
         case 0: { local_pos = vec2<f32>(-0.5, -0.5); } // bottom left
-        case 1: { local_pos = vec2<f32>(0.5, -0.5); }  // bottom right  
+        case 1: { local_pos = vec2<f32>(0.5, -0.5); }  // bottom right
         case 2: { local_pos = vec2<f32>(-0.5, 0.5); }  // top left
         case 3: { local_pos = vec2<f32>(0.5, -0.5); }  // bottom right
         case 4: { local_pos = vec2<f32>(0.5, 0.5); }   // top right
         default: { local_pos = vec2<f32>(-0.5, 0.5); } // top left
     }
-    
+
     // Load billboard center position from storage buffer. Each center is
     // duplicated 6 times in the geometry buffer, so pick the first occurrence.
     let raw_center = load_s_positions(billboard_index * 6);
     let world_center = u_wobject.world_transform * vec4<f32>(raw_center.xyz, 1.0);
-    
+
     // Transform center to camera space
     let camera_center = u_stdinfo.cam_transform * world_center;
-    
+
     // Get camera right and up vectors in world space
     // Extract right and up vectors from inverse camera transform
     let cam_right = vec3<f32>(u_stdinfo.cam_transform_inv[0].xyz);
     let cam_up = vec3<f32>(u_stdinfo.cam_transform_inv[1].xyz);
-    
+
     // Temporary: fixed size until texcoords binding issue resolved
     let size = vec2<f32>(1.0, 1.0);
-    
+
     // Calculate billboard vertex position in world space
     let billboard_offset = local_pos.x * cam_right * size.x + local_pos.y * cam_up * size.y;
     let world_pos = world_center.xyz + billboard_offset;
-    
+
     // Transform to clip space
     let clip_pos = u_stdinfo.projection_transform * u_stdinfo.cam_transform * vec4<f32>(world_pos, 1.0);
-    
+
     // Calculate texture coordinates
     var tex_coord: vec2<f32>;
     switch vertex_in_quad {
         case 0: { tex_coord = vec2<f32>(0.0, 0.0); } // bottom left
         case 1: { tex_coord = vec2<f32>(1.0, 0.0); } // bottom right
-        case 2: { tex_coord = vec2<f32>(0.0, 1.0); } // top left  
+        case 2: { tex_coord = vec2<f32>(0.0, 1.0); } // top left
         case 3: { tex_coord = vec2<f32>(1.0, 0.0); } // bottom right
         case 4: { tex_coord = vec2<f32>(1.0, 1.0); } // top right
         default: { tex_coord = vec2<f32>(0.0, 1.0); } // top left
     }
-    
+
     var varyings: Varyings;
     varyings.position = vec4<f32>(clip_pos);
     varyings.world_pos = vec3<f32>(world_pos);
-    
+
     // Load color if available - colors are duplicated 6x like positions
     let color = load_s_colors(billboard_index * 6);
     varyings.color = vec4<f32>(color, 1.0);
-    
+
     return varyings;
 }
 
 @fragment
 fn fs_main(varyings: Varyings) -> FragmentOutput {
     {$ include 'pygfx.clipping_planes.wgsl' $}
-    
+
     // Use the color from vertex shader
     let color = varyings.color;
     let physical_color = srgb2physical(color.rgb);
     let opacity = color.a * u_material.opacity;
     let out_color = vec4<f32>(physical_color, opacity);
-    
+
     var out: FragmentOutput;
     out.color = out_color;
-    
+
     return out;
 }

--- a/fury/wgsl/billboard_render.wgsl
+++ b/fury/wgsl/billboard_render.wgsl
@@ -36,8 +36,8 @@ fn vs_main(in: VertexInput) -> Varyings {
     let cam_right = vec3<f32>(u_stdinfo.cam_transform_inv[0].xyz);
     let cam_up = vec3<f32>(u_stdinfo.cam_transform_inv[1].xyz);
 
-    // Temporary: fixed size until texcoords binding issue resolved
-    let size = vec2<f32>(1.0, 1.0);
+    let normal_data = load_s_normals(billboard_index * 6);
+    let size = vec2<f32>(normal_data.x, normal_data.y);
 
     // Calculate billboard vertex position in world space
     let billboard_offset = local_pos.x * cam_right * size.x + local_pos.y * cam_up * size.y;

--- a/fury/wgsl/billboard_render.wgsl
+++ b/fury/wgsl/billboard_render.wgsl
@@ -1,0 +1,85 @@
+{$ include 'pygfx.std.wgsl' $}
+{$ include 'fury.utils.wgsl' $}
+
+struct VertexInput {
+    @builtin(vertex_index) index : u32,
+};
+
+@vertex
+fn vs_main(in: VertexInput) -> Varyings {
+    // Generate quad vertices for billboard
+    // Each billboard uses 6 vertices (2 triangles to form a quad)
+    let billboard_index = i32(in.index) / 6;
+    let vertex_in_quad = i32(in.index) % 6;
+    
+    // Quad vertices in local space (counter-clockwise winding)
+    var local_pos: vec2<f32>;
+    switch vertex_in_quad {
+        case 0: { local_pos = vec2<f32>(-0.5, -0.5); } // bottom left
+        case 1: { local_pos = vec2<f32>(0.5, -0.5); }  // bottom right  
+        case 2: { local_pos = vec2<f32>(-0.5, 0.5); }  // top left
+        case 3: { local_pos = vec2<f32>(0.5, -0.5); }  // bottom right
+        case 4: { local_pos = vec2<f32>(0.5, 0.5); }   // top right
+        default: { local_pos = vec2<f32>(-0.5, 0.5); } // top left
+    }
+    
+    // Load billboard center position from storage buffer. Each center is
+    // duplicated 6 times in the geometry buffer, so pick the first occurrence.
+    let raw_center = load_s_positions(billboard_index * 6);
+    let world_center = u_wobject.world_transform * vec4<f32>(raw_center.xyz, 1.0);
+    
+    // Transform center to camera space
+    let camera_center = u_stdinfo.cam_transform * world_center;
+    
+    // Get camera right and up vectors in world space
+    // Extract right and up vectors from inverse camera transform
+    let cam_right = vec3<f32>(u_stdinfo.cam_transform_inv[0].xyz);
+    let cam_up = vec3<f32>(u_stdinfo.cam_transform_inv[1].xyz);
+    
+    // Temporary: fixed size until texcoords binding issue resolved
+    let size = vec2<f32>(1.0, 1.0);
+    
+    // Calculate billboard vertex position in world space
+    let billboard_offset = local_pos.x * cam_right * size.x + local_pos.y * cam_up * size.y;
+    let world_pos = world_center.xyz + billboard_offset;
+    
+    // Transform to clip space
+    let clip_pos = u_stdinfo.projection_transform * u_stdinfo.cam_transform * vec4<f32>(world_pos, 1.0);
+    
+    // Calculate texture coordinates
+    var tex_coord: vec2<f32>;
+    switch vertex_in_quad {
+        case 0: { tex_coord = vec2<f32>(0.0, 0.0); } // bottom left
+        case 1: { tex_coord = vec2<f32>(1.0, 0.0); } // bottom right
+        case 2: { tex_coord = vec2<f32>(0.0, 1.0); } // top left  
+        case 3: { tex_coord = vec2<f32>(1.0, 0.0); } // bottom right
+        case 4: { tex_coord = vec2<f32>(1.0, 1.0); } // top right
+        default: { tex_coord = vec2<f32>(0.0, 1.0); } // top left
+    }
+    
+    var varyings: Varyings;
+    varyings.position = vec4<f32>(clip_pos);
+    varyings.world_pos = vec3<f32>(world_pos);
+    
+    // Load color if available
+    let color = load_s_colors(billboard_index);
+    varyings.color = vec4<f32>(color, 1.0);
+    
+    return varyings;
+}
+
+@fragment
+fn fs_main(varyings: Varyings) -> FragmentOutput {
+    {$ include 'pygfx.clipping_planes.wgsl' $}
+    
+    // Use the color from vertex shader
+    let color = varyings.color;
+    let physical_color = srgb2physical(color.rgb);
+    let opacity = color.a * u_material.opacity;
+    let out_color = vec4<f32>(physical_color, opacity);
+    
+    var out: FragmentOutput;
+    out.color = out_color;
+    
+    return out;
+}

--- a/fury/wgsl/billboard_render.wgsl
+++ b/fury/wgsl/billboard_render.wgsl
@@ -61,8 +61,8 @@ fn vs_main(in: VertexInput) -> Varyings {
     varyings.position = vec4<f32>(clip_pos);
     varyings.world_pos = vec3<f32>(world_pos);
     
-    // Load color if available
-    let color = load_s_colors(billboard_index);
+    // Load color if available - colors are duplicated 6x like positions
+    let color = load_s_colors(billboard_index * 6);
     varyings.color = vec4<f32>(color, 1.0);
     
     return varyings;


### PR DESCRIPTION
-  billboard actor using pure shader
- Implement Billboard, BillboardMaterial, and BillboardShader
- Add WGSL shder for quad generation


https://github.com/user-attachments/assets/c3eefd8d-be1b-44f9-bff7-31c26e11db0d

Example:

```python
import numpy as np
from fury import window, actor

centers = np.array([[0, 0, 0], [2, 0, 0], [-2, 0, 0]])
colors = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
sizes = np.array([[1.0, 1.0], [1.5, 0.8], [0.8, 1.5]])

billboard_actor = actor.billboard(
    centers=centers,
    colors=colors, 
    sizes=sizes,
    opacity=0.8
)

scene = window.Scene()
scene.add(billboard_actor)

sm = window.ShowManager(scene=scene, size=(600, 600))
sm.start()
```