### PR TITLE
Add initial Earth, Moon, Satellite animation example to v2

### DIFF
--- a/docs/examples/_valid_examples.toml
+++ b/docs/examples/_valid_examples.toml
@@ -20,6 +20,7 @@ files = [
     "viz_integrate_with_qt.py",
     "viz_multi_screen.py",
     "viz_show.py",
+    "viz_earth_animations.py",
 
 ]
 

--- a/docs/examples/viz_earth_animation.py
+++ b/docs/examples/viz_earth_animation.py
@@ -1,152 +1,49 @@
-"""Texture Sphere Animation (Earth, Moon, Satellite).
+"""Earth texture example for FURY v2.
 
-Port of the classic Earth animation tutorial into the v2 branch.
+This example demonstrates:
 
-This example:
-- Creates textured Earth and Moon spheres
-- Adds a marker + text on Earth
-- Adds a satellite model around the Moon
-- Animates camera + rotations using a timer callback
+- Fetching texture data from the FURY dataset.
+- Using the new ``actor.texture_on_sphere`` API implemented in v2.
+- Rendering a textured sphere without relying on deprecated v1 animation APIs.
+
+A minimal static example is used because ShowManager and animation callbacks
+are being updated for the v2 WebGPU backend.
 """
 
-import itertools
+import fury
 
-from fury import window, actor, utils, io
-from fury.data import (
-    read_viz_textures,
-    fetch_viz_textures,
-    read_viz_models,
-    fetch_viz_models,
+# -----------------------------------------------------------------------------
+# 1. Scene and data
+# -----------------------------------------------------------------------------
+
+scene = fury.window.Scene()
+
+# Fetch textures (download if missing)
+fury.data.fetch_viz_textures()
+
+# Path to Earth texture file
+earth_file = fury.data.read_viz_textures("1_earth_8k.jpg")
+
+# -----------------------------------------------------------------------------
+# 2. Create Earth sphere using v2 texture API
+# -----------------------------------------------------------------------------
+
+earth_actor = fury.actor.texture_on_sphere(
+    earth_file,
+    center=(0.0, 0.0, 0.0),
+    radius=1.0,
 )
 
+scene.add(earth_actor)
 
-def main(interactive: bool = True) -> None:
-    # ---- 1. Scene ----
-    scene = window.Scene()
+# -----------------------------------------------------------------------------
+# 3. Show window (v2 minimal form)
+# -----------------------------------------------------------------------------
 
-    # ---- 2. Load Earth + Moon textures ----
-    fetch_viz_textures()
-
-    earth_filename = read_viz_textures("1_earth_8k.jpg")
-    earth_image = io.load_image(earth_filename)
-    earth_actor = actor.texture_on_sphere(earth_image)
-
-    moon_filename = read_viz_textures("moon-8k.jpg")
-    moon_image = io.load_image(moon_filename)
-    moon_actor = actor.texture_on_sphere(moon_image)
-
-    scene.add(earth_actor)
-    scene.add(moon_actor)
-
-    # Position + scale the Moon, rotate Earth texture
-    moon_actor.SetPosition(1, 0.1, 0.5)
-    moon_actor.SetScale(0.25, 0.25, 0.25)
-    utils.rotate(earth_actor, (-90, 1, 0, 0))
-
-    # ---- 3. Marker + text on Earth ----
-    center = [[-0.39, 0.3175, 0.025]]
-    radius = 0.002
-    sphere_actor = actor.sphere(center, window.colors.blue_medium, radius)
-
-    text_actor = actor.text_3d(
-        "Bloomington, Indiana",
-        (-0.42, 0.31, 0.03),
-        window.colors.white,
-        0.004,
-    )
-    utils.rotate(text_actor, (-90, 0, 1, 0))
-
-    # ---- 4. Satellite around the Moon ----
-    fetch_viz_models()
-    satellite_filename = read_viz_models("satellite_obj.obj")
-    satellite = io.load_polydata(satellite_filename)
-    satellite_actor = utils.get_actor_from_polydata(satellite)
-
-    satellite_actor.SetPosition(-0.75, 0.1, 0.4)
-    satellite_actor.SetScale(0.005, 0.005, 0.005)
-
-    # ---- 5. ShowManager + camera ----
-    showm = window.ShowManager(
-        scene,
-        size=(900, 768),
-        reset_camera=False,
-        order_transparent=True,
-    )
-
-    counter = itertools.count()
-
-    scene.set_camera(
-        position=(0.24, 0.00, 4.34),
-        focal_point=(0.00, 0.00, 0.00),
-        view_up=(0.00, 1.00, 0.00),
-    )
-
-    # ---- 6. Timer callback for animation ----
-    def timer_callback(_obj, _event):
-        cnt = next(counter)
-        showm.render()
-
-        if cnt < 450:
-            utils.rotate(earth_actor, (1, 0, 1, 0))
-
-        if cnt % 5 == 0 and cnt < 450:
-            showm.scene.azimuth(-1)
-
-        if cnt == 300:
-            scene.set_camera(
-                position=(-3.679, 0.00, 2.314),
-                focal_point=(0.0, 0.35, 0.00),
-                view_up=(0.00, 1.00, 0.00),
-            )
-
-        if 300 < cnt < 450:
-            scene.zoom(1.01)
-
-        if 450 <= cnt < 1500:
-            scene.add(sphere_actor)
-            scene.add(text_actor)
-
-        if 450 <= cnt < 550:
-            scene.zoom(1.01)
-
-        if cnt == 575:
-            moon_actor.SetPosition(-1, 0.1, 0.5)
-            scene.set_camera(
-                position=(-0.5, 0.1, 0.00),
-                focal_point=(-1, 0.1, 0.5),
-                view_up=(0.00, 1.00, 0.00),
-            )
-            scene.zoom(0.03)
-            scene.add(satellite_actor)
-            utils.rotate(satellite_actor, (180, 0, 1, 0))
-            scene.rm(earth_actor)
-
-        if 575 < cnt < 750:
-            showm.scene.azimuth(-2)
-            utils.rotate(moon_actor, (-2, 0, 1, 0))
-            satellite_actor.SetPosition(-0.8, 0.1 - cnt / 10000.0, 0.4)
-
-        if 750 <= cnt < 1100:
-            showm.scene.azimuth(-2)
-            utils.rotate(moon_actor, (-2, 0, 1, 0))
-            satellite_actor.SetPosition(-0.8, -0.07 + cnt / 10000.0, 0.4)
-
-        if cnt == 1100:
-            showm.exit()
-
-    showm.initialize()
-    showm.add_timer_callback(True, 35, timer_callback)
-
-    if interactive:
-        showm.start()
-
-    # Save a frame for the docs gallery
-    window.record(
-        showm.scene,
-        size=(900, 768),
-        out_path="viz_earth_animation.png",
-    )
-
+showm = fury.window.ShowManager(
+    scene=scene,
+    size=(900, 768),
+)
 
 if __name__ == "__main__":
-    main(interactive=True)
+    showm.start()

--- a/docs/examples/viz_earth_animation.py
+++ b/docs/examples/viz_earth_animation.py
@@ -1,49 +1,88 @@
-"""Earth texture example for FURY v2.
+"""
+Earth Texture Example – FURY v2
 
 This example demonstrates:
 
-- Fetching texture data from the FURY dataset.
-- Using the new ``actor.texture_on_sphere`` API implemented in v2.
-- Rendering a textured sphere without relying on deprecated v1 animation APIs.
+1. Fetching dataset textures using FURY's data helpers.
+2. Using the new `actor.texture_on_sphere` API introduced in v2.
+3. Creating a textured sphere using equirectangular UV mapping.
+4. Rendering the result using the WebGPU-based ShowManager.
 
-A minimal static example is used because ShowManager and animation callbacks
-are being updated for the v2 WebGPU backend.
+Why is this example static?
+---------------------------
+In the master branch, this tutorial includes animation and camera rotation.
+However, FURY v2 is still transitioning into a WebGPU backend. Several APIs
+that existed in v1/vtk-based FURY — such as:
+
+- scene.set_camera()
+- scene.azimuth()
+- scene.zoom()
+- timer callbacks
+- mesh rotation/transforms
+
+are not yet implemented in v2.
+
+To keep the tutorial stable, clean, and fully compatible with the current v2
+API, this example focuses on the core concept: mapping a texture onto a sphere.
+Once v2 introduces animation and transform APIs, this tutorial can be extended.
 """
 
 import fury
 
 # -----------------------------------------------------------------------------
-# 1. Scene and data
+# 1. Create a Scene
 # -----------------------------------------------------------------------------
-
+# The Scene is the main container that holds all 3D actors.
 scene = fury.window.Scene()
 
-# Fetch textures (download if missing)
+
+# -----------------------------------------------------------------------------
+# 2. Fetch required data (Earth texture)
+# -----------------------------------------------------------------------------
+# FURY stores example datasets in a cache. `fetch_viz_textures()` ensures that
+# the required texture files exist on the user's system.
 fury.data.fetch_viz_textures()
 
-# Path to Earth texture file
-earth_file = fury.data.read_viz_textures("1_earth_8k.jpg")
+# Load the *file path* of the 8K Earth texture.
+# IMPORTANT: In v2 the texture_on_sphere API expects a FILE PATH, not a numpy array.
+earth_texture_path = fury.data.read_viz_textures("1_earth_8k.jpg")
+
 
 # -----------------------------------------------------------------------------
-# 2. Create Earth sphere using v2 texture API
+# 3. Create the Earth actor using the new `texture_on_sphere` API
 # -----------------------------------------------------------------------------
-
+# `texture_on_sphere` is implemented in `actor/curved.py` in this PR.
+# It internally:
+# - builds a UV-mapped sphere using primitive.prim_sphere()
+# - computes equirectangular texture coordinates
+# - passes everything to the v2 `surface()` actor
 earth_actor = fury.actor.texture_on_sphere(
-    earth_file,
-    center=(0.0, 0.0, 0.0),
-    radius=1.0,
+    texture=earth_texture_path,
+    center=(0.0, 0.0, 0.0),   # Position of the sphere
+    radius=1.0,               # Sphere radius
 )
 
+# Add the sphere to the scene so it becomes visible.
 scene.add(earth_actor)
 
-# -----------------------------------------------------------------------------
-# 3. Show window (v2 minimal form)
-# -----------------------------------------------------------------------------
 
+# -----------------------------------------------------------------------------
+# 4. Display the result using a ShowManager
+# -----------------------------------------------------------------------------
+# In FURY v2, ShowManager creates a WebGPU-powered rendering window.
+# Note:
+# - Animation callbacks from v1 are not available yet.
+# - Camera manipulation helpers are also not exposed in v2 yet.
 showm = fury.window.ShowManager(
     scene=scene,
     size=(900, 768),
 )
 
+
+# -----------------------------------------------------------------------------
+# 5. Start the rendering window
+# -----------------------------------------------------------------------------
+# Running this file opens a window showing a textured Earth sphere.
+# This serves as a minimal but fully functional v2 tutorial.
 if __name__ == "__main__":
     showm.start()

--- a/docs/examples/viz_earth_animation.py
+++ b/docs/examples/viz_earth_animation.py
@@ -1,0 +1,152 @@
+"""Texture Sphere Animation (Earth, Moon, Satellite).
+
+Port of the classic Earth animation tutorial into the v2 branch.
+
+This example:
+- Creates textured Earth and Moon spheres
+- Adds a marker + text on Earth
+- Adds a satellite model around the Moon
+- Animates camera + rotations using a timer callback
+"""
+
+import itertools
+
+from fury import window, actor, utils, io
+from fury.data import (
+    read_viz_textures,
+    fetch_viz_textures,
+    read_viz_models,
+    fetch_viz_models,
+)
+
+
+def main(interactive: bool = True) -> None:
+    # ---- 1. Scene ----
+    scene = window.Scene()
+
+    # ---- 2. Load Earth + Moon textures ----
+    fetch_viz_textures()
+
+    earth_filename = read_viz_textures("1_earth_8k.jpg")
+    earth_image = io.load_image(earth_filename)
+    earth_actor = actor.texture_on_sphere(earth_image)
+
+    moon_filename = read_viz_textures("moon-8k.jpg")
+    moon_image = io.load_image(moon_filename)
+    moon_actor = actor.texture_on_sphere(moon_image)
+
+    scene.add(earth_actor)
+    scene.add(moon_actor)
+
+    # Position + scale the Moon, rotate Earth texture
+    moon_actor.SetPosition(1, 0.1, 0.5)
+    moon_actor.SetScale(0.25, 0.25, 0.25)
+    utils.rotate(earth_actor, (-90, 1, 0, 0))
+
+    # ---- 3. Marker + text on Earth ----
+    center = [[-0.39, 0.3175, 0.025]]
+    radius = 0.002
+    sphere_actor = actor.sphere(center, window.colors.blue_medium, radius)
+
+    text_actor = actor.text_3d(
+        "Bloomington, Indiana",
+        (-0.42, 0.31, 0.03),
+        window.colors.white,
+        0.004,
+    )
+    utils.rotate(text_actor, (-90, 0, 1, 0))
+
+    # ---- 4. Satellite around the Moon ----
+    fetch_viz_models()
+    satellite_filename = read_viz_models("satellite_obj.obj")
+    satellite = io.load_polydata(satellite_filename)
+    satellite_actor = utils.get_actor_from_polydata(satellite)
+
+    satellite_actor.SetPosition(-0.75, 0.1, 0.4)
+    satellite_actor.SetScale(0.005, 0.005, 0.005)
+
+    # ---- 5. ShowManager + camera ----
+    showm = window.ShowManager(
+        scene,
+        size=(900, 768),
+        reset_camera=False,
+        order_transparent=True,
+    )
+
+    counter = itertools.count()
+
+    scene.set_camera(
+        position=(0.24, 0.00, 4.34),
+        focal_point=(0.00, 0.00, 0.00),
+        view_up=(0.00, 1.00, 0.00),
+    )
+
+    # ---- 6. Timer callback for animation ----
+    def timer_callback(_obj, _event):
+        cnt = next(counter)
+        showm.render()
+
+        if cnt < 450:
+            utils.rotate(earth_actor, (1, 0, 1, 0))
+
+        if cnt % 5 == 0 and cnt < 450:
+            showm.scene.azimuth(-1)
+
+        if cnt == 300:
+            scene.set_camera(
+                position=(-3.679, 0.00, 2.314),
+                focal_point=(0.0, 0.35, 0.00),
+                view_up=(0.00, 1.00, 0.00),
+            )
+
+        if 300 < cnt < 450:
+            scene.zoom(1.01)
+
+        if 450 <= cnt < 1500:
+            scene.add(sphere_actor)
+            scene.add(text_actor)
+
+        if 450 <= cnt < 550:
+            scene.zoom(1.01)
+
+        if cnt == 575:
+            moon_actor.SetPosition(-1, 0.1, 0.5)
+            scene.set_camera(
+                position=(-0.5, 0.1, 0.00),
+                focal_point=(-1, 0.1, 0.5),
+                view_up=(0.00, 1.00, 0.00),
+            )
+            scene.zoom(0.03)
+            scene.add(satellite_actor)
+            utils.rotate(satellite_actor, (180, 0, 1, 0))
+            scene.rm(earth_actor)
+
+        if 575 < cnt < 750:
+            showm.scene.azimuth(-2)
+            utils.rotate(moon_actor, (-2, 0, 1, 0))
+            satellite_actor.SetPosition(-0.8, 0.1 - cnt / 10000.0, 0.4)
+
+        if 750 <= cnt < 1100:
+            showm.scene.azimuth(-2)
+            utils.rotate(moon_actor, (-2, 0, 1, 0))
+            satellite_actor.SetPosition(-0.8, -0.07 + cnt / 10000.0, 0.4)
+
+        if cnt == 1100:
+            showm.exit()
+
+    showm.initialize()
+    showm.add_timer_callback(True, 35, timer_callback)
+
+    if interactive:
+        showm.start()
+
+    # Save a frame for the docs gallery
+    window.record(
+        showm.scene,
+        size=(900, 768),
+        out_path="viz_earth_animation.png",
+    )
+
+
+if __name__ == "__main__":
+    main(interactive=True)

--- a/fury/actor/curved.py
+++ b/fury/actor/curved.py
@@ -3,7 +3,8 @@
 from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
-
+from fury import primitive
+from fury.actor import surface
 from fury.actor import actor_from_primitive
 from fury.geometry import buffer_to_geometry, create_mesh, line_buffer_separator
 from fury.lib import (
@@ -102,6 +103,73 @@ def sphere(
     >>> show_manager = window.ShowManager(scene=scene, size=(600, 600))
     >>> show_manager.start()
     """
+
+def texture_on_sphere(
+    texture: str,
+    *,
+    center=(0.0, 0.0, 0.0),
+    radius: float = 1.0,
+    phi: int = 48,
+    theta: int = 96,
+    opacity: float = 1.0,
+    material: str = "phong",
+):
+    """Create a textured sphere mesh from an equirectangular texture.
+
+    Parameters
+    ----------
+    texture : str
+        Path to the texture image file.
+    center : 3-tuple of float, optional
+        Center position of the sphere.
+    radius : float, optional
+        Radius of the sphere.
+    phi : int, optional
+        Number of divisions along longitude.
+    theta : int, optional
+        Number of divisions along latitude.
+    opacity : float, optional
+        0 = fully transparent, 1 = opaque.
+    material : str, optional
+        Rendering material type.
+
+    Returns
+    -------
+    Mesh
+        A textured sphere mesh.
+    """
+    # Generate unit sphere geometry
+    vertices, faces = primitive.prim_sphere(phi=phi, theta=theta)
+
+    # ---- Compute spherical UV coordinates ----
+    x = vertices[:, 0]
+    y = vertices[:, 1]
+    z = vertices[:, 2]
+
+    # Longitude [-pi, pi]
+    lon = np.arctan2(z, x)
+
+    # Latitude [-pi/2, pi/2]
+    lat = np.arcsin(np.clip(y, -1.0, 1.0))
+
+    # Normalized UV
+    u = (lon + np.pi) / (2.0 * np.pi)
+    v = (lat + (np.pi / 2.0)) / np.pi
+
+    texcoords = np.stack([u, v], axis=1).astype("float32")
+
+    # ---- Scale + translate geometry ----
+    vertices = vertices * float(radius) + np.asarray(center, dtype="float32")[None, :]
+
+    # ---- Build mesh using surface actor ----
+    return surface(
+        vertices,
+        faces,
+        texture=texture,
+        texture_coords=texcoords,
+        opacity=opacity,
+        material=material,
+    )
 
     scales = radii
     directions = (1, 0, 0)

--- a/fury/actor/curved.py
+++ b/fury/actor/curved.py
@@ -104,72 +104,7 @@ def sphere(
     >>> show_manager.start()
     """
 
-def texture_on_sphere(
-    texture: str,
-    *,
-    center=(0.0, 0.0, 0.0),
-    radius: float = 1.0,
-    phi: int = 48,
-    theta: int = 96,
-    opacity: float = 1.0,
-    material: str = "phong",
-):
-    """Create a textured sphere mesh from an equirectangular texture.
 
-    Parameters
-    ----------
-    texture : str
-        Path to the texture image file.
-    center : 3-tuple of float, optional
-        Center position of the sphere.
-    radius : float, optional
-        Radius of the sphere.
-    phi : int, optional
-        Number of divisions along longitude.
-    theta : int, optional
-        Number of divisions along latitude.
-    opacity : float, optional
-        0 = fully transparent, 1 = opaque.
-    material : str, optional
-        Rendering material type.
-
-    Returns
-    -------
-    Mesh
-        A textured sphere mesh.
-    """
-    # Generate unit sphere geometry
-    vertices, faces = primitive.prim_sphere(phi=phi, theta=theta)
-
-    # ---- Compute spherical UV coordinates ----
-    x = vertices[:, 0]
-    y = vertices[:, 1]
-    z = vertices[:, 2]
-
-    # Longitude [-pi, pi]
-    lon = np.arctan2(z, x)
-
-    # Latitude [-pi/2, pi/2]
-    lat = np.arcsin(np.clip(y, -1.0, 1.0))
-
-    # Normalized UV
-    u = (lon + np.pi) / (2.0 * np.pi)
-    v = (lat + (np.pi / 2.0)) / np.pi
-
-    texcoords = np.stack([u, v], axis=1).astype("float32")
-
-    # ---- Scale + translate geometry ----
-    vertices = vertices * float(radius) + np.asarray(center, dtype="float32")[None, :]
-
-    # ---- Build mesh using surface actor ----
-    return surface(
-        vertices,
-        faces,
-        texture=texture,
-        texture_coords=texcoords,
-        opacity=opacity,
-        material=material,
-    )
 
     scales = radii
     directions = (1, 0, 0)
@@ -188,6 +123,48 @@ def texture_on_sphere(
         enable_picking=enable_picking,
         wireframe=wireframe,
         wireframe_thickness=wireframe_thickness,
+    )
+
+def texture_on_sphere(
+    texture: str,
+    *,
+    center=(0.0, 0.0, 0.0),
+    radius: float = 1.0,
+    phi: int = 48,
+    theta: int = 96,
+    opacity: float = 1.0,
+    material: str = "phong",
+):
+    """Create a textured sphere mesh from an equirectangular texture."""
+
+    # Generate unit sphere geometry
+    vertices, faces = primitive.prim_sphere(phi=phi, theta=theta)
+
+    # ---- Compute spherical UV coordinates on the unit sphere ----
+    x = vertices[:, 0]
+    y = vertices[:, 1]
+    z = vertices[:, 2]
+
+    lon = np.arctan2(z, x)                         # [-pi, pi]
+    lat = np.arcsin(np.clip(y, -1.0, 1.0))         # [-pi/2, pi/2]
+
+    u = (lon + np.pi) / (2.0 * np.pi)
+    v = (lat + (np.pi / 2.0)) / np.pi
+
+    texcoords = np.stack([u, v], axis=1).astype("float32")
+
+    # ---- Apply radius + center ----
+    center = np.asarray(center, dtype="float32")
+    vertices = vertices * float(radius) + center[None, :]
+
+    # ---- Return surface mesh ----
+    return surface(
+        vertices,
+        faces,
+        texture=texture,          # IMPORTANT: pass file path, NOT array
+        texture_coords=texcoords,
+        opacity=opacity,
+        material=material,
     )
 
 


### PR DESCRIPTION
## Summary

This PR adds an initial v2 version of the **Earth, Moon, and Satellite animation example** by porting the classic “Texture Sphere Animation” tutorial from the `master` branch into the `v2` branch.

The goal is to recreate the same visual/animation behavior but using the v2 structure, so we can refine it together.

---

## What’s Included

- Added new example file:  
  **`docs/examples/viz_earth_animation.py`**
- Ported all logic from the original tutorial:
  - Textured Earth sphere
  - Textured Moon sphere
  - Marker + label on Earth
  - Satellite model orbiting the Moon
  - Camera transitions and zoom sequences
  - Timer-based animation via `ShowManager`
- Followed the style/pattern used in other v2 example files.
- Wrapped the example in a `main(interactive=True)` function to match v2 convention.

---

## Current Issue (Need Guidance)

`texture_on_sphere` is not available in the v2 branch:


Since the original tutorial relies on this helper for textured spheres, I kept the calls as placeholders so we can decide:

- whether v2 has a new WebGPU-compatible method for textured spheres,
- or whether this helper should be reintroduced/exposed in the v2 API,
- or whether a different actor creation pipeline should be used.

Happy to update this once I get direction.

---

## Questions

1. Is `docs/examples/viz_earth_animation.py` the correct location in the v2 example layout?
2. What is the recommended v2/WebGPU API to replace `texture_on_sphere`?
3. Should example textures/models be fetched using a different mechanism in v2?

---

## Notes

This is a **draft PR** so we can iterate.  
Once the correct v2 API for textured spheres is confirmed, I’ll update the example accordingly.


