### PR TITLE
FPS support (setting and displaying)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
         args: ["fury"]
         pass_filenames: false
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.3
+    rev: v0.14.4
     hooks:
       # Run the linter
     -   id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
         args: ["fury"]
         pass_filenames: false
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.4
+    rev: v0.14.5
     hooks:
       # Run the linter
     -   id: ruff

--- a/fury/lib.py
+++ b/fury/lib.py
@@ -126,7 +126,8 @@ WheelEvent = gfx.WheelEvent
 KeyboardEvent = gfx.KeyboardEvent
 run = loop.run
 call_later = loop.call_later
-
+Clock = gfx.Clock
+Stats = gfx.Stats
 
 plane_geometry = gfx.plane_geometry
 

--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -471,42 +471,15 @@ def test_add_to_scene(sample_actor, sample_ui_actor):
     assert sample_gfx_scene not in scene.children
 
 
-def test_show_manager_fps_display_modes():
-    """Test FPS display modes: offscreen (console) vs interactive (visual stats)."""
-    # Test 1: Offscreen with show_fps=True (uses console printing via Renderer)
-    show_m_offscreen = ShowManager(show_fps=True, window_type="offscreen")
+def test_show_manager_fps_display():
+    """Test FPS display using Stats overlay."""
+    show_m = ShowManager(show_fps=True)
 
-    # Before render: stats not initialized, renderer has console FPS enabled
-    assert show_m_offscreen._stats is None
-    assert show_m_offscreen._stats_initialized is False
-    assert show_m_offscreen.renderer._show_fps is True
-    assert show_m_offscreen.get_fps() is None
-
-    # Test 2: show_fps=False (no FPS display at all)
-    show_m_no_fps = ShowManager(show_fps=False, window_type="offscreen")
-
-    # Renderer should not have console FPS enabled
-    assert show_m_no_fps.renderer._show_fps is False
-    assert show_m_no_fps._stats is None
-    assert show_m_no_fps.get_fps() is None
-
-
-def test_show_manager_fps_interactive_mode():
-    """Test FPS display for interactive (non-offscreen) windows uses Stats."""
-    # Interactive window with show_fps=True should NOT use renderer console FPS
-    # Instead, Stats overlay will be created lazily on first render
-    show_m = ShowManager(show_fps=True, window_type="default")
-
-    # Initial state: Stats not yet created (lazy initialization)
     assert show_m._stats is None
     assert show_m._stats_initialized is False
-    # Renderer should NOT use console FPS for interactive windows
-    assert show_m.renderer._show_fps is False
     assert show_m.get_fps() is None
 
-    # Test with show_fps=False for interactive window
-    show_m_no_fps = ShowManager(show_fps=False, window_type="default")
+    show_m_no_fps = ShowManager(show_fps=False)
     assert show_m_no_fps._stats is None
     assert show_m_no_fps._stats_initialized is False
-    assert show_m_no_fps.renderer._show_fps is False
     assert show_m_no_fps.get_fps() is None

--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -469,3 +469,44 @@ def test_add_to_scene(sample_actor, sample_ui_actor):
     assert sample_ui_actor not in scene.ui_elements
     assert sample_ui_actor.actors[0] not in scene.ui_scene.children
     assert sample_gfx_scene not in scene.children
+
+
+def test_show_manager_fps_display_modes():
+    """Test FPS display modes: offscreen (console) vs interactive (visual stats)."""
+    # Test 1: Offscreen with show_fps=True (uses console printing via Renderer)
+    show_m_offscreen = ShowManager(show_fps=True, window_type="offscreen")
+
+    # Before render: stats not initialized, renderer has console FPS enabled
+    assert show_m_offscreen._stats is None
+    assert show_m_offscreen._stats_initialized is False
+    assert show_m_offscreen.renderer._show_fps is True
+    assert show_m_offscreen.get_fps() is None
+
+    # Test 2: show_fps=False (no FPS display at all)
+    show_m_no_fps = ShowManager(show_fps=False, window_type="offscreen")
+
+    # Renderer should not have console FPS enabled
+    assert show_m_no_fps.renderer._show_fps is False
+    assert show_m_no_fps._stats is None
+    assert show_m_no_fps.get_fps() is None
+
+
+def test_show_manager_fps_interactive_mode():
+    """Test FPS display for interactive (non-offscreen) windows uses Stats."""
+    # Interactive window with show_fps=True should NOT use renderer console FPS
+    # Instead, Stats overlay will be created lazily on first render
+    show_m = ShowManager(show_fps=True, window_type="default")
+
+    # Initial state: Stats not yet created (lazy initialization)
+    assert show_m._stats is None
+    assert show_m._stats_initialized is False
+    # Renderer should NOT use console FPS for interactive windows
+    assert show_m.renderer._show_fps is False
+    assert show_m.get_fps() is None
+
+    # Test with show_fps=False for interactive window
+    show_m_no_fps = ShowManager(show_fps=False, window_type="default")
+    assert show_m_no_fps._stats is None
+    assert show_m_no_fps._stats_initialized is False
+    assert show_m_no_fps.renderer._show_fps is False
+    assert show_m_no_fps.get_fps() is None

--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -146,6 +146,8 @@ def test_show_manager_initialization_default():
     assert show_m.size == (800, 800)
     assert show_m.pixel_ratio == 1
     assert show_m.enable_events is True
+    assert show_m._show_fps is False
+    assert show_m._max_fps == 60
 
 
 def test_show_manager_initialization_custom():
@@ -157,6 +159,8 @@ def test_show_manager_initialization_custom():
         enable_events=False,
         screen_config=[2],  # Two vertical sections
         window_type="offscreen",
+        show_fps=True,
+        max_fps=120,
     )
     assert show_m.title == "Custom Title"
     assert show_m.size == (1024, 768)
@@ -164,6 +168,8 @@ def test_show_manager_initialization_custom():
     assert show_m.enable_events is False
     assert show_m._total_screens == 2  # Two screens
     assert len(show_m.screens) == 2
+    assert show_m._show_fps is True
+    assert show_m._max_fps == 120
 
 
 def test_show_manager_initialization_multiple_screens():

--- a/fury/window.py
+++ b/fury/window.py
@@ -398,8 +398,7 @@ def render_screens(renderer, screens, stats=None):
     screens : list of Screen
         The list of Screen objects to render.
     stats : Stats, optional
-        Optional pygfx Stats helper to time rendering. If provided, it will
-        wrap the rendering cycle and display FPS overlay after rendering all screens."""
+        Stats helper to display FPS overlay."""
     if stats is not None:
         stats.start()
 
@@ -510,7 +509,7 @@ class ShowManager:
     qt_parent : QWidget
         An existing QWidget to embed the QtCanvas within (if `window_type` is 'qt').
     show_fps : bool
-        Whether to print FPS statistics in the console.
+        Whether to display FPS statistics using an on-screen overlay.
     max_fps : int
         Maximum frames per second for the canvas.
     """
@@ -595,12 +594,8 @@ class ShowManager:
         self._max_fps = max_fps
         self._window_type = self._setup_window(window_type)
 
-        # For offscreen rendering, enable console FPS printing in the renderer
-        # For interactive windows, we'll use visual Stats overlay instead
-        use_renderer_fps = self._show_fps and self._window_type == "offscreen"
-
         if renderer is None:
-            renderer = Renderer(self.window, show_fps=use_renderer_fps)
+            renderer = Renderer(self.window)
         self.renderer = renderer
         self.renderer.pixel_ratio = pixel_ratio
         self.renderer.add_event_handler(
@@ -621,7 +616,6 @@ class ShowManager:
         )
         self._callbacks = {}
 
-        # Stats will be created lazily on first render to avoid initialization issues
         self._stats = None
         self._stats_initialized = False
 
@@ -979,14 +973,7 @@ class ShowManager:
 
     def _draw_function(self):
         """Draw all screens and request a window redraw."""
-        # Lazy initialize stats on first render if requested
-        # Skip stats for offscreen (crashes)
-        should_init_stats = (
-            self._show_fps
-            and not self._stats_initialized
-            and self._window_type != "offscreen"
-        )
-        if should_init_stats:
+        if self._show_fps and not self._stats_initialized:
             self._stats = Stats(self.renderer)
             self._stats_initialized = True
 

--- a/fury/window.py
+++ b/fury/window.py
@@ -499,9 +499,9 @@ class ShowManager:
     qt_parent : QWidget
         An existing QWidget to embed the QtCanvas within (if `window_type` is 'qt').
     show_fps : bool
-        Whether to display FPS statistics in the renderer.
+        Whether to print FPS statistics in the console.
     max_fps : int
-        Maximum frames per second for the canvas (default: 60).
+        Maximum frames per second for the canvas.
     """
 
     def __init__(
@@ -570,9 +570,9 @@ class ShowManager:
             An existing QWidget to embed the QtCanvas within (if `window_type`
             is 'qt').
         show_fps : bool, optional
-            Whether to display FPS statistics in the renderer. Defaults to False.
+            Whether to display FPS statistics in the renderer.
         max_fps : int, optional
-            Maximum frames per second for the canvas. Defaults to 60.
+            Maximum frames per second for the canvas.
         """
         self._size = size
         self._title = title

--- a/fury/window.py
+++ b/fury/window.py
@@ -498,6 +498,10 @@ class ShowManager:
         An existing QtWidgets QApplication instance (if `window_type` is 'qt').
     qt_parent : QWidget
         An existing QWidget to embed the QtCanvas within (if `window_type` is 'qt').
+    show_fps : bool
+        Whether to display FPS statistics in the renderer.
+    max_fps : int
+        Maximum frames per second for the canvas (default: 60).
     """
 
     def __init__(
@@ -516,6 +520,8 @@ class ShowManager:
         enable_events=True,
         qt_app=None,
         qt_parent=None,
+        show_fps=False,
+        max_fps=60,
     ):
         """Manage the rendering window, scenes, and interactions.
 
@@ -563,6 +569,10 @@ class ShowManager:
         qt_parent : QWidget, optional
             An existing QWidget to embed the QtCanvas within (if `window_type`
             is 'qt').
+        show_fps : bool, optional
+            Whether to display FPS statistics in the renderer. Defaults to False.
+        max_fps : int, optional
+            Maximum frames per second for the canvas. Defaults to 60.
         """
         self._size = size
         self._title = title
@@ -570,10 +580,12 @@ class ShowManager:
         self._qt_app = qt_app
         self._qt_parent = qt_parent
         self._is_initial_resize = None
+        self._show_fps = show_fps
+        self._max_fps = max_fps
         self._window_type = self._setup_window(window_type)
 
         if renderer is None:
-            renderer = Renderer(self.window)
+            renderer = Renderer(self.window, show_fps=self._show_fps)
         self.renderer = renderer
         self.renderer.pixel_ratio = pixel_ratio
         self.renderer.add_event_handler(
@@ -656,16 +668,25 @@ class ShowManager:
             )
 
         if window_type == "default" or window_type == "glfw":
-            self.window = Canvas(size=self._size, title=self._title)
+            self.window = Canvas(
+                size=self._size, title=self._title, max_fps=self._max_fps
+            )
         elif window_type == "qt":
             self.window = QtCanvas(
-                size=self._size, title=self._title, parent=self._qt_parent
+                size=self._size,
+                title=self._title,
+                parent=self._qt_parent,
+                max_fps=self._max_fps,
             )
             self._is_qt = True
         elif window_type == "jupyter":
-            self.window = JupyterCanvas(size=self._size, title=self._title)
+            self.window = JupyterCanvas(
+                size=self._size, title=self._title, max_fps=self._max_fps
+            )
         else:
-            self.window = OffscreenCanvas(size=self._size, title=self._title)
+            self.window = OffscreenCanvas(
+                size=self._size, title=self._title, max_fps=self._max_fps
+            )
 
         return window_type
 


### PR DESCRIPTION
FPS was limited to 30 all this time! now we set it to 60 and added the ability to show the FPS (in the console). Both arguments are added to the ShowManager.

```python
ShowManager(scene=scene, title="FPS", show_fps=True, max_fps=60)
```