### PR TITLE
BF: Rectangle2D warning for np.divide fixed and compatibility with 0.14.0 Pygfx version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
         args: ["fury"]
         pass_filenames: false
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.2
+    rev: v0.14.1
     hooks:
       # Run the linter
     -   id: ruff

--- a/docs/examples/viz_integrate_with_qt.py
+++ b/docs/examples/viz_integrate_with_qt.py
@@ -30,7 +30,6 @@ class Main(QtWidgets.QWidget):
             scene=self.scene,
             window_type="qt",
             title="FURY 2.0: Integrate Qt Example",
-            size=None,
             qt_app=app,
             qt_parent=self,
         )

--- a/fury/__init__.py
+++ b/fury/__init__.py
@@ -18,6 +18,9 @@ __all__ += [
     "get_info",
 ]
 
+gfx, _, _ = optional_package("pygfx", min_version="0.14.0")
+gfx_version = gfx.__version__
+
 
 def get_info(verbose=False):
     """Return dict describing the context of this package.
@@ -49,7 +52,7 @@ def get_info(verbose=False):
         "sys_platform": sys.platform,
         "numpy_version": numpy.__version__,
         "scipy_version": scipy.__version__,
-        # TODO: Add pygfx version if applicable
+        "pygfx_version": gfx_version,
     }
 
     if have_mpl:

--- a/fury/lib.py
+++ b/fury/lib.py
@@ -32,10 +32,10 @@ PyQt6, have_py_qt6, _ = optional_package("PyQt6", trip_msg=qt_pckg_msg)
 PyQt5, have_py_qt5, _ = optional_package("PyQt5", trip_msg=qt_pckg_msg)
 
 if have_py_side6 or have_py_qt6 or have_py_qt5:
-    from rendercanvas.qt import RenderCanvas as QtRenderCanvas
+    from rendercanvas.qt import RenderCanvas as QtRenderCanvas, loop as QtLoop
 
     def get_app():
-        return loop._app
+        return QtLoop._app
 
 
 if have_py_side6:

--- a/fury/lib.py
+++ b/fury/lib.py
@@ -4,9 +4,9 @@ from typing import TypeAlias
 
 import jinja2
 import pygfx as gfx
+from rendercanvas.auto import RenderCanvas, loop
+from rendercanvas.offscreen import RenderCanvas as OffscreenRenderCanvas
 import wgpu
-from wgpu.gui.auto import WgpuCanvas, run
-from wgpu.gui.offscreen import WgpuCanvas as OffscreenWgpuCanvas
 
 from fury.optpkg import optional_package
 
@@ -19,7 +19,7 @@ jupyter_rfb, have_jupyter_rfb, _ = optional_package(
     "jupyter_rfb", trip_msg=jupyter_pckg_msg
 )
 if have_jupyter_rfb:
-    from wgpu.gui.jupyter import WgpuCanvas as JupyterWgpuCanvas
+    from rendercanvas.jupyter import RenderCanvas as JupyterWgpuCanvas
 
 qt_pckg_msg = (
     "You do not have any qt package installed. The qt window will not work for "
@@ -32,7 +32,11 @@ PyQt6, have_py_qt6, _ = optional_package("PyQt6", trip_msg=qt_pckg_msg)
 PyQt5, have_py_qt5, _ = optional_package("PyQt5", trip_msg=qt_pckg_msg)
 
 if have_py_side6 or have_py_qt6 or have_py_qt5:
-    from wgpu.gui.qt import WgpuCanvas as QtWgpuCanvas, get_app
+    from rendercanvas.qt import RenderCanvas as QtRenderCanvas
+
+    def get_app():
+        return loop._app
+
 
 if have_py_side6:
     from PySide6 import QtWidgets
@@ -94,9 +98,8 @@ OrthographicCamera = gfx.OrthographicCamera
 PerspectiveCamera = gfx.PerspectiveCamera
 ScreenCoordsCamera = gfx.ScreenCoordsCamera
 Renderer = gfx.WgpuRenderer
-run = run
-Canvas = WgpuCanvas
-OffscreenCanvas = OffscreenWgpuCanvas
+Canvas = RenderCanvas
+OffscreenCanvas = OffscreenRenderCanvas
 BaseShader = gfx.renderers.wgpu.BaseShader
 MeshPhongShader = gfx.renderers.wgpu.shaders.meshshader.MeshPhongShader
 MeshStandardShader = gfx.renderers.wgpu.shaders.meshshader.MeshStandardShader
@@ -119,6 +122,7 @@ WindowEvent = gfx.WindowEvent
 PointerEvent = gfx.PointerEvent
 WheelEvent = gfx.WheelEvent
 KeyboardEvent = gfx.KeyboardEvent
+run = loop.run
 
 
 plane_geometry = gfx.plane_geometry
@@ -128,7 +132,7 @@ if have_jupyter_rfb:
 else:
     JupyterCanvas = jupyter_rfb
 if have_py_side6 or have_py_qt6 or have_py_qt5:
-    QtCanvas = QtWgpuCanvas
+    QtCanvas = QtRenderCanvas
 else:
     QtCanvas = PySide6
     QtWidgets = PySide6

--- a/fury/optpkg.py
+++ b/fury/optpkg.py
@@ -2,6 +2,8 @@
 
 import importlib
 
+from packaging.version import Version
+
 try:
     import pytest
 except ImportError:
@@ -123,22 +125,25 @@ class TripWire:
         raise TripWireError(self._msg)
 
 
-def optional_package(name, *, trip_msg=None):
+def optional_package(name, *, trip_msg=None, min_version=None):
     """Return package-like thing and module setup for package `name`.
 
     Parameters
     ----------
     name : str
-        Package name to be imported.
-    trip_msg : None or str, optional
+        Package name.
+    trip_msg : None or str
         Message to give when someone tries to use the return package, but we
         could not import it, and have returned a TripWire object instead.
-        Default message if None.
+    min_version : None or str
+        If not None, require that the imported package be at least this
+        version.  If the package has no ``__version__`` attribute, or if the
+        version is not parseable, raise an error.
 
     Returns
     -------
     pkg_like : module or ``TripWire`` instance
-        If we can import the package, return it. Otherwise return an object
+        If we can import the package, return it.  Otherwise return an object
         raising an error when accessed.
     have_pkg : bool
         True if import for package was successful, false otherwise.
@@ -150,21 +155,31 @@ def optional_package(name, *, trip_msg=None):
     --------
     Typical use would be something like this at the top of a module using an
     optional package:
+
     >>> from fury.optpkg import optional_package
     >>> pkg, have_pkg, setup_module = optional_package('not_a_package')
-    >>> # Of course in this case the package doesn't exist, and so, in the module:
+
+    Of course in this case the package doesn't exist, and so, in the module:
+
     >>> have_pkg
     False
+
+    and
+
     >>> pkg.some_function() #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-    ...
+        ...
     TripWireError: We need package not_a_package for these functions, but
     ``import not_a_package`` raised an ImportError
-    >>> # If the module does exist - we get the module
+
+    If the module does exist - we get the module
+
     >>> pkg, _, _ = optional_package('os')
     >>> hasattr(pkg, 'path')
     True
-    >>> # Or a submodule if that's what we asked for
+
+    Or a submodule if that's what we asked for
+
     >>> subpkg, _, _ = optional_package('os.path')
     >>> hasattr(subpkg, 'dirname')
     True
@@ -173,13 +188,27 @@ def optional_package(name, *, trip_msg=None):
         pkg = importlib.import_module(name)
     except ImportError:
         pass
-    else:  # import worked
-        # top level module
-        return pkg, True, lambda: None
+    else:
+        if not min_version:
+            return pkg, True, lambda: None
+
+        current_version = getattr(pkg, "__version__", "0.0.0")
+        if Version(current_version) >= Version(min_version):
+            return pkg, True, lambda: None
+
+        if trip_msg is None:
+            trip_msg = (
+                f"We need at least version {min_version} of "
+                f"package {name}, but ``import {name}`` "
+                f"found version {current_version}."
+            )
+            if current_version == "0.0.0":
+                trip_msg += "Your installation might be incomplete or corrupted."
+
     if trip_msg is None:
         trip_msg = (
-            "We need package %s for these functions, but "
-            "``import %s`` raised an ImportError" % (name, name)
+            f"We need package {name} for these functions, but "
+            f"``import {name}`` raised an ImportError"
         )
     pkg = TripWire(trip_msg)
 

--- a/fury/tests/test_actor.py
+++ b/fury/tests/test_actor.py
@@ -4,6 +4,7 @@ from PIL import Image
 import numpy as np
 import numpy.testing as npt
 import pytest
+import rendercanvas.glfw
 
 from fury import actor, window
 from fury.io import load_image_texture
@@ -22,6 +23,13 @@ from fury.utils import (
 )
 
 _, have_numba, _ = optional_package("numba")
+
+
+def _do_nothing_patch(self):
+    pass
+
+
+rendercanvas.glfw.RenderCanvas._rc_close = _do_nothing_patch
 
 
 def random_png(width, height):
@@ -1054,8 +1062,6 @@ def test_streamtube():
     middle_pixel = img_array[img_array.shape[0] // 2, img_array.shape[1] // 2]
     r, g, b, a = middle_pixel
     assert r > g and r > b
-
-    scene.remove(tube_actor)
 
 
 def test_line_projection():

--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -289,7 +289,7 @@ def test_show_manager_snapshot(tmpdir):
 
     show_m = ShowManager(window_type="offscreen")
     show_m.render()
-    show_m.window.draw_frame()
+    show_m.window.draw()
     arr = show_m.snapshot(str(fname))
 
     saved_arr = load_image(str(fname))
@@ -304,7 +304,7 @@ def test_show_manager_snapshot_multiple_screens(tmpdir):
     show_m = ShowManager(screen_config=[2], window_type="offscreen")  # Two screens
     fname = tmpdir.join("snapshot_multiple.png")
     show_m.render()
-    show_m.window.draw_frame()
+    show_m.window.draw()
     arr = show_m.snapshot(str(fname))
     saved_arr = load_image(str(fname))
     assert isinstance(arr, np.ndarray)

--- a/fury/ui/core.py
+++ b/fury/ui/core.py
@@ -656,7 +656,9 @@ class Rectangle2D(UI):
     """
 
     @warn_on_args_to_kwargs()
-    def __init__(self, *, size=(0, 0), position=(0, 0), color=(1, 1, 1), opacity=1.0):
+    def __init__(
+        self, *, size=(100, 100), position=(0, 0), color=(1, 1, 1), opacity=1.0
+    ):
         """Initialize a rectangle.
 
         Parameters

--- a/fury/ui/tests/test_core.py
+++ b/fury/ui/tests/test_core.py
@@ -27,13 +27,13 @@ def test_rectangle2d_initialization_default(mock_ui_context_v2):
     Checks default size, color, opacity, and position.
     """
     rect = ui.Rectangle2D()
-    npt.assert_equal(rect.size, (0, 0))
+    npt.assert_equal(rect.size, (100, 100))
     npt.assert_array_equal(rect.color, [1, 1, 1, 1])
     npt.assert_equal(rect.opacity, 1.0)
     assert isinstance(rect.actor, Mesh)
     assert rect.actor in rect.actors
 
-    npt.assert_array_equal(rect.get_position(Anchor.LEFT, Anchor.BOTTOM), [0, 0])
+    npt.assert_array_equal(rect.get_position(Anchor.LEFT, Anchor.BOTTOM), [0, 100])
 
 
 def test_rectangle2d_initialization_custom(mock_ui_context_v2):

--- a/fury/window.py
+++ b/fury/window.py
@@ -877,7 +877,7 @@ class ShowManager:
             "true",
             "1",
         ]:
-            self.window.draw_frame()
+            self._draw_function()
             self.snapshot(f"{self._title}.png")
             self.window.close()
             return
@@ -934,7 +934,7 @@ def snapshot(
         scene=scene, screen_config=screen_config, window_type="offscreen"
     )
     show_m.render()
-    show_m.window.draw_frame()
+    show_m.window.draw()
     arr = show_m.snapshot(fname)
 
     if return_array:

--- a/fury/window.py
+++ b/fury/window.py
@@ -665,8 +665,6 @@ class ShowManager:
         if window_type == "default" or window_type == "glfw":
             self.window = Canvas(size=self._size, title=self._title)
         elif window_type == "qt":
-            if self._qt_app is None:
-                self._qt_app = get_app()
             self.window = QtCanvas(
                 size=self._size, title=self._title, parent=self._qt_parent
             )
@@ -883,6 +881,8 @@ class ShowManager:
             return
 
         if self._is_qt:
+            if self._qt_app is None:
+                self._qt_app = get_app()
             self._qt_app.exec()
         else:
             run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "pillow>=10.4.0",
     "packaging>=23.0",
     "lazy_loader>=0.4",
-    "pygfx>=0.13.0",
+    "pygfx>=0.14.0",
     "glfw>=2.7.0",
 ]
 
@@ -117,6 +117,8 @@ filterwarnings = [
     "ignore:.*You do not have Matplotlib installed.*:UserWarning",
     "ignore:We'll no longer accept the way you call the.*function:UserWarning:.*doctest",
     "ignore:.*There is no current event loop.*:DeprecationWarning",
+    # This is due to the Qt deprecation warnings in RenderCanvas
+    "ignore:.*ApplicationAttribute.AA_EnableHighDpiScaling.*:DeprecationWarning"
 ]
 # addopts = "--cov --cov-report html --cov-report term-missing --cov-fail-under 95"
 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -6,5 +6,5 @@ pillow>=8.0.1
 aiohttp>=3.8.4
 pygltflib>=1.15.1
 lazy_loader>=0.4
-pygfx>=0.13.0
+pygfx>=0.14.0
 glfw>=2.7.0


### PR DESCRIPTION
## BF: Rectangle2D warning for np.divide fixed and compatibility with Pygfx 0.14.0.

**PR Contents**
- Fixes np.divide warning for Rectangle2D ui.
- Defaults to have (100, 100) size for Rectangle.
- Updates test cases.

- Pygfx has introduced a wrapper dependency called render canvas (Maintained by them only) which introduces a layer between direct canvas and window system to maintain similar apis across.
- We are not required to add this explicitly in the dependencies as this is a default dependency of wgpu-py.  
