### PR TITLE
ENH: Surface now uses normals and phong material

### DIFF
--- a/fury/material.py
+++ b/fury/material.py
@@ -89,6 +89,7 @@ def _create_mesh_material(
     opacity=1.0,
     mode="vertex",
     flat_shading=True,
+    texture=None,
 ):
     """Create a mesh material.
 
@@ -110,6 +111,8 @@ def _create_mesh_material(
         The color mode of the material. Options are 'auto' and 'vertex'.
     flat_shading : bool, optional
         Whether to use flat shading (True) or smooth shading (False).
+    texture : Texture or TextureMap, optional
+        The texture map specifying the color for each texture coordinate.
 
     Returns
     -------
@@ -124,20 +127,19 @@ def _create_mesh_material(
     opacity = validate_opacity(opacity)
     color = validate_color(color, opacity, mode)
 
+    args = {
+        "pick_write": enable_picking,
+        "color_mode": mode,
+        "color": color,
+        "opacity": opacity,
+        "flat_shading": flat_shading,
+        "map": texture,
+    }
+
     if material == "phong":
-        return MeshPhongMaterial(
-            pick_write=enable_picking,
-            color_mode=mode,
-            color=color,
-            flat_shading=flat_shading,
-        )
+        return MeshPhongMaterial(**args)
     elif material == "basic":
-        return MeshBasicMaterial(
-            pick_write=enable_picking,
-            color_mode=mode,
-            color=color,
-            flat_shading=flat_shading,
-        )
+        return MeshBasicMaterial(**args)
     else:
         raise ValueError(f"Unsupported material type: {material}")
 

--- a/fury/tests/test_actor.py
+++ b/fury/tests/test_actor.py
@@ -559,6 +559,22 @@ def test_surface_basic_vertices_and_faces():
     assert isinstance(surface_actor.material, MeshPhongMaterial)
     assert surface_actor.material.opacity == 1.0
 
+    def test_surface_with_normals():
+        """Test surface creation with normals."""
+        vertices = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32)
+        faces = np.array([[0, 1, 2]], dtype=np.int32)
+        normals = np.array([[0, 0, 1], [0, 0, 1], [0, 0, 1]], dtype=np.float32)
+
+        surface_actor = actor.surface(vertices, faces, normals=normals)
+
+        assert np.array_equal(surface_actor.geometry.positions.data, vertices)
+        assert np.array_equal(surface_actor.geometry.indices.data, faces)
+        assert np.array_equal(surface_actor.geometry.normals.data, normals)
+        assert not hasattr(surface_actor.geometry, "colors")
+        assert not hasattr(surface_actor.geometry, "texcoords")
+        assert isinstance(surface_actor.material, MeshPhongMaterial)
+        assert surface_actor.material.opacity == 1.0
+
 
 def test_surface_with_vertex_colors():
     """Test surface creation with vertex colors."""
@@ -572,6 +588,23 @@ def test_surface_with_vertex_colors():
     assert np.array_equal(surface_actor.geometry.indices.data, faces)
     assert np.array_equal(surface_actor.geometry.colors.data, colors)
 
+    assert isinstance(surface_actor.material, MeshPhongMaterial)
+    assert surface_actor.material.opacity == 1.0
+
+
+def test_surface_with_vertex_colors_and_normals():
+    """Test surface creation with vertex colors and normals."""
+    vertices = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32)
+    faces = np.array([[0, 1, 2]], dtype=np.int32)
+    colors = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=np.float32)
+    normals = np.array([[0, 0, 1], [0, 0, 1], [0, 0, 1]], dtype=np.float32)
+
+    surface_actor = actor.surface(vertices, faces, colors=colors, normals=normals)
+
+    assert np.array_equal(surface_actor.geometry.positions.data, vertices)
+    assert np.array_equal(surface_actor.geometry.indices.data, faces)
+    assert np.array_equal(surface_actor.geometry.colors.data, colors)
+    assert np.array_equal(surface_actor.geometry.normals.data, normals)
     assert isinstance(surface_actor.material, MeshPhongMaterial)
     assert surface_actor.material.opacity == 1.0
 


### PR DESCRIPTION
### ENH: Surface now uses normals and phong material


**PR Contents**
- Simplified `_create_mesh_material` method to have single dict of parameters.
- Updated test cases for the same.

**Preveiw**

<img width="516" height="719" alt="image" src="https://github.com/user-attachments/assets/aa412709-51ec-4b34-bae4-d939ef0e9ee2" />
