### PR TITLE
ImGui introduced in FURY

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', 3.11, 3.12]
+        python-version: [3.11, 3.12, 3.13]
         os: [ubuntu-latest, macos-latest, windows-latest]
         platform: [x64]
         install-type: [pip, ]  # conda]
@@ -109,12 +109,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
         channels: defaults, conda-forge
         use-only-tar-bz2: true
+    - name: Setup Headless
+      run: ci/setup_headless.sh
     - name: Install Dependencies
       run: ci/install_dependencies.sh
     - name: Install FURY
       run: ci/install.sh
-    - name: Setup Headless
-      run: ci/setup_headless.sh
     - name: Run the tests!
       run: |
         if [ "${{ matrix.use-pre }}" == "true" ]; then

--- a/ci/setup_headless.sh
+++ b/ci/setup_headless.sh
@@ -3,10 +3,11 @@
 echo "DISPLAY=:99.0" >> $GITHUB_ENV
 
 if [ "$RUNNER_OS" == "Linux" ]; then
-	echo "LIBGL_ALWAYS_SOFTWARE=1" >> $GITHUB_ENV
-    echo "LIBGL_ALWAYS_INDIRECT=0" >> $GITHUB_ENV
 	sudo apt-get update -y -qq;
-    sudo apt-get install --no-install-recommends -y libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers xvfb libxcb-cursor0;
+  sudo apt-get install --no-install-recommends -y libegl1-mesa-dev libglu1-mesa-dev libgl1-mesa-dri \
+	libxcb-xfixes0-dev mesa-vulkan-drivers xvfb libxcb-cursor0 libx11-dev libxrandr-dev libxinerama-dev \
+	libxcursor-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev x11proto-core-dev \
+	libxcb1-dev libx11-xcb-dev libxkbcommon-dev;
 	Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1  &
     sleep 3
 elif [ "$RUNNER_OS" == "Windows" ]; then

--- a/docs/examples/viz_imgui.py
+++ b/docs/examples/viz_imgui.py
@@ -1,0 +1,105 @@
+"""
+===========================
+ImGui Integration Example
+===========================
+
+This example demonstrates how to integrate an ImGui user interface
+into a FURY scene using the :class:`fury.window.ShowManager` and
+``imgui_draw_function`` callback.
+
+A small ImGui window is created with a checkbox that controls the
+visibility of a group of colored spheres rendered by FURY.
+
+"""
+
+import numpy as np
+from imgui_bundle import imgui
+
+from fury.actor import sphere
+from fury.window import Scene, ShowManager
+
+
+###############################################################################
+# First, we define an ImGui draw function.
+#
+# This function will be called every frame by the :class:`ShowManager`.
+# Inside it, we build a simple ImGui window with a checkbox that can
+# toggle the visibility of our actor.
+
+
+def create_imgui_controls():
+    # Set the initial position and size of the ImGui window. The
+    # ``first_use_ever`` condition ensures this is only applied the
+    # first time the window appears.
+    imgui.set_next_window_pos((10, 10), imgui.Cond_.first_use_ever)
+    imgui.set_next_window_size((220, 120), imgui.Cond_.first_use_ever)
+
+    expanded, _ = imgui.begin("Controls")
+    if expanded:
+        # The checkbox returns (changed, value); we only need the value.
+        _, visible = imgui.checkbox("Show spheres", sphere_actor.visible)
+        sphere_actor.visible = visible
+
+    imgui.end()
+
+
+###############################################################################
+# Now we create some simple data and build the FURY actor.
+#
+# We will render three spheres at different positions, each with a
+# different color (red, green, blue). These are combined into a single
+# FURY actor that we add to the scene.
+
+points = np.asarray(
+    [
+        (15.0, 0.0, 0.0),
+        (0.0, 15.0, 0.0),
+        (0.0, 0.0, 15.0),
+    ],
+    dtype=float,
+)
+
+radii = 15.0
+
+colors = np.asarray(
+    [
+        (1.0, 0.0, 0.0),
+        (0.0, 1.0, 0.0),
+        (0.0, 0.0, 1.0),
+    ],
+    dtype=float,
+)
+
+sphere_actor = sphere(
+    points,
+    radii=radii,
+    colors=colors,
+    phi=48,
+    theta=48,
+)
+
+
+###############################################################################
+# Next, we create the :class:`Scene` and add our actor to it.
+
+scene = Scene()
+scene.add(sphere_actor)
+
+
+###############################################################################
+# Finally, we create a :class:`ShowManager` and enable ImGui support.
+#
+# Passing ``imgui=True`` turns on ImGui integration, and the
+# ``imgui_draw_function`` argument specifies which function will be
+# used to define the ImGui user interface each frame.
+
+if __name__ == "__main__":
+    show_m = ShowManager(
+        title="FURY ImGui Integration Example",
+        scene=scene,
+        size=(800, 600),
+        window_type="default",
+        imgui=True,
+        imgui_draw_function=create_imgui_controls,
+    )
+    show_m.start()

--- a/fury/lib.py
+++ b/fury/lib.py
@@ -10,6 +10,18 @@ import wgpu
 
 from fury.optpkg import optional_package
 
+imgui_message = (
+    "You do not have imgui-bundle installed. The GUI will not work for you. "
+    "Please install or upgrade imgui-bundle using pip install -U imgui-bundle"
+)
+imgui_bundle, have_imgui_bundle, _ = optional_package(
+    "imgui_bundle", trip_msg=imgui_message
+)
+if have_imgui_bundle:
+    from wgpu.utils.imgui import ImguiRenderer
+else:
+    ImguiRenderer = imgui_bundle
+
 jupyter_pckg_msg = (
     "You do not have jupyter-rfb installed. The jupyter widget will not work for "
     "you. Please install or upgrade jupyter-rfb using pip install -U jupyter-rfb"
@@ -100,6 +112,7 @@ OrthographicCamera = gfx.OrthographicCamera
 PerspectiveCamera = gfx.PerspectiveCamera
 ScreenCoordsCamera = gfx.ScreenCoordsCamera
 Renderer = gfx.WgpuRenderer
+UIRenderer = ImguiRenderer
 Canvas = RenderCanvas
 OffscreenCanvas = OffscreenRenderCanvas
 BaseShader = gfx.renderers.wgpu.BaseShader

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ doc = [
     "sphinx >=6.1.2",
     "texext",
     "tomli; python_version < \"3.11\"",
+    "imgui_bundle",
     ]
 style = ["ruff", "pre-commit"]
 typing = ["mypy", "types-Pillow", "data-science-types"]

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -4,3 +4,4 @@ Cython
 jupyter-rfb>=0.4.4
 PySide6>=6.8.2.1
 numba>=0.61.2
+imgui_bundle


### PR DESCRIPTION
### NF: Imgui introduced.

- Provides APIs to enable and disable imgui.
- It can be activated from the init or using the API at later point.
- Checks different apis to enable/disable imgui.
- Checks setting the callback for drawing the imgui.
- Introduced a tutorial.
