### PR TITLE
Shader-generated Streamtube actor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
         args: ["fury"]
         pass_filenames: false
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.3
+    rev: v0.14.4
     hooks:
       # Run the linter
     -   id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
         args: ["fury"]
         pass_filenames: false
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.4
+    rev: v0.14.5
     hooks:
       # Run the linter
     -   id: ruff

--- a/fury/actor/curved.py
+++ b/fury/actor/curved.py
@@ -6,19 +6,30 @@ import numpy as np
 
 from fury.actor import actor_from_primitive
 from fury.geometry import buffer_to_geometry, create_mesh, line_buffer_separator
-from fury.lib import Line, register_wgpu_render_function
-from fury.material import StreamlinesMaterial, _create_mesh_material, validate_opacity
+from fury.lib import (
+    Buffer,
+    Line,
+    Mesh,
+    MeshPhongShader,
+    register_wgpu_render_function,
+)
+from fury.material import (
+    StreamlinesMaterial,
+    StreamtubeMaterial,
+    _StreamtubeBakedMaterial,
+    _create_mesh_material,
+    validate_opacity,
+)
 from fury.optpkg import optional_package
 import fury.primitive as fp
-from fury.shader import StreamlinesShader
+from fury.shader import StreamlinesShader, _StreamtubeBakingShader
 
 numba, have_numba, _ = optional_package("numba")
 
-# Create a conditional numba decorator
 if have_numba:
     njit = numba.njit
 else:
-    # No-op decorator when numba is not available
+
     def njit(*args, **kwargs):
         def decorator(func):
             return func
@@ -476,19 +487,6 @@ class Streamlines(Line):
             The color of the outline.
         enable_picking : bool, optional
             Whether the streamline should be pickable in a 3D scene.
-
-        Raises
-        ------
-        ValueError
-            If lines is not a valid numpy array with shape (N, 3).
-        ValueError
-            If colors is not a valid color tuple or array.
-        ValueError
-            If thickness or outline_thickness is not a positive number.
-        ValueError
-            If opacity is not between 0 and 1.
-        TypeError
-            If enable_picking is not a boolean.
         """
         super().__init__()
 
@@ -611,11 +609,9 @@ def compute_tangents(points):
     if N < 2:
         return tangents
 
-    # Central difference for interior points
     for i in range(1, N - 1):
         tangents[i] = points[i + 1] - points[i - 1]
 
-    # Forward/backward difference for endpoints
     tangents[0] = points[1] - points[0]
     tangents[-1] = points[-1] - points[-2]
 
@@ -774,6 +770,309 @@ def generate_tube_geometry(points, number_of_sides, radius, end_caps):
     return vertices, indices
 
 
+def _create_streamtube_baked(
+    lines,
+    *,
+    colors=None,
+    opacity=1.0,
+    radius=0.1,
+    segments=6,
+    end_caps=True,
+    enable_picking=True,
+    flat_shading=False,
+    material="phong",
+):
+    """Internal: Create streamtube geometry on the GPU using compute shaders.
+
+    This function is used internally by ``streamtube()`` and should not be
+    called directly by users.
+
+    Parameters
+    ----------
+    lines : sequence of array_like, shape (N_i, 3)
+        Iterable of polylines representing streamline vertices. Each line is
+        converted to ``float32`` and padded to the maximum length for GPU upload.
+    colors : array_like or None, optional
+        Per-line colors. Accepts a single RGB/RGBA vector or an array of shape
+        ``(1, 3|4)``/``(n_lines, 3|4)``. Defaults to white per line when ``None``.
+    opacity : float, optional
+        Opacity multiplier applied to the material. Valid range is ``[0, 1]``.
+    radius : float, optional
+        Tube radius in world units.
+    segments : int, optional
+        Number of radial segments making up the tube cross-section.
+    end_caps : bool, optional
+        If ``True`` flat caps are generated on both ends of each tube.
+    enable_picking : bool, optional
+        Whether the mesh writes to the picking buffer.
+    flat_shading : bool, optional
+        Controls whether flat or smooth shading is used by the Phong material.
+    material : {"phong"}, optional
+        Material type. GPU streamtubes currently only support ``"phong"``.
+
+    Returns
+    -------
+    Mesh
+        A pygfx mesh containing GPU-generated streamtube geometry and material.
+    """
+
+    if material != "phong":
+        raise ValueError("GPU streamtubes currently support material='phong' only.")
+
+    opacity = validate_opacity(opacity)
+
+    lines_arr = [
+        np.asarray(line, dtype=np.float32).reshape(-1, 3)
+        for line in np.asarray(lines, dtype=object)
+    ]
+    n_lines = len(lines_arr)
+
+    if n_lines == 0:
+        geometry = buffer_to_geometry(
+            positions=np.zeros((0, 3), dtype=np.float32),
+            normals=np.zeros((0, 3), dtype=np.float32),
+            colors=np.zeros((0, 3), dtype=np.float32),
+            indices=np.zeros((0, 3), dtype=np.uint32),
+        )
+        material_obj = _StreamtubeBakedMaterial(
+            opacity=opacity,
+            pick_write=enable_picking,
+            flat_shading=flat_shading,
+            color_mode="vertex",
+        )
+        material_obj.radius = radius
+        material_obj.segments = segments
+        material_obj.end_caps = end_caps
+        return create_mesh(geometry=geometry, material=material_obj)
+
+    line_lengths = np.array([line.shape[0] for line in lines_arr], dtype=np.uint32)
+    max_line_length = int(line_lengths.max(initial=0))
+
+    line_data = np.zeros((n_lines, max_line_length, 3), dtype=np.float32)
+    for idx, line in enumerate(lines_arr):
+        line_data[idx, : line.shape[0]] = line
+
+    if colors is None:
+        line_colors = np.tile(np.array([1.0, 1.0, 1.0], dtype=np.float32), (n_lines, 1))
+    else:
+        colors_arr = np.asarray(colors, dtype=np.float32)
+        if colors_arr.ndim == 1:
+            if colors_arr.size == 3:
+                colors_arr = colors_arr
+            elif colors_arr.size == 4:
+                colors_arr = colors_arr[:3]
+            else:
+                raise ValueError(
+                    "Colors must have length 3 (RGB) or 4 (RGBA) when provided as a "
+                    "vector."
+                )
+            line_colors = np.tile(colors_arr, (n_lines, 1))
+        elif colors_arr.ndim == 2:
+            if colors_arr.shape[0] not in (1, n_lines):
+                raise ValueError(
+                    "Colors array first dimension must be 1 or match number of lines."
+                )
+            base_colors = (
+                colors_arr
+                if colors_arr.shape[0] == n_lines
+                else np.repeat(colors_arr, n_lines, axis=0)
+            )
+            if base_colors.shape[1] == 3:
+                line_colors = base_colors
+            elif base_colors.shape[1] == 4:
+                line_colors = base_colors[:, :3]
+            else:
+                raise ValueError("Colors second dimension must be 3 (RGB) or 4 (RGBA).")
+        else:
+            raise ValueError(
+                "Colors must be a vector or a 2D array when using GPU backend."
+            )
+
+    line_colors = line_colors.astype(np.float32, copy=False)
+    color_components = line_colors.shape[1]
+
+    tube_sides = int(segments)
+    segments_per_line = np.maximum(line_lengths - 1, 0).astype(np.uint32)
+
+    ring_vertices_per_line = line_lengths * tube_sides
+    cap_vertex_count = 2 if end_caps else 0
+    vertices_per_line = ring_vertices_per_line + cap_vertex_count
+
+    ring_triangles_per_line = segments_per_line * tube_sides * 2
+    cap_triangles_per_line = (tube_sides * 2) if end_caps else 0
+    triangles_per_line = ring_triangles_per_line + cap_triangles_per_line
+
+    vertex_offsets = np.zeros(n_lines, dtype=np.uint32)
+    triangle_offsets = np.zeros(n_lines, dtype=np.uint32)
+    if n_lines > 1:
+        vertex_offsets[1:] = np.cumsum(vertices_per_line[:-1], dtype=np.uint64).astype(
+            np.uint32
+        )
+        triangle_offsets[1:] = np.cumsum(
+            triangles_per_line[:-1], dtype=np.uint64
+        ).astype(np.uint32)
+
+    total_vertices = int(vertices_per_line.astype(np.uint64).sum())
+    total_triangles = int(triangles_per_line.astype(np.uint64).sum())
+
+    positions_data = np.zeros((total_vertices, 3), dtype=np.float32)
+    normals_data = np.zeros((total_vertices, 3), dtype=np.float32)
+    colors_data = np.zeros((total_vertices, color_components), dtype=np.float32)
+    indices_data = np.zeros((total_triangles, 3), dtype=np.uint32)
+
+    geometry = buffer_to_geometry(
+        positions=positions_data,
+        normals=normals_data,
+        colors=colors_data,
+        indices=indices_data,
+    )
+
+    material_obj = _StreamtubeBakedMaterial(
+        opacity=opacity,
+        pick_write=enable_picking,
+        flat_shading=flat_shading,
+        color_mode="vertex",
+    )
+
+    material_obj.radius = radius
+    material_obj.segments = segments
+    material_obj.end_caps = end_caps
+
+    mesh_obj = create_mesh(geometry=geometry, material=material_obj)
+
+    mesh_obj.n_lines = n_lines  # type: ignore[attr-defined]
+    mesh_obj.max_line_length = max_line_length  # type: ignore[attr-defined]
+    mesh_obj.tube_sides = tube_sides  # type: ignore[attr-defined]
+    mesh_obj.radius = float(radius)  # type: ignore[attr-defined]
+    mesh_obj.line_lengths = line_lengths  # type: ignore[attr-defined]
+    mesh_obj.vertex_offsets = vertex_offsets  # type: ignore[attr-defined]
+    mesh_obj.triangle_offsets = triangle_offsets  # type: ignore[attr-defined]
+    mesh_obj.end_caps = end_caps  # type: ignore[attr-defined]
+    mesh_obj.lines = lines_arr  # type: ignore[attr-defined]
+    mesh_obj.line_colors = line_colors  # type: ignore[attr-defined]
+    mesh_obj.color_components = color_components  # type: ignore[attr-defined]
+    mesh_obj._needs_gpu_update = True  # type: ignore[attr-defined]
+
+    mesh_obj.line_buffer = Buffer(line_data.reshape(-1))  # type: ignore[attr-defined]
+    mesh_obj.length_buffer = Buffer(line_lengths)  # type: ignore[attr-defined]
+    mesh_obj.color_buffer = Buffer(line_colors)  # type: ignore[attr-defined]
+    mesh_obj.vertex_offset_buffer = Buffer(vertex_offsets)  # type: ignore[attr-defined]
+    mesh_obj.triangle_offset_buffer = Buffer(triangle_offsets)  # type: ignore[attr-defined]
+
+    material_obj._setup_compute_shader(
+        line_count=n_lines,
+        max_line_length=max_line_length,
+        tube_segments=tube_sides,
+    )
+
+    return mesh_obj
+
+
+def _create_streamtube_prebaked(
+    lines,
+    *,
+    colors=None,
+    opacity=1.0,
+    radius=0.1,
+    segments=6,
+    end_caps=True,
+    enable_picking=True,
+    flat_shading=False,
+    material="phong",
+):
+    """Internal: Create GPU streamtubes and bake geometry immediately.
+
+    This function creates streamtubes using GPU compute shaders and immediately
+    bakes the geometry by triggering an offscreen render pass. The result is a
+    mesh with fully computed geometry that no longer needs compute shaders.
+
+    This function is used internally by ``streamtube()`` and should not be
+    called directly by users.
+
+    Parameters
+    ----------
+    lines : sequence of array_like, shape (N_i, 3)
+        Iterable of polylines representing streamline vertices.
+    colors : array_like or None, optional
+        Per-line colors. Accepts a single RGB/RGBA vector or an array of shape
+        ``(1, 3|4)``/``(n_lines, 3|4)``. Defaults to white per line when ``None``.
+    opacity : float, optional
+        Opacity multiplier applied to the material. Valid range is ``[0, 1]``.
+    radius : float, optional
+        Tube radius in world units.
+    segments : int, optional
+        Number of radial segments making up the tube cross-section.
+    end_caps : bool, optional
+        If ``True`` flat caps are generated on both ends of each tube.
+    enable_picking : bool, optional
+        Whether the mesh writes to the picking buffer.
+    flat_shading : bool, optional
+        Controls whether flat or smooth shading is used by the Phong material.
+    material : {"phong"}, optional
+        Material type. GPU streamtubes currently only support ``"phong"``.
+
+    Returns
+    -------
+    Mesh
+        A pygfx Mesh with baked geometry that uses a standard render-only material.
+    """
+
+    mesh = _create_streamtube_baked(
+        lines,
+        colors=colors,
+        opacity=opacity,
+        radius=radius,
+        segments=segments,
+        end_caps=end_caps,
+        enable_picking=enable_picking,
+        flat_shading=flat_shading,
+        material=material,
+    )
+
+    if getattr(mesh, "n_lines", 0) == 0:
+        mesh.material = StreamtubeMaterial(
+            opacity=opacity,
+            pick_write=enable_picking,
+            flat_shading=flat_shading,
+            color_mode="vertex",
+        )
+        mesh._needs_gpu_update = False  # type: ignore[attr-defined]
+        return mesh
+
+    from fury.window import Scene, ShowManager
+
+    sm = ShowManager(scene=Scene(), window_type="offscreen")
+    try:
+        sm.screens[0].scene.add(mesh)
+        sm.render()
+        sm.window.draw()
+    finally:
+        sm.screens[0].scene.remove(mesh)
+        sm.close()
+
+    old_mat = mesh.material
+    baked_mat = StreamtubeMaterial(
+        opacity=float(getattr(old_mat, "opacity", opacity)),
+        pick_write=bool(getattr(old_mat, "pick_write", enable_picking)),
+        flat_shading=bool(getattr(old_mat, "flat_shading", flat_shading)),
+        color_mode=str(getattr(old_mat, "color_mode", "vertex")),
+    )
+    mesh.material = baked_mat
+
+    mesh._needs_gpu_update = False  # type: ignore[attr-defined]
+    for attr in (
+        "line_buffer",
+        "length_buffer",
+        "color_buffer",
+        "vertex_offset_buffer",
+        "triangle_offset_buffer",
+    ):
+        if hasattr(mesh, attr):
+            delattr(mesh, attr)
+
+    return mesh
+
+
 def streamtube(
     lines,
     *,
@@ -785,6 +1084,7 @@ def streamtube(
     flat_shading=False,
     material="phong",
     enable_picking=True,
+    backend=None,
 ):
     """
     Create a streamtube from a list of lines using parallel processing.
@@ -810,12 +1110,80 @@ def streamtube(
         Material model (e.g., 'phong', 'basic').
     enable_picking : bool, optional
         If True, the actor can be picked in a 3D scene.
+    backend : {"cpu", "gpu", None}, optional
+        Backend selection for streamtube generation. Options:
+        - ``"cpu"``: Force CPU-based geometry generation (default fallback).
+        - ``"gpu"``: Use GPU compute shaders for geometry generation.
+        - ``None``: Automatically choose GPU baked workflow when available.
 
     Returns
     -------
     Actor
         A mesh actor containing the generated streamtubes.
+
+    Notes
+    -----
+    This function performs streamtube geometry creation internally. When GPU
+    capabilities are available, it will automatically bake the geometry once
+    using a compute pass and then render with a standard material. No extra
+    parameters are required from the caller. For advanced control, the
+    optional ``backend`` parameter can be set to "cpu" to force CPU generation
+    or "gpu" to use the integrated compute+render path. When left as ``None``
+    (default), the function chooses the baked GPU workflow automatically.
     """
+    if lines is None or not hasattr(lines, "__iter__"):
+        raise ValueError("lines must be an iterable of arrays")
+
+    lines_list = list(lines)
+    if len(lines_list) == 0:
+        raise ValueError("lines cannot be empty")
+
+    if radius <= 0:
+        raise ValueError(f"radius must be positive, got {radius}")
+
+    if segments < 3:
+        raise ValueError(f"segments must be at least 3, got {segments}")
+
+    if backend not in ("cpu", "gpu", None):
+        raise ValueError(f"backend must be 'cpu', 'gpu', or None, got {backend!r}")
+
+    if backend == "gpu":
+        return _create_streamtube_baked(
+            lines,
+            colors=colors,
+            opacity=opacity,
+            radius=radius,
+            segments=segments,
+            end_caps=end_caps,
+            enable_picking=enable_picking,
+            flat_shading=flat_shading,
+            material=material,
+        )
+    elif backend == "cpu":
+        pass
+    else:
+        try:
+            return _create_streamtube_prebaked(
+                lines,
+                colors=colors,
+                opacity=opacity,
+                radius=radius,
+                segments=segments,
+                end_caps=end_caps,
+                enable_picking=enable_picking,
+                flat_shading=flat_shading,
+                material=material,
+            )
+        except (ImportError, RuntimeError, AttributeError) as e:
+            import warnings
+
+            warnings.warn(
+                f"GPU streamtube baking failed ({type(e).__name__}: {e}), "
+                "falling back to CPU backend",
+                UserWarning,
+                stacklevel=2,
+            )
+            pass
 
     def task(points):
         """Task to generate tube geometry for a single line.
@@ -830,7 +1198,6 @@ def streamtube(
         tuple
             A tuple containing the vertices and indices for the tube geometry.
         """
-        # Ensure points are float32 for consistency with Numba functions
         points_arr = np.asarray(points, dtype=np.float32)
         return generate_tube_geometry(points_arr, segments, radius, end_caps)
 
@@ -896,3 +1263,73 @@ def streamtube(
     )
     obj = create_mesh(geometry=geo, material=mat)
     return obj
+
+
+@register_wgpu_render_function(Mesh, _StreamtubeBakedMaterial)
+def _register_streamtube_baking_shaders(wobject):
+    """Internal: Create compute and render shaders for GPU streamtubes.
+
+    This function is called automatically by the render system and should not
+    be invoked directly by users.
+
+    Parameters
+    ----------
+    wobject : Mesh
+        Mesh produced by the internal streamtube function.
+
+    Returns
+    -------
+    tuple of BaseShader
+        A ``(compute_shader, render_shader)`` pair ready for registration.
+    """
+
+    class _StreamtubeRenderShader(MeshPhongShader):
+        """Render shader wrapper that auto-detaches compute after first bake."""
+
+        def get_render_info(self, wobject, shared):
+            """Get render info and auto-detach compute shader if baking is done.
+
+            Parameters
+            ----------
+            wobject : Mesh
+                The mesh object being rendered.
+            shared : dict
+                Shared rendering state.
+
+            Returns
+            -------
+            dict
+                Render information for the shader.
+            """
+            try:
+                mat = getattr(wobject, "material", None)
+                needs_update = bool(getattr(wobject, "_needs_gpu_update", False))
+                auto_detach = bool(getattr(mat, "auto_detach", True))
+                if (
+                    isinstance(mat, _StreamtubeBakedMaterial)
+                    and auto_detach
+                    and not needs_update
+                ):
+                    baked_mat = StreamtubeMaterial(
+                        opacity=float(getattr(mat, "opacity", 1.0)),
+                        pick_write=bool(getattr(mat, "pick_write", True)),
+                        flat_shading=bool(getattr(mat, "flat_shading", False)),
+                        color_mode=str(getattr(mat, "color_mode", "vertex")),
+                    )
+                    wobject.material = baked_mat
+                    for attr in (
+                        "line_buffer",
+                        "length_buffer",
+                        "color_buffer",
+                        "vertex_offset_buffer",
+                        "triangle_offset_buffer",
+                    ):
+                        if hasattr(wobject, attr):
+                            delattr(wobject, attr)
+            except Exception:
+                pass
+            return super().get_render_info(wobject, shared)
+
+    compute_shader = _StreamtubeBakingShader(wobject)
+    render_shader = _StreamtubeRenderShader(wobject)
+    return compute_shader, render_shader

--- a/fury/tests/test_actor.py
+++ b/fury/tests/test_actor.py
@@ -1200,7 +1200,7 @@ def test_streamtube_gpu_invalid_inputs():
         )
 
     with pytest.raises(
-        ValueError, match="first dimension must be 1 or match number of lines"
+        ValueError, match=r"first dimension must be 1 or \d+ \(number of lines\)"
     ):
         actor.streamtube(
             [line_a, line_b],
@@ -1208,7 +1208,9 @@ def test_streamtube_gpu_invalid_inputs():
             backend="gpu",
         )
 
-    with pytest.raises(ValueError, match=r"length 3 \(RGB\) or 4 \(RGBA\)"):
+    with pytest.raises(
+        ValueError, match=r"(must have 3|components, got) \(RGB\) or 4 \(RGBA\)"
+    ):
         actor.streamtube(
             [line_a],
             colors=np.array([1.0, 0.5], dtype=np.float32),

--- a/fury/tests/test_actor.py
+++ b/fury/tests/test_actor.py
@@ -13,6 +13,7 @@ from fury.material import (
     VectorFieldArrowMaterial,
     VectorFieldLineMaterial,
     VectorFieldThinLineMaterial,
+    _StreamtubeBakedMaterial,
 )
 from fury.optpkg import optional_package
 from fury.utils import (
@@ -1086,6 +1087,133 @@ def test_streamtube():
     middle_pixel = img_array[img_array.shape[0] // 2, img_array.shape[1] // 2]
     r, g, b, a = middle_pixel
     assert r > g and r > b
+
+
+def test_streamtube_gpu_geometry_and_buffers():
+    """GPU streamtube: geometry, buffers, and material state consistency."""
+    lines = [
+        np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.5]], dtype=np.float32),
+        np.array([[0.5, -0.5, 0.2], [0.5, 0.5, 0.8]], dtype=np.float32),
+    ]
+    colors = np.array([[1.0, 0.0, 0.0, 0.6], [0.0, 1.0, 0.0, 0.4]], dtype=np.float32)
+    radius = 0.15
+    segments = 5
+
+    mesh = actor.streamtube(
+        lines,
+        colors=colors,
+        opacity=0.75,
+        radius=radius,
+        segments=segments,
+        end_caps=True,
+        backend="gpu",
+    )
+
+    assert isinstance(mesh.material, _StreamtubeBakedMaterial)
+    assert mesh.n_lines == len(lines)
+
+    line_lengths = np.array([line.shape[0] for line in lines], dtype=np.uint32)
+    assert np.array_equal(mesh.line_lengths, line_lengths)
+    assert mesh.max_line_length == int(line_lengths.max())
+    assert mesh.tube_sides == segments
+    assert mesh.end_caps is True
+
+    vertices_per_line = line_lengths * segments + 2
+    expected_vertex_offsets = np.zeros_like(line_lengths)
+    if len(lines) > 1:
+        expected_vertex_offsets[1:] = np.cumsum(
+            vertices_per_line[:-1], dtype=np.uint64
+        ).astype(np.uint32)
+    assert np.array_equal(mesh.vertex_offsets, expected_vertex_offsets)
+
+    segments_per_line = np.maximum(line_lengths - 1, 0)
+    triangles_per_line = segments_per_line * segments * 2 + segments * 2
+    expected_triangle_offsets = np.zeros_like(line_lengths)
+    if len(lines) > 1:
+        expected_triangle_offsets[1:] = np.cumsum(
+            triangles_per_line[:-1], dtype=np.uint64
+        ).astype(np.uint32)
+    assert np.array_equal(mesh.triangle_offsets, expected_triangle_offsets)
+
+    total_vertices = int(vertices_per_line.astype(np.uint64).sum())
+    total_triangles = int(triangles_per_line.astype(np.uint64).sum())
+    assert mesh.geometry.positions.data.shape == (total_vertices, 3)
+    assert mesh.geometry.indices.data.shape == (total_triangles, 3)
+    assert mesh.geometry.colors.data.shape == (total_vertices, 3)
+
+    reshaped_line_buffer = mesh.line_buffer.data.reshape(
+        len(lines), mesh.max_line_length, 3
+    )
+    expected_line_data = np.zeros_like(reshaped_line_buffer)
+    for idx, line in enumerate(lines):
+        expected_line_data[idx, : line.shape[0]] = line
+    assert np.allclose(reshaped_line_buffer, expected_line_data)
+
+    expected_colors = colors[:, :3]
+    assert np.allclose(mesh.line_colors, expected_colors)
+    assert np.allclose(mesh.color_buffer.data, expected_colors)
+    assert mesh.color_components == 3
+
+    assert np.isclose(mesh.material.radius, radius)
+    assert mesh.material.segments == segments
+    assert mesh.material.end_caps is True
+    assert mesh.material.line_count == mesh.n_lines
+
+
+def test_streamtube_gpu_color_broadcast_and_material_flags():
+    """GPU streamtube: color broadcasting and material flags."""
+    lines = [
+        np.array([[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.5, 1.5, 0.5]], dtype=np.float32),
+        np.array([[1.0, 0.0, 0.0], [1.5, 0.5, 0.5], [2.0, 1.0, 1.0]], dtype=np.float32),
+    ]
+    base_color = (0.2, 0.4, 0.6)
+
+    mesh = actor.streamtube(
+        lines,
+        colors=base_color,
+        segments=4,
+        end_caps=False,
+        enable_picking=False,
+        backend="gpu",
+    )
+
+    expected_colors = np.tile(np.asarray(base_color, dtype=np.float32), (len(lines), 1))
+    assert np.allclose(mesh.line_colors, expected_colors)
+    assert np.allclose(mesh.color_buffer.data, expected_colors)
+    assert mesh.color_components == 3
+
+    assert isinstance(mesh.material, _StreamtubeBakedMaterial)
+    assert mesh.material.pick_write is False
+    assert mesh.material.flat_shading is False
+    assert mesh.material.end_caps is False
+    assert mesh.material.segments == 4
+
+
+def test_streamtube_gpu_invalid_inputs():
+    """GPU streamtube: invalid inputs raise informative errors."""
+    line_a = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float32)
+    line_b = np.array([[0.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32)
+
+    with pytest.raises(ValueError, match="material='phong' only"):
+        actor.streamtube(
+            [line_a], colors=(1.0, 0.0, 0.0), backend="gpu", material="basic"
+        )
+
+    with pytest.raises(
+        ValueError, match="first dimension must be 1 or match number of lines"
+    ):
+        actor.streamtube(
+            [line_a, line_b],
+            colors=np.ones((3, 3), dtype=np.float32),
+            backend="gpu",
+        )
+
+    with pytest.raises(ValueError, match=r"length 3 \(RGB\) or 4 \(RGBA\)"):
+        actor.streamtube(
+            [line_a],
+            colors=np.array([1.0, 0.5], dtype=np.float32),
+            backend="gpu",
+        )
 
 
 def test_line_projection():

--- a/fury/wgsl/streamtube_compute.wgsl
+++ b/fury/wgsl/streamtube_compute.wgsl
@@ -1,0 +1,275 @@
+{{ bindings_code }}
+
+const MAX_LINE_LENGTH = u32({{ max_line_length }});
+const TUBE_SIDES = u32({{ tube_sides }});
+const N_LINES = u32({{ n_lines }});
+const TUBE_RADIUS = f32({{ tube_radius }});
+const COLOR_CHANNELS = u32({{ color_channels }});
+const PI = 3.14159265359;
+
+const USE_END_CAPS = {{ end_caps }}u;
+
+fn safe_normalize(v: vec3<f32>) -> vec3<f32> {
+    let len_v = length(v);
+    if (len_v > 1e-6) {
+        return v / len_v;
+    }
+    return vec3<f32>(0.0, 0.0, 1.0);
+}
+
+fn get_line_point(line_idx: u32, point_idx: u32, line_length: u32) -> vec3<f32> {
+    if (line_length == 0u) {
+        return vec3<f32>(0.0, 0.0, 0.0);
+    }
+
+    let last_idx = min(line_length - 1u, MAX_LINE_LENGTH - 1u);
+    let clamped_idx = min(point_idx, last_idx);
+    let base_idx = (line_idx * MAX_LINE_LENGTH + clamped_idx) * 3u;
+
+    if (base_idx + 2u >= arrayLength(&s_line_data)) {
+        return vec3<f32>(0.0, 0.0, 0.0);
+    }
+
+    return vec3<f32>(
+        s_line_data[base_idx],
+        s_line_data[base_idx + 1u],
+        s_line_data[base_idx + 2u],
+    );
+}
+
+fn rodrigues_rotate(v: vec3<f32>, axis: vec3<f32>, sin_angle: f32, cos_angle: f32) -> vec3<f32> {
+    return v * cos_angle + cross(axis, v) * sin_angle + axis * dot(axis, v) * (1.0 - cos_angle);
+}
+
+fn get_tangent(line_idx: u32, point_idx: u32, line_length: u32) -> vec3<f32> {
+    if (line_length <= 1u) {
+        return vec3<f32>(0.0, 0.0, 1.0);
+    }
+
+    let point = get_line_point(line_idx, point_idx, line_length);
+    var tangent: vec3<f32>;
+    if (point_idx == 0u) {
+        tangent = get_line_point(line_idx, 1u, line_length) - point;
+    } else if (point_idx == line_length - 1u) {
+        tangent = point - get_line_point(line_idx, point_idx - 1u, line_length);
+    } else {
+        tangent = get_line_point(line_idx, point_idx + 1u, line_length)
+            - get_line_point(line_idx, point_idx - 1u, line_length);
+    }
+    return safe_normalize(tangent);
+}
+
+fn write_vertex_color(vertex_idx: u32, color: vec4<f32>, color_len: u32) {
+    if (COLOR_CHANNELS == 0u || color_len == 0u) {
+        return;
+    }
+
+    let base = vertex_idx * COLOR_CHANNELS;
+    if (base >= color_len) {
+        return;
+    }
+
+    s_vertex_colors[base] = color.x;
+    if (COLOR_CHANNELS > 1u && base + 1u < color_len) {
+        s_vertex_colors[base + 1u] = color.y;
+    }
+    if (COLOR_CHANNELS > 2u && base + 2u < color_len) {
+        s_vertex_colors[base + 2u] = color.z;
+    }
+    if (COLOR_CHANNELS > 3u && base + 3u < color_len) {
+        s_vertex_colors[base + 3u] = color.w;
+    }
+}
+
+@compute @workgroup_size({{ workgroup_size }})
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let line_idx = gid.x;
+    if (line_idx >= N_LINES) {
+        return;
+    }
+
+    let line_length = s_line_lengths[line_idx];
+    if (line_length < 2u) {
+        return;
+    }
+
+    let base_vertex_idx = s_vertex_offsets[line_idx];
+    let base_triangle_idx = s_triangle_offsets[line_idx];
+
+    let pos_len = arrayLength(&s_vertex_positions);
+    let norm_len = arrayLength(&s_vertex_normals);
+    let color_len = arrayLength(&s_vertex_colors);
+    if (pos_len < 3u || norm_len < 3u) {
+        return;
+    }
+
+$$ if color_channels == 4
+    let line_color = load_s_line_colors(i32(line_idx));
+$$ elif color_channels == 3
+    let line_color_rgb = load_s_line_colors(i32(line_idx));
+    let line_color = vec4<f32>(line_color_rgb, 1.0);
+$$ elif color_channels == 2
+    let line_color_rg = load_s_line_colors(i32(line_idx));
+    let line_color = vec4<f32>(line_color_rg, 0.0, 1.0);
+$$ elif color_channels == 1
+    let line_color_scalar = load_s_line_colors(i32(line_idx));
+    let line_color = vec4<f32>(line_color_scalar, line_color_scalar, line_color_scalar, 1.0);
+$$ else
+    let line_color = vec4<f32>(1.0, 1.0, 1.0, 1.0);
+$$ endif
+    let vertices_per_point = TUBE_SIDES;
+
+    var tangents_arr: array<vec3<f32>, MAX_LINE_LENGTH>;
+    for (var i = 0u; i < line_length; i++) {
+        tangents_arr[i] = get_tangent(line_idx, i, line_length);
+    }
+
+    var normals_arr: array<vec3<f32>, MAX_LINE_LENGTH>;
+    var binormals_arr: array<vec3<f32>, MAX_LINE_LENGTH>;
+
+    var base_tangent = tangents_arr[0u];
+    if (length(base_tangent) < 1e-6) {
+        base_tangent = vec3<f32>(0.0, 0.0, 1.0);
+        tangents_arr[0u] = base_tangent;
+    }
+    var reference = vec3<f32>(0.0, 0.0, 1.0);
+    if (abs(dot(base_tangent, reference)) > 0.99) {
+        reference = vec3<f32>(1.0, 0.0, 0.0);
+    }
+    var base_binormal = safe_normalize(cross(base_tangent, reference));
+    if (length(base_binormal) < 1e-6) {
+        base_binormal = vec3<f32>(0.0, 1.0, 0.0);
+    }
+    var base_normal = safe_normalize(cross(base_binormal, base_tangent));
+    normals_arr[0u] = base_normal;
+    binormals_arr[0u] = base_binormal;
+
+    for (var i = 1u; i < line_length; i++) {
+        let prev_tangent = tangents_arr[i - 1u];
+        let curr_tangent = tangents_arr[i];
+        var axis = cross(prev_tangent, curr_tangent);
+        let sin_angle = length(axis);
+        let cos_angle = clamp(dot(prev_tangent, curr_tangent), -1.0, 1.0);
+
+        var normal = normals_arr[i - 1u];
+        var binormal = binormals_arr[i - 1u];
+        if (sin_angle > 1e-6) {
+            let axis_norm = axis / sin_angle;
+            normal = rodrigues_rotate(normal, axis_norm, sin_angle, cos_angle);
+            binormal = rodrigues_rotate(binormal, axis_norm, sin_angle, cos_angle);
+        }
+
+        normals_arr[i] = safe_normalize(normal);
+        binormals_arr[i] = safe_normalize(binormal);
+    }
+
+    for (var i = 0u; i < line_length; i++) {
+        let point = get_line_point(line_idx, i, line_length);
+        let tangent = tangents_arr[i];
+        let normal = normals_arr[i];
+        let binormal = binormals_arr[i];
+
+        for (var j = 0u; j < TUBE_SIDES; j++) {
+            let angle = 2.0 * PI * f32(j) / f32(TUBE_SIDES);
+            let cos_a = cos(angle);
+            let sin_a = sin(angle);
+
+            let offset = normal * cos_a + binormal * sin_a;
+            let vertex_pos = point + offset * TUBE_RADIUS;
+            let vertex_normal = safe_normalize(offset);
+
+            let vertex_idx = base_vertex_idx + i * vertices_per_point + j;
+            let pos_base = vertex_idx * 3u;
+            if (pos_base + 2u < pos_len
+                && pos_base + 2u < norm_len) {
+                s_vertex_positions[pos_base] = vertex_pos.x;
+                s_vertex_positions[pos_base + 1u] = vertex_pos.y;
+                s_vertex_positions[pos_base + 2u] = vertex_pos.z;
+
+                s_vertex_normals[pos_base] = vertex_normal.x;
+                s_vertex_normals[pos_base + 1u] = vertex_normal.y;
+                s_vertex_normals[pos_base + 2u] = vertex_normal.z;
+                write_vertex_color(vertex_idx, line_color, color_len);
+            }
+        }
+
+        if (i < line_length - 1u) {
+            for (var j = 0u; j < TUBE_SIDES; j++) {
+                let next_j = (j + 1u) % TUBE_SIDES;
+
+                let v0 = base_vertex_idx + i * vertices_per_point + j;
+                let v1 = base_vertex_idx + i * vertices_per_point + next_j;
+                let v2 = base_vertex_idx + (i + 1u) * vertices_per_point + j;
+                let v3 = base_vertex_idx + (i + 1u) * vertices_per_point + next_j;
+
+                let tri_base = base_triangle_idx + (i * TUBE_SIDES + j) * 2u;
+                let idx_base = tri_base * 3u;
+                if (idx_base + 5u < arrayLength(&s_indices)) {
+                    s_indices[idx_base] = v0;
+                    s_indices[idx_base + 1u] = v1;
+                    s_indices[idx_base + 2u] = v3;
+                    s_indices[idx_base + 3u] = v0;
+                    s_indices[idx_base + 4u] = v3;
+                    s_indices[idx_base + 5u] = v2;
+                }
+            }
+        }
+    }
+
+    if (USE_END_CAPS == 1u && line_length >= 2u) {
+        let ring_vertex_count = line_length * TUBE_SIDES;
+        let start_center_idx = base_vertex_idx + ring_vertex_count;
+        let end_center_idx = start_center_idx + 1u;
+
+        let start_point = get_line_point(line_idx, 0u, line_length);
+        let end_point = get_line_point(line_idx, line_length - 1u, line_length);
+        let start_normal = safe_normalize(-tangents_arr[0u]);
+        let end_normal = safe_normalize(tangents_arr[line_length - 1u]);
+
+        if (start_center_idx * 3u + 2u < pos_len && start_center_idx * 3u + 2u < norm_len) {
+            let base = start_center_idx * 3u;
+            s_vertex_positions[base] = start_point.x;
+            s_vertex_positions[base + 1u] = start_point.y;
+            s_vertex_positions[base + 2u] = start_point.z;
+            s_vertex_normals[base] = start_normal.x;
+            s_vertex_normals[base + 1u] = start_normal.y;
+            s_vertex_normals[base + 2u] = start_normal.z;
+        }
+        write_vertex_color(start_center_idx, line_color, color_len);
+
+        if (end_center_idx * 3u + 2u < pos_len && end_center_idx * 3u + 2u < norm_len) {
+            let base = end_center_idx * 3u;
+            s_vertex_positions[base] = end_point.x;
+            s_vertex_positions[base + 1u] = end_point.y;
+            s_vertex_positions[base + 2u] = end_point.z;
+            s_vertex_normals[base] = end_normal.x;
+            s_vertex_normals[base + 1u] = end_normal.y;
+            s_vertex_normals[base + 2u] = end_normal.z;
+        }
+        write_vertex_color(end_center_idx, line_color, color_len);
+
+        let side_triangles = (line_length - 1u) * TUBE_SIDES * 2u;
+        var tri_idx = base_triangle_idx + side_triangles;
+
+        // Start cap
+        for (var j = 0u; j < TUBE_SIDES; j++) {
+            let next_j = (j + 1u) % TUBE_SIDES;
+            let idx_base = tri_idx * 3u;
+            s_indices[idx_base] = base_vertex_idx + next_j;
+            s_indices[idx_base + 1u] = base_vertex_idx + j;
+            s_indices[idx_base + 2u] = start_center_idx;
+            tri_idx += 1u;
+        }
+
+        // End cap
+        let end_ring_base = base_vertex_idx + (line_length - 1u) * TUBE_SIDES;
+        for (var j = 0u; j < TUBE_SIDES; j++) {
+            let next_j = (j + 1u) % TUBE_SIDES;
+            let idx_base = tri_idx * 3u;
+            s_indices[idx_base] = end_ring_base + j;
+            s_indices[idx_base + 1u] = end_ring_base + next_j;
+            s_indices[idx_base + 2u] = end_center_idx;
+            tri_idx += 1u;
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces experimental GPU backend for `streamtube`, powered by compute shaders. making it possible to render now thousands to millions of tubes.

https://github.com/user-attachments/assets/bfd478d3-d891-4515-963f-1eb979374b34


https://github.com/user-attachments/assets/d3dd6e45-2e29-4bea-9301-f3e47cb466d6





Compute shader is only ran once to update the buffers using a flag. And, the generation time is super fast (1 million streamtubes in 2.5 sec).


```python
import numpy as np
from fury import window
from fury.actor.curved import streamtube

def build_helix(turns=3, samples=200, radius=1.0, pitch=0.25):
    theta = np.linspace(0.0, turns * 2.0 * np.pi, samples, dtype=np.float32)
    x = radius * np.cos(theta)
    y = radius * np.sin(theta)
    z = pitch * theta
    return np.column_stack((x, y, z))

helix1 = build_helix()
helix2 = build_helix(turns=2, samples=160, radius=0.6, pitch=0.18) + np.array([0.0, 0.0, 0.5])
helix3 = build_helix(turns=1.5, samples=120, radius=0.8, pitch=0.1) + np.array([2.0, 0.0, 0.0])

lines = [helix1, helix2, helix3]
colors = [(1, 0, 0), (0, 1, 0), (0, 0, 1)] 
radius = 0.05

actor = streamtube(lines, colors=colors, radius=radius, backend="gpu")

scene = window.Scene()
scene.add(actor)
showm = window.ShowManager(scene=scene, size=(900, 600))
showm.start()

```

Benchmark:
<img width="841" height="318" alt="image" src="https://github.com/user-attachments/assets/a63f0646-8e56-45f5-90a6-ea790015b4b2" />
