### PR TITLE
ENH: Enabled wire frame.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
         args: ["fury"]
         pass_filenames: false
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.2
+    rev: v0.14.3
     hooks:
       # Run the linter
     -   id: ruff

--- a/fury/actor/core.py
+++ b/fury/actor/core.py
@@ -26,6 +26,8 @@ def actor_from_primitive(
     smooth=False,
     enable_picking=True,
     repeat_primitive=True,
+    wireframe=False,
+    wireframe_thickness=1.0,
 ):
     """Build an actor from a primitive.
 
@@ -57,6 +59,10 @@ def actor_from_primitive(
     repeat_primitive : bool, optional
         Whether to repeat the primitive for each center. If False,
         only one instance of the primitive is created at the first center.
+    wireframe : bool, optional
+        Whether to render the mesh as a wireframe.
+    wireframe_thickness : float, optional
+        The thickness of the wireframe lines.
 
     Returns
     -------
@@ -99,7 +105,11 @@ def actor_from_primitive(
     )
 
     mat = _create_mesh_material(
-        material=material, enable_picking=enable_picking, flat_shading=not smooth
+        material=material,
+        enable_picking=enable_picking,
+        flat_shading=not smooth,
+        wireframe=wireframe,
+        wireframe_thickness=wireframe_thickness,
     )
     obj = create_mesh(geometry=geo, material=mat)
     obj.local.position = centers[0]

--- a/fury/actor/curved.py
+++ b/fury/actor/curved.py
@@ -37,6 +37,8 @@ def sphere(
     material="phong",
     enable_picking=True,
     smooth=True,
+    wireframe=False,
+    wireframe_thickness=1.0,
 ):
     """Create one or many spheres with different colors and radii.
 
@@ -63,6 +65,10 @@ def sphere(
         Whether the spheres should be pickable in a 3D scene.
     smooth : bool, optional
         Whether to create a smooth sphere or a faceted sphere.
+    wireframe : bool, optional
+        Whether to render the mesh as a wireframe.
+    wireframe_thickness : float, optional
+        The thickness of the wireframe lines.
 
     Returns
     -------
@@ -99,6 +105,8 @@ def sphere(
         material=material,
         smooth=smooth,
         enable_picking=enable_picking,
+        wireframe=wireframe,
+        wireframe_thickness=wireframe_thickness,
     )
 
 
@@ -114,6 +122,8 @@ def ellipsoid(
     material="phong",
     enable_picking=True,
     smooth=True,
+    wireframe=False,
+    wireframe_thickness=1.0,
 ):
     """
     Create ellipsoid actor(s) with specified orientation and scaling.
@@ -146,6 +156,10 @@ def ellipsoid(
         Allow picking of the ellipsoids in a 3D scene.
     smooth : bool, optional
         Whether to create a smooth ellipsoid or a faceted ellipsoid.
+    wireframe : bool, optional
+        Whether to render the mesh as a wireframe.
+    wireframe_thickness : float, optional
+        The thickness of the wireframe lines.
 
     Returns
     -------
@@ -231,6 +245,8 @@ def ellipsoid(
         smooth=smooth,
         enable_picking=enable_picking,
         repeat_primitive=False,
+        wireframe=wireframe,
+        wireframe_thickness=wireframe_thickness,
     )
 
 
@@ -247,6 +263,8 @@ def cylinder(
     opacity=None,
     material="phong",
     enable_picking=True,
+    wireframe=False,
+    wireframe_thickness=1.0,
 ):
     """Create one or many cylinders with different features.
 
@@ -280,6 +298,10 @@ def cylinder(
         The material type for the cylinders. Options are 'phong' and 'basic'.
     enable_picking : bool, optional
         Whether the cylinders should be pickable in a 3D scene.
+    wireframe : bool, optional
+        Whether to render the mesh as a wireframe.
+    wireframe_thickness : float, optional
+        The thickness of the wireframe lines.
 
     Returns
     -------
@@ -313,6 +335,8 @@ def cylinder(
         opacity=opacity,
         material=material,
         enable_picking=enable_picking,
+        wireframe=wireframe,
+        wireframe_thickness=wireframe_thickness,
     )
 
 
@@ -328,6 +352,8 @@ def cone(
     opacity=None,
     material="phong",
     enable_picking=True,
+    wireframe=False,
+    wireframe_thickness=1.0,
 ):
     """Create one or many cones with different features.
 
@@ -358,6 +384,10 @@ def cone(
         The material type for the cones. Options are 'phong' and 'basic'.
     enable_picking : bool, optional
         Whether the cones should be pickable in a 3D scene.
+    wireframe : bool, optional
+        Whether to render the mesh as a wireframe.
+    wireframe_thickness : float, optional
+        The thickness of the wireframe lines.
 
     Returns
     -------
@@ -389,6 +419,8 @@ def cone(
         opacity=opacity,
         material=material,
         enable_picking=enable_picking,
+        wireframe=wireframe,
+        wireframe_thickness=wireframe_thickness,
     )
 
 

--- a/fury/actor/planar.py
+++ b/fury/actor/planar.py
@@ -40,6 +40,8 @@ def square(
     opacity=None,
     material="phong",
     enable_picking=True,
+    wireframe=False,
+    wireframe_thickness=1.0,
 ):
     """Create one or many squares with different features.
 
@@ -62,6 +64,10 @@ def square(
         The material type for the squares. Options are 'phong' and 'basic'.
     enable_picking : bool, optional
         Whether the squares should be pickable in a 3D scene.
+    wireframe : bool, optional
+        Whether to render the mesh as a wireframe.
+    wireframe_thickness : float, optional
+        The thickness of the wireframe lines.
 
     Returns
     -------
@@ -92,6 +98,8 @@ def square(
         opacity=opacity,
         material=material,
         enable_picking=enable_picking,
+        wireframe=wireframe,
+        wireframe_thickness=wireframe_thickness,
     )
 
 
@@ -105,6 +113,8 @@ def star(
     opacity=None,
     material="phong",
     enable_picking=True,
+    wireframe=False,
+    wireframe_thickness=1.0,
 ):
     """Create one or many stars with different features.
 
@@ -129,6 +139,10 @@ def star(
         The material type for the stars. Options are 'phong' and 'basic'.
     enable_picking : bool, optional
         Whether the stars should be pickable in a 3D scene.
+    wireframe : bool, optional
+        Whether to render the mesh as a wireframe.
+    wireframe_thickness : float, optional
+        The thickness of the wireframe lines.
 
     Returns
     -------
@@ -159,6 +173,8 @@ def star(
         opacity=opacity,
         material=material,
         enable_picking=enable_picking,
+        wireframe=wireframe,
+        wireframe_thickness=wireframe_thickness,
     )
 
 
@@ -173,6 +189,8 @@ def disk(
     opacity=None,
     material="phong",
     enable_picking=True,
+    wireframe=False,
+    wireframe_thickness=1.0,
 ):
     """Visualize one or many disks with different features.
 
@@ -201,6 +219,10 @@ def disk(
         The material type for the disk. Options are 'phong' and 'basic'.
     enable_picking : bool, optional
         Whether the disk should be pickable in a 3D scene.
+    wireframe : bool, optional
+        Whether to render the mesh as a wireframe.
+    wireframe_thickness : float, optional
+        The thickness of the wireframe lines.
 
     Returns
     -------
@@ -232,6 +254,8 @@ def disk(
         opacity=opacity,
         material=material,
         enable_picking=enable_picking,
+        wireframe=wireframe,
+        wireframe_thickness=wireframe_thickness,
     )
 
 
@@ -244,6 +268,8 @@ def triangle(
     opacity=None,
     material="phong",
     enable_picking=True,
+    wireframe=False,
+    wireframe_thickness=1.0,
 ):
     """Create one or many triangles with different features.
 
@@ -266,6 +292,10 @@ def triangle(
         The material type for the triangles. Options are 'phong' and 'basic'.
     enable_picking : bool, optional
         Whether the triangles should be pickable in a 3D scene.
+    wireframe : bool, optional
+        Whether to render the mesh as a wireframe.
+    wireframe_thickness : float, optional
+        The thickness of the wireframe lines.
 
     Returns
     -------
@@ -296,6 +326,8 @@ def triangle(
         opacity=opacity,
         material=material,
         enable_picking=enable_picking,
+        wireframe=wireframe,
+        wireframe_thickness=wireframe_thickness,
     )
 
 

--- a/fury/actor/polyhedron.py
+++ b/fury/actor/polyhedron.py
@@ -14,6 +14,8 @@ def box(
     material="phong",
     enable_picking=True,
     detailed=True,
+    wireframe=False,
+    wireframe_thickness=1.0,
 ):
     """Create one or many boxes with different features.
 
@@ -39,6 +41,10 @@ def box(
     detailed : bool, optional
         Whether to create a detailed box with 24 vertices or a simple box with
         8 vertices.
+    wireframe : bool, optional
+        Whether to render the mesh as a wireframe.
+    wireframe_thickness : float, optional
+        The thickness of the wireframe lines.
 
     Returns
     -------
@@ -69,6 +75,8 @@ def box(
         opacity=opacity,
         material=material,
         enable_picking=enable_picking,
+        wireframe=wireframe,
+        wireframe_thickness=wireframe_thickness,
     )
 
 
@@ -81,6 +89,8 @@ def frustum(
     opacity=None,
     material="phong",
     enable_picking=True,
+    wireframe=False,
+    wireframe_thickness=1.0,
 ):
     """Create one or many frustums with different features.
 
@@ -103,6 +113,10 @@ def frustum(
         The material type for the frustums. Options are 'phong' and 'basic'.
     enable_picking : bool, optional
         Whether the frustums should be pickable in a 3D scene.
+    wireframe : bool, optional
+        Whether to render the mesh as a wireframe.
+    wireframe_thickness : float, optional
+        The thickness of the wireframe lines.
 
     Returns
     -------
@@ -133,6 +147,8 @@ def frustum(
         opacity=opacity,
         material=material,
         enable_picking=enable_picking,
+        wireframe=wireframe,
+        wireframe_thickness=wireframe_thickness,
     )
 
 
@@ -145,6 +161,8 @@ def tetrahedron(
     opacity=None,
     material="phong",
     enable_picking=True,
+    wireframe=False,
+    wireframe_thickness=1.0,
 ):
     """Create one or many tetrahedrons with different features.
 
@@ -167,6 +185,10 @@ def tetrahedron(
         The material type for the tetrahedrons. Options are 'phong' and 'basic'.
     enable_picking : bool, optional
         Whether the tetrahedrons should be pickable in a 3D scene.
+    wireframe : bool, optional
+        Whether to render the mesh as a wireframe.
+    wireframe_thickness : float, optional
+        The thickness of the wireframe lines.
 
     Returns
     -------
@@ -197,6 +219,8 @@ def tetrahedron(
         opacity=opacity,
         material=material,
         enable_picking=enable_picking,
+        wireframe=wireframe,
+        wireframe_thickness=wireframe_thickness,
     )
 
 
@@ -209,6 +233,8 @@ def icosahedron(
     opacity=None,
     material="phong",
     enable_picking=True,
+    wireframe=False,
+    wireframe_thickness=1.0,
 ):
     """Create one or many icosahedrons with different features.
 
@@ -231,6 +257,10 @@ def icosahedron(
         The material type for the icosahedrons. Options are 'phong' and 'basic'.
     enable_picking : bool, optional
         Whether the icosahedrons should be pickable in a 3D scene.
+    wireframe : bool, optional
+        Whether to render the mesh as a wireframe.
+    wireframe_thickness : float, optional
+        The thickness of the wireframe lines.
 
     Returns
     -------
@@ -261,6 +291,8 @@ def icosahedron(
         opacity=opacity,
         material=material,
         enable_picking=enable_picking,
+        wireframe=wireframe,
+        wireframe_thickness=wireframe_thickness,
     )
 
 
@@ -273,6 +305,8 @@ def rhombicuboctahedron(
     opacity=None,
     material="phong",
     enable_picking=True,
+    wireframe=False,
+    wireframe_thickness=1.0,
 ):
     """Create one or many rhombicuboctahedrons with different features.
 
@@ -295,6 +329,10 @@ def rhombicuboctahedron(
         The material type for the rhombicuboctahedrons. Options are 'phong' and 'basic'.
     enable_picking : bool, optional
         Whether the rhombicuboctahedrons should be pickable in a 3D scene.
+    wireframe : bool, optional
+        Whether to render the mesh as a wireframe.
+    wireframe_thickness : float, optional
+        The thickness of the wireframe lines.
 
     Returns
     -------
@@ -326,6 +364,8 @@ def rhombicuboctahedron(
         opacity=opacity,
         material=material,
         enable_picking=enable_picking,
+        wireframe=wireframe,
+        wireframe_thickness=wireframe_thickness,
     )
 
 
@@ -338,6 +378,8 @@ def triangularprism(
     opacity=None,
     material="phong",
     enable_picking=True,
+    wireframe=False,
+    wireframe_thickness=1.0,
 ):
     """Create one or many triangular prisms with different features.
 
@@ -360,6 +402,10 @@ def triangularprism(
         The material type for the triangular prisms. Options are 'phong' and 'basic'.
     enable_picking : bool, optional
         Whether the triangular prisms should be pickable in a 3D scene.
+    wireframe : bool, optional
+        Whether to render the mesh as a wireframe.
+    wireframe_thickness : float, optional
+        The thickness of the wireframe lines.
 
     Returns
     -------
@@ -390,6 +436,8 @@ def triangularprism(
         opacity=opacity,
         material=material,
         enable_picking=enable_picking,
+        wireframe=wireframe,
+        wireframe_thickness=wireframe_thickness,
     )
 
 
@@ -402,6 +450,8 @@ def pentagonalprism(
     opacity=None,
     material="phong",
     enable_picking=True,
+    wireframe=False,
+    wireframe_thickness=1.0,
 ):
     """Create one or many pentagonal prisms with different features.
 
@@ -424,6 +474,10 @@ def pentagonalprism(
         The material type for the pentagonal prisms. Options are 'phong' and 'basic'.
     enable_picking : bool, optional
         Whether the pentagonal prisms should be pickable in a 3D scene.
+    wireframe : bool, optional
+        Whether to render the mesh as a wireframe.
+    wireframe_thickness : float, optional
+        The thickness of the wireframe lines.
 
     Returns
     -------
@@ -454,6 +508,8 @@ def pentagonalprism(
         opacity=opacity,
         material=material,
         enable_picking=enable_picking,
+        wireframe=wireframe,
+        wireframe_thickness=wireframe_thickness,
     )
 
 
@@ -466,6 +522,8 @@ def octagonalprism(
     opacity=None,
     material="phong",
     enable_picking=True,
+    wireframe=False,
+    wireframe_thickness=1.0,
 ):
     """Create one or many octagonal prisms with different features.
 
@@ -488,6 +546,10 @@ def octagonalprism(
         The material type for the octagonal prisms. Options are 'phong' and 'basic'.
     enable_picking : bool, optional
         Whether the octagonal prisms should be pickable in a 3D scene.
+    wireframe : bool, optional
+        Whether to render the mesh as a wireframe.
+    wireframe_thickness : float, optional
+        The thickness of the wireframe lines.
 
     Returns
     -------
@@ -518,6 +580,8 @@ def octagonalprism(
         opacity=opacity,
         material=material,
         enable_picking=enable_picking,
+        wireframe=wireframe,
+        wireframe_thickness=wireframe_thickness,
     )
 
 
@@ -531,6 +595,8 @@ def superquadric(
     opacity=None,
     material="phong",
     enable_picking=True,
+    wireframe=False,
+    wireframe_thickness=1.0,
 ):
     """Create one or many superquadrics with different features.
 
@@ -555,6 +621,10 @@ def superquadric(
         The material type for the superquadrics. Options are 'phong' and 'basic'.
     enable_picking : bool, optional
         Whether the superquadrics should be pickable in a 3D scene.
+    wireframe : bool, optional
+        Whether to render the mesh as a wireframe.
+    wireframe_thickness : float, optional
+        The thickness of the wireframe lines.
 
     Returns
     -------
@@ -585,4 +655,6 @@ def superquadric(
         opacity=opacity,
         material=material,
         enable_picking=enable_picking,
+        wireframe=wireframe,
+        wireframe_thickness=wireframe_thickness,
     )

--- a/fury/material.py
+++ b/fury/material.py
@@ -90,6 +90,8 @@ def _create_mesh_material(
     mode="vertex",
     flat_shading=True,
     texture=None,
+    wireframe=False,
+    wireframe_thickness=-1.0,
 ):
     """Create a mesh material.
 
@@ -113,6 +115,10 @@ def _create_mesh_material(
         Whether to use flat shading (True) or smooth shading (False).
     texture : Texture or TextureMap, optional
         The texture map specifying the color for each texture coordinate.
+    wireframe : bool, optional
+        Whether to render the mesh as a wireframe.
+    wireframe_thickness : float, optional
+        The thickness of the wireframe lines.
 
     Returns
     -------
@@ -134,6 +140,8 @@ def _create_mesh_material(
         "opacity": opacity,
         "flat_shading": flat_shading,
         "map": texture,
+        "wireframe": wireframe,
+        "wireframe_thickness": wireframe_thickness,
     }
 
     if material == "phong":

--- a/fury/tests/test_actor.py
+++ b/fury/tests/test_actor.py
@@ -122,6 +122,30 @@ def validate_actors(actor_type="actor_name", prim_count=1, **kwargs):
     scene.remove(get_actor_1)
 
 
+def test_actor_from_primitive_wireframe():
+    """Test wireframe and wireframe_thickness for primitive actors."""
+    sphere_actor = actor.sphere(
+        centers=np.array([[0, 0, 0]]), colors=np.array([[1, 0, 0]])
+    )
+
+    # By default, wireframe is off
+    assert not sphere_actor.material.wireframe
+    assert sphere_actor.material.wireframe_thickness == 1.0
+
+    # Test enabling wireframe
+    sphere_actor.material.wireframe = True
+    assert sphere_actor.material.wireframe
+
+    # Test disabling wireframe
+    sphere_actor.material.wireframe = False
+    assert not sphere_actor.material.wireframe
+
+    # Test setting wireframe thickness
+    new_thickness = 5.0
+    sphere_actor.material.wireframe_thickness = new_thickness
+    assert sphere_actor.material.wireframe_thickness == new_thickness
+
+
 def test_sphere():
     centers = np.array([[0, 0, 0]])
     colors = np.array([[1, 0, 0]])


### PR DESCRIPTION
### ENH: Enabled wire frame.
**PR Contents**
- Test case for actor_from_prim to test wireframe.
- Enabled wireframe for all the basic geometric actors.
- This provides the structure of the Mesh with Triangles.

**Preview**
<img width="800" height="800" alt="FURY 2 0" src="https://github.com/user-attachments/assets/c6797a3b-6540-4f80-8fe6-536b86ad6ac5" />


### 
**Code to Try**

```
import numpy as np

from fury.window import show
from fury.actor import box

centers = np.random.rand(5, 3) * 10
box_actor = box(centers=centers, wireframe=True, wireframe_thickness=2.0)

if __name__ == "__main__":
    show(actors=[box_actor])
```