### PR TITLE
CI: relax pre-commit and use a specific CI to check weekly

### DIFF
--- a/.github/workflows/precommit_update.yml
+++ b/.github/workflows/precommit_update.yml
@@ -1,0 +1,26 @@
+name: Pre-commit auto-update
+
+on:
+  schedule:
+    - cron: "0 2 * * Mon"  # weekly
+  # on demand
+  workflow_dispatch:
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+
+      - uses: browniebroke/pre-commit-autoupdate-action@f5c3ec85103b9f8f9be60b9c006cec763d2bdd02 # v1.0.1
+
+      - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        if: always()
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update/pre-commit-hooks
+          title: Update pre-commit hooks
+          commit-message: "chore: update pre-commit hooks"
+          body: Update versions of pre-commit hooks to latest version.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,12 @@
 exclude: ".*/(data|docs/experimental)/.*"
 repos:
--   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
-    rev: v0.7.0
-    hooks:
-    -   id: pre-commit-update
-        args: [--keep, pre-commit-update]
+# Relax this rule for now because it creates too many PRs conflicts.
+# A GH actions will checkout this weekly instead
+# -   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
+#     rev: v0.7.0
+#     hooks:
+#     -   id: pre-commit-update
+#         args: [--keep, pre-commit-update]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:


### PR DESCRIPTION
This PR is too avoid many unecessary conflict in PR due to pre-commit autoupdate.

Now, it is done separatly, every week, and a dedicated PR should be created. 