### PR TITLE
MTN: Pindown the sphinx version below 9.0.0.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,8 @@ dev = [
 doc = [
     "fury[plot]",
     "numpydoc",
-    "sphinx >=6.1.2",
+    "sphinx >=6.1.2,<9.0.0",
+    "ablog >=0.11.1",
     "texext",
     "tomli; python_version < \"3.11\"",
     "imgui_bundle",

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,5 +1,5 @@
 # These are dependencies of various sphinx extensions for documentation.
-sphinx>=5.0.0
+sphinx>=5.0.0,<9.0.0
 ipython
 matplotlib
 sphinx-copybutton


### PR DESCRIPTION
- Ablog has not release the updated version supporting the sphinx v9.
- Once that is out we can lift the pinning of sphinx.