### PR TITLE
NF: Streamline based ROI filtering

### DIFF
--- a/docs/examples/_valid_examples.toml
+++ b/docs/examples/_valid_examples.toml
@@ -20,7 +20,8 @@ files = [
     "viz_integrate_with_qt.py",
     "viz_multi_screen.py",
     "viz_show.py",
-    "viz_imgui.py"
+    "viz_imgui.py",
+    "viz_shapes.py"
 
 ]
 
@@ -34,6 +35,7 @@ files = [
     "viz_vector_field.py",
     "viz_spherical_harmonics.py",
     "viz_line_projections.py",
+    "viz_streamlines_roi.py",
     "viz_contour.py",
 
 ]

--- a/docs/examples/viz_streamlines_roi.py
+++ b/docs/examples/viz_streamlines_roi.py
@@ -1,0 +1,87 @@
+"""
+============================
+Streamlines: Simple ROI Mask
+============================
+
+Build a small bundle of streamlines and a tiny ROI mask. Streamlines passing
+through the ROI are blue; the rest are gray.
+"""
+
+import numpy as np
+
+from fury import actor, window
+
+###############################################################################
+# Create a handful of straight streamlines with multiple points.
+
+x_coords = np.linspace(-5.0, 5.0, 11, dtype=np.float32)
+lines = np.stack(
+    [
+        np.column_stack(
+            [x_coords, np.full_like(x_coords, -1.0), np.zeros_like(x_coords)]
+        ),
+        np.column_stack(
+            [x_coords, np.full_like(x_coords, 0.0), np.zeros_like(x_coords)]
+        ),
+        np.column_stack(
+            [x_coords, np.full_like(x_coords, 1.0), np.zeros_like(x_coords)]
+        ),
+        np.column_stack(
+            [x_coords, np.full_like(x_coords, 3.0), np.zeros_like(x_coords)]
+        ),
+        np.column_stack(
+            [x_coords, np.full_like(x_coords, -3.0), np.zeros_like(x_coords)]
+        ),
+    ],
+    axis=0,
+).astype(np.float32)
+
+
+###############################################################################
+# Define a small ROI mask (all ones) and place its origin explicitly.
+
+mask_shape = (9, 9, 9)
+mask = np.zeros(mask_shape, dtype=np.uint8)
+mask[3:7, 3:7, 3:7] = 1  # A small cube in the center
+roi_origin = (-5.0, -5.0, -5.0)  # voxel (0,0,0) is at (-5, -5, -5) in world coords
+
+###############################################################################
+# Build actors
+
+all_lines = actor.streamlines(
+    lines,
+    colors=(0.7, 0.7, 0.7),
+    thickness=2.0,
+    opacity=0.2,
+)
+
+roi_filtered = actor.streamlines(
+    lines,
+    colors=(0.0, 0.0, 1.0),
+    thickness=4.0,
+    outline_thickness=1.5,
+    outline_color=(0.1, 0.1, 0.1),
+    roi_mask=mask,
+    roi_origin=roi_origin,
+    opacity=1.0,
+)
+
+roi_surface = actor.contour_from_roi(
+    mask,
+    color=(0.0, 0.8, 0.3),
+    opacity=0.4,
+)
+roi_surface.translate(roi_origin)
+
+###############################################################################
+# Create a scene and show
+scene = window.Scene()
+scene.add(all_lines)
+scene.add(roi_filtered)
+scene.add(roi_surface)
+
+show_manager = window.ShowManager(
+    scene=scene, title="FURY Simple Streamline ROI", size=(800, 600)
+)
+window.update_camera(show_manager.screens[0].camera, None, scene)
+show_manager.start()

--- a/fury/actor/curved.py
+++ b/fury/actor/curved.py
@@ -618,7 +618,7 @@ class Streamlines(Line):
         else:
             colors_arr = np.asarray(colors, dtype=np.float32)
 
-        self._roi_origin = self._resolve_roi_origin()
+        self._roi_origin = self._resolve_roi_origin(roi_origin)
 
         self._input_positions_array = positions_arr
         self._input_colors_array = colors_arr
@@ -849,8 +849,8 @@ def streamlines(
 
     Returns
     -------
-        Streamline
-            The created streamline object.
+    Streamline
+        The created streamline object.
     """
     lines_list = (
         [np.asarray(seg) for seg in lines]

--- a/fury/actor/curved.py
+++ b/fury/actor/curved.py
@@ -12,6 +12,7 @@ from fury.lib import (
 )
 from fury.material import (
     StreamlinesMaterial,
+    _StreamlineBakedMaterial,
     _StreamtubeBakedMaterial,
     _create_mesh_material,
     validate_opacity,
@@ -20,6 +21,7 @@ from fury.optpkg import optional_package
 import fury.primitive as fp
 from fury.shader import (
     StreamlinesShader,
+    _StreamlineBakingShader,
     _StreamtubeBakingShader,
     _StreamtubeRenderShader,
 )
@@ -453,9 +455,92 @@ class Streamlines(Line):
         The thickness of the outline.
     outline_color : tuple, optional
         The color of the outline.
+    roi_mask : ndarray, optional
+        3D array where values > 0 define the ROI voxels. This enables
+        shader-side ROI testing using the volumetric mask, which is assumed
+        to be centered at the origin with unit voxel spacing.
+    roi_origin : array-like of shape (3,), optional
+        World-space coordinates of the ROI voxel (0, 0, 0). When not
+        provided, defaults to (0, 0, 0).
     enable_picking : bool, optional
-        Whether the streamline should be pickable in a 3D scene, by default True.
+        Whether the streamline should be pickable in a 3D scene.
+    line_lengths : ndarray, optional
+        Optional precomputed point counts for each line (used for ROI
+        baking). When omitted, lengths are inferred from NaN separators.
+    line_offsets : ndarray, optional
+        Optional precomputed offsets into the flattened buffer for each
+        line (used for ROI baking). When omitted, offsets are inferred from
+        NaN separators.
     """
+
+    @staticmethod
+    def _compute_line_metadata(positions, *, line_lengths=None, line_offsets=None):
+        """Infer per-line lengths and offsets from a flattened buffer with NaNs.
+
+        Parameters
+        ----------
+        positions : ndarray, shape (N, 3)
+            The flattened array of line positions, with NaNs separating lines.
+        line_lengths : ndarray, optional
+            Optional precomputed point counts for each line.
+        line_offsets : ndarray, optional
+            Optional precomputed offsets into the flattened buffer for each
+            line.
+
+        Returns
+        -------
+        tuple of ndarray
+            A tuple (line_lengths, line_offsets).
+        """
+        if line_lengths is not None and line_offsets is not None:
+            return (
+                np.asarray(line_lengths, dtype=np.uint32).reshape(-1),
+                np.asarray(line_offsets, dtype=np.uint32).reshape(-1),
+            )
+
+        positions = np.asarray(positions)
+        if positions.ndim != 2 or positions.shape[1] != 3:
+            raise ValueError("lines must be a 2D array of shape (N, 3)")
+
+        nan_mask = np.any(~np.isfinite(positions), axis=1)
+        split_indices = list(np.where(nan_mask)[0]) + [positions.shape[0]]
+
+        lengths = []
+        offsets = []
+        start = 0
+        for idx in split_indices:
+            if idx > start:
+                offsets.append(start)
+                lengths.append(idx - start)
+            start = idx + 1
+
+        return np.asarray(lengths, dtype=np.uint32), np.asarray(
+            offsets, dtype=np.uint32
+        )
+
+    @staticmethod
+    def _validate_roi_mask(mask):
+        """Validate and extract the mask.
+
+        Parameters
+        ----------
+        mask : ndarray
+            3D array where values > 0 define the ROI voxels.
+
+        Returns
+        -------
+        ndarray
+            The validated ROI mask as a binary array.
+
+        Raises
+        ------
+        ValueError
+            If the mask is not a 3D array.
+        """
+        mask = np.asarray(mask)
+        if mask.ndim != 3:
+            raise ValueError("roi_mask must be a 3D array.")
+        return (mask > 0).astype(np.uint8)
 
     def __init__(
         self,
@@ -466,7 +551,11 @@ class Streamlines(Line):
         opacity=1.0,
         outline_thickness=1.0,
         outline_color=(1, 0, 0),
+        roi_mask=None,
+        roi_origin=None,
         enable_picking=True,
+        line_lengths=None,
+        line_offsets=None,
     ):
         """
         Create a streamline representation.
@@ -485,8 +574,22 @@ class Streamlines(Line):
             The thickness of the outline.
         outline_color : tuple, optional
             The color of the outline.
+        roi_mask : ndarray, optional
+            3D array where values > 0 define the ROI voxels. This enables
+            shader-side ROI testing using the volumetric mask, which is assumed
+            to be centered at the origin with unit voxel spacing.
+        roi_origin : array-like of shape (3,), optional
+            World-space coordinates of the ROI voxel (0, 0, 0). When not
+            provided, defaults to (0, 0, 0).
         enable_picking : bool, optional
             Whether the streamline should be pickable in a 3D scene.
+        line_lengths : ndarray, optional
+            Optional precomputed point counts for each line (used for ROI
+            baking). When omitted, lengths are inferred from NaN separators.
+        line_offsets : ndarray, optional
+            Optional precomputed offsets into the flattened buffer for each
+            line (used for ROI baking). When omitted, offsets are inferred from
+            NaN separators.
         """
         super().__init__()
 
@@ -509,18 +612,200 @@ class Streamlines(Line):
         if not isinstance(enable_picking, bool):
             raise TypeError("enable_picking must be a boolean")
 
+        positions_arr = np.asarray(lines, dtype=np.float32)
+        if colors is None:
+            colors_arr = np.ones((positions_arr.shape[0], 4), dtype=np.float32)
+        else:
+            colors_arr = np.asarray(colors, dtype=np.float32)
+
+        self._roi_origin = self._resolve_roi_origin()
+
+        self._input_positions_array = positions_arr
+        self._input_colors_array = colors_arr
+        self._line_lengths, self._line_offsets = self._compute_line_metadata(
+            positions_arr, line_lengths=line_lengths, line_offsets=line_offsets
+        )
+        self.n_lines = int(self._line_lengths.size)
+        self._out_capacity = int(positions_arr.shape[0])
+        self._color_channels = int(colors_arr.shape[1]) if colors_arr.ndim == 2 else 3
+
+        if roi_mask is None:
+            positions_out = positions_arr
+            colors_out = colors_arr
+        else:
+            positions_out = np.full_like(positions_arr, np.nan, dtype=np.float32)
+            colors_out = np.full_like(colors_arr, np.nan, dtype=np.float32)
+
         self.geometry = buffer_to_geometry(
-            positions=lines.astype("float32"), colors=colors.astype("float32")
+            positions=positions_out.astype("float32"),
+            colors=colors_out.astype("float32"),
         )
 
-        self.material = StreamlinesMaterial(
-            outline_thickness=outline_thickness,
-            outline_color=outline_color,
-            pick_write=enable_picking,
-            opacity=opacity,
-            thickness=thickness,
-            color_mode="vertex",
+        material_kwargs = {
+            "outline_thickness": outline_thickness,
+            "outline_color": outline_color,
+            "pick_write": enable_picking,
+            "opacity": opacity,
+            "thickness": thickness,
+            "color_mode": "vertex",
+        }
+
+        if roi_mask is None:
+            self.material = StreamlinesMaterial(**material_kwargs)
+            self._needs_gpu_update = False
+        else:
+            self.material = _StreamlineBakedMaterial(**material_kwargs)
+            self._needs_gpu_update = True
+
+        self._line_lengths_buffer = Buffer(self._line_lengths.astype(np.uint32))
+        self._line_offsets_buffer = Buffer(self._line_offsets.astype(np.uint32))
+        self._line_positions_in = Buffer(positions_arr.astype(np.float32).ravel())
+        self._line_colors_in = Buffer(colors_arr.astype(np.float32).ravel())
+        self._roi_mask_buffer = None
+        self._roi_auto_detach = True
+        self.roi_mask = roi_mask
+
+    @property
+    def roi_mask(self):
+        """Get the ROI mask.
+
+        Returns
+        -------
+        ndarray or None
+            The ROI mask as a 3D array, or None if no mask is set.
+        """
+        if self._roi_mask_buffer is not None:
+            return self._roi_mask_buffer.data
+        return None
+
+    @roi_mask.setter
+    def roi_mask(self, mask):
+        """Set the ROI mask.
+
+        Parameters
+        ----------
+        mask : ndarray
+            3D array where values > 0 define the ROI voxels.
+        """
+        if mask is None:
+            self._roi_mask_buffer = None
+            self.material.roi_dim = (0, 0, 0)
+            self.material.roi_enabled = False
+            self._roi_origin = self._resolve_roi_origin(None)
+            self._needs_gpu_update = False
+            self._restore_full_geometry()
+            if isinstance(self.material, _StreamlineBakedMaterial):
+                self.material = StreamlinesMaterial(
+                    outline_thickness=self.material.outline_thickness,
+                    outline_color=self.material.outline_color,
+                    pick_write=self.material.pick_write,
+                    opacity=self.material.opacity,
+                    thickness=self.material.thickness,
+                    color_mode=self.material.color_mode,
+                )
+            return
+
+        mask_arr = self._validate_roi_mask(mask)
+        self._roi_mask_buffer = Buffer(mask_arr.astype(np.uint32).ravel())
+        self.material.roi_dim = mask_arr.shape
+        self.material.roi_enabled = True
+        self._reset_output_buffers()
+        self._ensure_baked_material()
+        self._needs_gpu_update = True
+
+    @property
+    def roi_origin(self):
+        """Get the ROI origin.
+
+        Returns
+        -------
+        ndarray or None
+            The ROI origin as a (3,) array, or None if no origin is set.
+        """
+        return self._roi_origin
+
+    @roi_origin.setter
+    def roi_origin(self, origin):
+        """Set the ROI origin (world-space position of voxel (0, 0, 0)).
+
+        Parameters
+        ----------
+        origin : array-like of shape (3,) or None
+            The ROI origin coordinates. If None, defaults to (0, 0, 0).
+        """
+        self._roi_origin = self._resolve_roi_origin(origin)
+        if self._roi_mask_buffer is not None:
+            self._ensure_baked_material()
+            self._needs_gpu_update = True
+
+    def _reset_output_buffers(self):
+        """Clear output buffers before compute baking."""
+        if self._out_capacity == 0:
+            return
+        nan_positions = np.full_like(
+            self._input_positions_array, np.nan, dtype=np.float32
         )
+        nan_colors = np.full_like(self._input_colors_array, np.nan, dtype=np.float32)
+        if hasattr(self.geometry.positions, "data"):
+            pos_data = self.geometry.positions.data
+            self.geometry.positions.data[...] = nan_positions.reshape(pos_data.shape)
+        else:
+            self.geometry.positions = Buffer(nan_positions.ravel())
+        if hasattr(self.geometry.colors, "data"):
+            col_data = self.geometry.colors.data
+            self.geometry.colors.data[...] = nan_colors.reshape(col_data.shape)
+        else:
+            self.geometry.colors = Buffer(nan_colors.ravel())
+
+    def _restore_full_geometry(self):
+        """Restore full, unfiltered streamline buffers."""
+        if hasattr(self.geometry.positions, "data"):
+            pos_data = self.geometry.positions.data
+            self.geometry.positions.data[...] = self._input_positions_array.reshape(
+                pos_data.shape
+            )
+        else:
+            self.geometry.positions = Buffer(self._input_positions_array.ravel())
+        if hasattr(self.geometry.colors, "data"):
+            col_data = self.geometry.colors.data
+            self.geometry.colors.data[...] = self._input_colors_array.reshape(
+                col_data.shape
+            )
+        else:
+            self.geometry.colors = Buffer(self._input_colors_array.ravel())
+
+    def _ensure_baked_material(self):
+        """Ensure baked material is active when ROI filtering is requested."""
+        if isinstance(self.material, _StreamlineBakedMaterial):
+            return
+        self.material = _StreamlineBakedMaterial(
+            outline_thickness=self.material.outline_thickness,
+            outline_color=self.material.outline_color,
+            pick_write=self.material.pick_write,
+            opacity=self.material.opacity,
+            thickness=self.material.thickness,
+            color_mode=self.material.color_mode,
+        )
+
+    def _resolve_roi_origin(self, origin):
+        """Validate and resolve ROI origin from user input.
+
+        Parameters
+        ----------
+        origin : array-like of shape (3,) or None
+            The ROI origin coordinates. If None, defaults to (0, 0, 0).
+
+        Returns
+        -------
+        ndarray
+            The resolved ROI origin as a (3,) array.
+        """
+        if origin is None:
+            return np.zeros((3,), dtype=np.float32)
+        origin = np.asarray(origin, dtype=np.float32).reshape(-1)
+        if origin.size != 3:
+            raise ValueError("roi_origin must have exactly three values.")
+        return origin
 
 
 def streamlines(
@@ -531,6 +816,8 @@ def streamlines(
     opacity=1.0,
     outline_thickness=1.0,
     outline_color=(0, 0, 0),
+    roi_mask=None,
+    roi_origin=None,
     enable_picking=True,
 ):
     """Create a streamline representation.
@@ -549,15 +836,37 @@ def streamlines(
         The thickness of the outline.
     outline_color : tuple, optional
         The color of the outline.
+    roi_mask : ndarray, optional
+        3D array where values > 0 define the ROI voxels. When provided,
+        streamlines are filtered in a compute baking pass using this volumetric
+        mask, which is assumed to be centered at the origin with unit voxel
+        spacing.
+    roi_origin : array-like of shape (3,), optional
+        Origin of the ROI voxel (0, 0, 0) in world-space coordinates. When not
+        provided, defaults to (0, 0, 0).
     enable_picking : bool, optional
         Whether the streamline should be pickable in a 3D scene.
 
     Returns
     -------
-    Streamline
-        The created streamline object.
+        Streamline
+            The created streamline object.
     """
-    lines_positions, lines_colors = line_buffer_separator(lines, color=colors)
+    lines_list = (
+        [np.asarray(seg) for seg in lines]
+        if not isinstance(lines, np.ndarray) or lines.ndim != 3
+        else [np.asarray(seg) for seg in lines]
+    )
+    lengths = np.asarray([len(seg) for seg in lines_list], dtype=np.uint32)
+    offsets = np.zeros_like(lengths)
+    running = 0
+    for i, ln in enumerate(lengths):
+        offsets[i] = running
+        running += int(ln)
+        if i < len(lengths) - 1:
+            running += 1  # separator slot
+
+    lines_positions, lines_colors = line_buffer_separator(lines_list, color=colors)
 
     return Streamlines(
         lines_positions,
@@ -566,12 +875,16 @@ def streamlines(
         opacity=opacity,
         outline_thickness=outline_thickness,
         outline_color=outline_color,
+        roi_mask=roi_mask,
+        roi_origin=roi_origin,
         enable_picking=enable_picking,
+        line_lengths=lengths,
+        line_offsets=offsets,
     )
 
 
 @register_wgpu_render_function(Streamlines, StreamlinesMaterial)
-def register_render_streamline(wobject):
+def _register_render_streamline(wobject):
     """Register the streamline render function.
 
     Parameters
@@ -585,6 +898,25 @@ def register_render_streamline(wobject):
         The created streamline shader.
     """
     return StreamlinesShader(wobject)
+
+
+@register_wgpu_render_function(Streamlines, _StreamlineBakedMaterial)
+def _register_streamline_baking_shaders(wobject):
+    """Register the streamline baking shaders.
+
+    Parameters
+    ----------
+    wobject : Streamline
+        The streamline object to register.
+
+    Returns
+    -------
+    _StreamlineBakingShader, StreamlinesShader
+        The created streamline shader pipeline.
+    """
+    compute_shader = _StreamlineBakingShader(wobject)
+    render_shader = StreamlinesShader(wobject)
+    return compute_shader, render_shader
 
 
 @njit(cache=True)

--- a/fury/actor/tests/test_curved.py
+++ b/fury/actor/tests/test_curved.py
@@ -4,7 +4,11 @@ import pytest
 
 from fury import actor, window
 from fury.actor.tests._helpers import validate_actors
-from fury.material import _StreamtubeBakedMaterial
+from fury.material import (
+    StreamlinesMaterial,
+    _StreamlineBakedMaterial,
+    _StreamtubeBakedMaterial,
+)
 
 
 def test_sphere():
@@ -210,6 +214,77 @@ def test_streamtube_gpu_invalid_inputs():
             colors=np.array([1.0, 0.5], dtype=np.float32),
             backend="gpu",
         )
+
+
+def test_streamlines_roi_metadata_and_reset():
+    """Streamlines ROI mask toggles baked material and restores buffers."""
+    lines = [
+        np.array([[-1.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=np.float32),
+        np.array([[0.0, 1.0, 0.0], [1.0, 1.0, 0.0]], dtype=np.float32),
+    ]
+    roi_mask = np.ones((2, 3, 4), dtype=np.uint8)
+
+    wobj = actor.streamlines(lines, colors=(0.2, 0.2, 0.2), roi_mask=roi_mask)
+
+    assert np.array_equal(wobj._line_lengths, np.array([2, 2], dtype=np.uint32))
+    assert np.array_equal(wobj._line_offsets, np.array([0, 3], dtype=np.uint32))
+    assert isinstance(wobj.material, _StreamlineBakedMaterial)
+    assert wobj.material.roi_enabled is True
+    assert wobj.material.roi_dim == roi_mask.shape
+    assert np.allclose(wobj.roi_origin, (0.0, 0.0, 0.0))
+    assert not np.isfinite(wobj.geometry.positions.data).all()
+
+    wobj.roi_mask = None
+    assert isinstance(wobj.material, StreamlinesMaterial)
+    assert wobj.material.roi_enabled is False
+    assert wobj._needs_gpu_update is False
+    assert np.allclose(
+        wobj.geometry.positions.data,
+        wobj._input_positions_array.reshape(wobj.geometry.positions.data.shape),
+        equal_nan=True,
+    )
+
+
+def test_streamlines_roi_origin_updates_needs_update_flag():
+    """Changing ROI origin sets compute update when a mask is present."""
+    lines = [
+        np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float32),
+        np.array([[0.0, 2.0, 0.0], [1.0, 2.0, 0.0]], dtype=np.float32),
+    ]
+    roi_mask = np.ones((3, 3, 3), dtype=np.uint8)
+
+    wobj = actor.streamlines(
+        lines, colors=(0.1, 0.1, 0.1), roi_mask=roi_mask, roi_origin=(1.0, 2.0, 3.0)
+    )
+
+    assert np.allclose(wobj.roi_origin, (1.0, 2.0, 3.0))
+    wobj._needs_gpu_update = False
+    wobj.roi_origin = (2.5, -1.0, 0.5)
+    assert np.allclose(wobj.roi_origin, (2.5, -1.0, 0.5))
+    assert wobj._needs_gpu_update is True
+
+
+def test_streamlines_helper_populates_buffers_without_roi():
+    """Actor helper populates metadata buffers when no ROI is provided."""
+    lines = [
+        np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]], dtype=np.float32),
+        np.array([[1.0, 0.0, 0.0], [2.0, 1.0, 1.0]], dtype=np.float32),
+    ]
+
+    wobj = actor.streamlines(lines, colors=(1.0, 0.0, 0.0))
+
+    assert isinstance(wobj.material, StreamlinesMaterial)
+    assert np.array_equal(
+        wobj._line_lengths_buffer.data, wobj._line_lengths.astype(np.uint32)
+    )
+    assert np.array_equal(
+        wobj._line_offsets_buffer.data, wobj._line_offsets.astype(np.uint32)
+    )
+    assert np.allclose(
+        wobj.geometry.positions.data,
+        wobj._input_positions_array.reshape(wobj.geometry.positions.data.shape),
+        equal_nan=True,
+    )
 
 
 def test_actor_from_primitive_wireframe():

--- a/fury/material.py
+++ b/fury/material.py
@@ -766,6 +766,12 @@ class StreamlinesMaterial(LineMaterial):
         The thickness of the outline.
     outline_color : tuple, optional
         The color of the outline as an RGBA tuple.
+    roi_enabled : bool, optional
+        Whether ROI culling is active. This is typically driven by the presence
+        of an ROI mask on the actor.
+    roi_dim : tuple, optional
+        3D integer dimensions (nx, ny, nz) of a mask grid when a volumetric
+        ROI is used in the shader.
     **kwargs : dict
         Additional keyword arguments for the material.
     """
@@ -774,9 +780,18 @@ class StreamlinesMaterial(LineMaterial):
         LineMaterial.uniform_type,
         outline_thickness="f4",
         outline_color="4xf4",
+        roi_enabled="i4",
+        roi_dim="4xi4",
     )
 
-    def __init__(self, outline_thickness=0.0, outline_color=(0, 0, 0), **kwargs):
+    def __init__(
+        self,
+        outline_thickness=0.0,
+        outline_color=(0, 0, 0),
+        roi_enabled=None,
+        roi_dim=(0, 0, 0),
+        **kwargs,
+    ):
         """Initialize the Streamline Material.
 
         Parameters
@@ -785,12 +800,20 @@ class StreamlinesMaterial(LineMaterial):
             The thickness of the outline.
         outline_color : tuple, optional
             The color of the outline as an RGBA tuple.
+        roi_enabled : bool, optional
+            Whether ROI culling is active. If None, ROI culling defaults to
+            False until an ROI mask is attached by the actor.
+        roi_dim : tuple, optional
+            3D integer dimensions (nx, ny, nz) of a mask grid when a volumetric
+            ROI is used in the shader.
         **kwargs : dict
             Additional keyword arguments for the material.
         """
         super().__init__(**kwargs)
         self.outline_thickness = outline_thickness
         self.outline_color = outline_color
+        self.roi_dim = roi_dim
+        self.roi_enabled = roi_enabled
 
     @property
     def outline_thickness(self):
@@ -840,6 +863,85 @@ class StreamlinesMaterial(LineMaterial):
 
         self.uniform_buffer.data["outline_color"] = value
         self.uniform_buffer.update_full()
+
+    @property
+    def roi_enabled(self):
+        """Return True when ROI-based culling is active.
+
+        Returns
+        -------
+        bool
+            True if ROI-based culling is enabled, False otherwise.
+        """
+        return bool(self.uniform_buffer.data["roi_enabled"])
+
+    @roi_enabled.setter
+    def roi_enabled(self, value):
+        """Enable/disable ROI-based culling.
+
+        Parameters
+        ----------
+        value : bool
+            True to enable ROI-based culling, False to disable.
+        """
+        self.uniform_buffer.data["roi_enabled"] = int(bool(value))
+        self.uniform_buffer.update_full()
+
+    @property
+    def roi_dim(self):
+        """ROI grid dimensions as (nx, ny, nz).
+
+        Returns
+        -------
+        tuple
+            A tuple of three integers representing the ROI grid dimensions.
+        """
+        return tuple(int(x) for x in self.uniform_buffer.data["roi_dim"][:3])
+
+    @roi_dim.setter
+    def roi_dim(self, value):
+        """Set the ROI grid dimensions.
+
+        Parameters
+        ----------
+        value : tuple
+            A tuple of three integers representing the ROI grid dimensions.
+        """
+        dims = np.asarray(value, dtype=np.int32).reshape(-1)
+        if dims.size != 3:
+            raise ValueError("roi_dim must contain exactly three integers.")
+        self.uniform_buffer.data["roi_dim"] = (
+            int(dims[0]),
+            int(dims[1]),
+            int(dims[2]),
+            0,
+        )
+        self.uniform_buffer.update_full()
+
+
+class _StreamlineBakedMaterial(StreamlinesMaterial):
+    """Initialize the internal baked streamline material.
+
+    Parameters
+    ----------
+    auto_detach : bool, optional
+        If True, automatically switch to render-only material after baking.
+    **kwargs : dict
+        Additional keyword arguments for the material.
+    """
+
+    def __init__(self, *, auto_detach=True, **kwargs):
+        """Initialize the internal baked streamline material.
+
+        Parameters
+        ----------
+        auto_detach : bool, optional
+            If True, automatically switch to render-only material after baking.
+        **kwargs : dict
+            Additional keyword arguments for the material.
+        """
+        super().__init__(**kwargs)
+        self.auto_detach = bool(auto_detach)
 
 
 class BillboardMaterial(MeshBasicMaterial):

--- a/fury/shader.py
+++ b/fury/shader.py
@@ -12,6 +12,7 @@ from fury.lib import (
     ThinLineSegmentShader,
     load_wgsl,
 )
+from fury.material import StreamlinesMaterial, _StreamlineBakedMaterial
 
 
 class VectorFieldComputeShader(BaseShader):
@@ -185,6 +186,43 @@ class VectorFieldShader(LineShader):
 class StreamlinesShader(LineShader):
     """Shader for StreamlineActor."""
 
+    def get_render_info(self, wobject, shared):
+        """Get render information for the streamline shader.
+
+        Parameters
+        ----------
+        wobject : Streamlines
+            The streamline object to be rendered.
+        shared : dict
+            Shared information for the shader.
+
+        Returns
+        -------
+        dict
+            A dictionary containing the render information.
+        """
+        mat = getattr(wobject, "material", None)
+        needs_update = bool(getattr(wobject, "_needs_gpu_update", False))
+        auto_detach = bool(getattr(mat, "auto_detach", True))
+        if (
+            isinstance(mat, _StreamlineBakedMaterial)
+            and auto_detach
+            and not needs_update
+        ):
+            new_mat = StreamlinesMaterial(
+                outline_thickness=float(getattr(mat, "outline_thickness", 0.0)),
+                outline_color=tuple(getattr(mat, "outline_color", (0, 0, 0))),
+                pick_write=bool(getattr(mat, "pick_write", True)),
+                opacity=float(getattr(mat, "opacity", 1.0)),
+                thickness=float(getattr(mat, "thickness", 2.0)),
+                color_mode=str(getattr(mat, "color_mode", "vertex")),
+            )
+            new_mat.roi_enabled = False
+            new_mat.roi_dim = (0, 0, 0)
+            wobject.material = new_mat
+
+        return super().get_render_info(wobject, shared)
+
     def get_code(self):
         """Get the WGSL code for the streamline render shader.
 
@@ -194,6 +232,174 @@ class StreamlinesShader(LineShader):
             The WGSL code as a string.
         """
         return load_wgsl("streamline_render.wgsl", package_name="fury.wgsl")
+
+
+class _StreamlineBakingShader(BaseShader):
+    """Initialize the streamline baking compute shader.
+
+    Parameters
+    ----------
+    wobject : Streamlines
+        The streamline object to be rendered.
+    """
+
+    type = "compute"
+
+    def __init__(self, wobject):
+        """Initialize the streamline baking compute shader.
+
+        Parameters
+        ----------
+        wobject : Streamlines
+            The streamline object to be rendered.
+        """
+        super().__init__(wobject)
+        n_lines = int(getattr(wobject, "n_lines", 0))
+        self["n_lines"] = n_lines
+        self["workgroup_size"] = min(64, max(n_lines, 1))
+        self["out_capacity"] = int(getattr(wobject, "_out_capacity", 0))
+        self["color_channels"] = int(getattr(wobject, "_color_channels", 3))
+        roi_dim = getattr(getattr(wobject, "material", None), "roi_dim", (0, 0, 0))
+        self["roi_dim_x"], self["roi_dim_y"], self["roi_dim_z"] = (
+            int(roi_dim[0]),
+            int(roi_dim[1]),
+            int(roi_dim[2]),
+        )
+        self["roi_origin_x"], self["roi_origin_y"], self["roi_origin_z"] = (
+            wobject.roi_origin
+        )
+        self["roi_enabled"] = (
+            1
+            if getattr(getattr(wobject, "material", None), "roi_enabled", False)
+            else 0
+        )
+
+    def get_render_info(self, wobject, _shared):
+        """Get render information for the streamline baking compute shader.
+
+        Parameters
+        ----------
+        wobject : Streamlines
+            The streamline object to be rendered.
+        _shared : dict
+            Shared information for the shader.
+
+        Returns
+        -------
+        dict
+            A dictionary containing the render information.
+        """
+        needs_update = bool(getattr(wobject, "_needs_gpu_update", False))
+        n_lines = int(getattr(wobject, "n_lines", 0))
+        if not needs_update or n_lines == 0:
+            return {"indices": (0, 1, 1)}
+        workgroup_size = min(64, max(n_lines, 1))
+        groups = int(ceil(n_lines / workgroup_size))
+        wobject._needs_gpu_update = False
+        return {"indices": (groups, 1, 1)}
+
+    def get_pipeline_info(self, _wobject, _shared):
+        """Get pipeline information for the streamline baking compute shader.
+
+        Parameters
+        ----------
+        _wobject : Streamlines
+            The streamline object to be rendered.
+        _shared : dict
+            Shared information for the shader.
+
+        Returns
+        -------
+        dict
+            A dictionary containing the pipeline information.
+        """
+        return {}
+
+    def get_bindings(self, wobject, _shared):
+        """Get the bindings for the streamline baking compute shader.
+
+        Parameters
+        ----------
+        wobject : Streamlines
+            The streamline object to be rendered.
+        _shared : dict
+            Shared information for the shader.
+
+        Returns
+        -------
+        dict
+            A dictionary containing the bindings for the shader.
+        """
+        geometry = wobject.geometry
+
+        n_lines = int(getattr(wobject, "n_lines", 0))
+        self["n_lines"] = n_lines
+        self["workgroup_size"] = min(64, max(n_lines, 1))
+        self["out_capacity"] = int(getattr(wobject, "_out_capacity", 0))
+        self["color_channels"] = int(getattr(wobject, "_color_channels", 3))
+        roi_dim = getattr(getattr(wobject, "material", None), "roi_dim", (0, 0, 0))
+        self["roi_dim_x"], self["roi_dim_y"], self["roi_dim_z"] = (
+            int(roi_dim[0]),
+            int(roi_dim[1]),
+            int(roi_dim[2]),
+        )
+        self["roi_origin_x"], self["roi_origin_y"], self["roi_origin_z"] = (
+            wobject.roi_origin
+        )
+        self["roi_enabled"] = (
+            1
+            if getattr(getattr(wobject, "material", None), "roi_enabled", False)
+            else 0
+        )
+
+        bindings = {
+            0: Binding(
+                "s_line_positions",
+                "buffer/read_only_storage",
+                getattr(wobject, "_line_positions_in", None),
+                "COMPUTE",
+            ),
+            1: Binding(
+                "s_line_colors",
+                "buffer/read_only_storage",
+                getattr(wobject, "_line_colors_in", None),
+                "COMPUTE",
+            ),
+            2: Binding(
+                "s_line_lengths",
+                "buffer/storage",
+                getattr(wobject, "_line_lengths_buffer", None),
+                "COMPUTE",
+            ),
+            3: Binding(
+                "s_line_offsets",
+                "buffer/storage",
+                getattr(wobject, "_line_offsets_buffer", None),
+                "COMPUTE",
+            ),
+            4: Binding(
+                "s_roi_mask",
+                "buffer/read_only_storage",
+                getattr(wobject, "_roi_mask_buffer", None),
+                "COMPUTE",
+            ),
+            5: Binding(
+                "s_out_positions", "buffer/storage", geometry.positions, "COMPUTE"
+            ),
+            6: Binding("s_out_colors", "buffer/storage", geometry.colors, "COMPUTE"),
+        }
+        self.define_bindings(0, bindings)
+        return {0: bindings}
+
+    def get_code(self):
+        """Get the WGSL code for the streamline baking compute shader.
+
+        Returns
+        -------
+        str
+            The WGSL code as a string.
+        """
+        return load_wgsl("streamline_compute.wgsl", package_name="fury.wgsl")
 
 
 class VectorFieldArrowShader(VectorFieldShader):

--- a/fury/tests/test_material.py
+++ b/fury/tests/test_material.py
@@ -24,6 +24,7 @@ from fury.material import (
     VectorFieldArrowMaterial,
     VectorFieldLineMaterial,
     VectorFieldThinLineMaterial,
+    _StreamlineBakedMaterial,
     _StreamtubeBakedMaterial,
     _create_mesh_material,
     _create_vector_field_material,
@@ -585,6 +586,8 @@ def test_StreamlinesMaterial_initialization_defaults():
 
     assert material.outline_thickness == 0.0
     assert np.array_equal(material.outline_color, (0, 0, 0))
+    assert material.roi_enabled is False
+    assert material.roi_dim == (0, 0, 0)
 
 
 def test_StreamlinesMaterial_custom_initialization():
@@ -605,6 +608,8 @@ def test_StreamlinesMaterial_custom_initialization():
     assert np.allclose(material.outline_color, outline_color)
     assert material.thickness == 3.0
     assert round(material.opacity, 2) == 0.7
+    assert material.roi_enabled is False
+    assert material.roi_dim == (0, 0, 0)
 
 
 def test_StreamlinesMaterial_inheritance():
@@ -644,6 +649,7 @@ def test_StreamlinesMaterial_with_kwargs():
     # Test inherited properties
     assert material.thickness == 2.0
     assert round(material.opacity, 1) == 0.8
+    assert material.roi_enabled is False
 
 
 def test_StreamlinesMaterial_outline_thickness_property():
@@ -700,12 +706,36 @@ def test_StreamlinesMaterial_outline_color_property():
     assert np.allclose(material.outline_color, np_color)
 
 
+def test_StreamlinesMaterial_roi_mask_properties():
+    """StreamlinesMaterial: ROI mask flags and dimensions can be set."""
+    material = StreamlinesMaterial()
+    assert material.roi_enabled is False
+    assert material.roi_dim == (0, 0, 0)
+
+    material.roi_dim = (16, 24, 32)
+    assert material.roi_dim == (16, 24, 32)
+
+    material.roi_enabled = True
+    assert material.roi_enabled is True
+
+    with pytest.raises(ValueError):
+        material.roi_dim = (1, 2)
+
+
 def test_StreamlinesMaterial_uniform_type():
     """StreamlinesMaterial: Test uniform_type contains expected fields."""
     assert "outline_thickness" in StreamlinesMaterial.uniform_type
     assert "outline_color" in StreamlinesMaterial.uniform_type
     assert StreamlinesMaterial.uniform_type["outline_thickness"] == "f4"
     assert StreamlinesMaterial.uniform_type["outline_color"] == "4xf4"
+    assert "roi_enabled" in StreamlinesMaterial.uniform_type
+    assert StreamlinesMaterial.uniform_type["roi_enabled"] == "i4"
+    assert "roi_dim" in StreamlinesMaterial.uniform_type
+    assert StreamlinesMaterial.uniform_type["roi_dim"] == "4xi4"
+    assert "roi_min" not in StreamlinesMaterial.uniform_type
+    assert "roi_max" not in StreamlinesMaterial.uniform_type
+    assert "roi_spacing" not in StreamlinesMaterial.uniform_type
+    assert "roi_origin" not in StreamlinesMaterial.uniform_type
 
     # Check inheritance from LineMaterial
     assert "thickness" in StreamlinesMaterial.uniform_type
@@ -730,17 +760,17 @@ def test_StreamlinesMaterial_edge_cases():
     expected_rgb = (1.5, -0.5, 2.0)
     assert np.allclose(material.outline_color, expected_rgb)
 
-    # Test empty tuple/list (should fail gracefully)
-    try:
-        material.outline_color = ()
-    except (ValueError, IndexError, TypeError):
-        pass  # Expected to fail
 
-    # Test single value (should fail gracefully)
-    try:
-        material.outline_color = 0.5
-    except (ValueError, IndexError, TypeError):
-        pass  # Expected to fail
+def test_StreamlineBakedMaterial_defaults_and_properties():
+    """_StreamlineBakedMaterial defaults and property wiring."""
+    mat = _StreamlineBakedMaterial()
+    assert isinstance(mat, StreamlinesMaterial)
+    assert mat.auto_detach is True
+    assert mat.roi_enabled is False
+    assert mat.roi_dim == (0, 0, 0)
+
+    mat.auto_detach = False
+    assert mat.auto_detach is False
 
 
 def test_StreamtubeBakedMaterial_defaults():

--- a/fury/tests/test_shader.py
+++ b/fury/tests/test_shader.py
@@ -1,6 +1,7 @@
 import math
 
 import numpy as np
+import pytest
 
 from fury.actor import SphGlyph, VectorField
 from fury.actor.curved import (
@@ -21,6 +22,7 @@ from fury.shader import (
     VectorFieldComputeShader,
     VectorFieldShader,
     VectorFieldThinShader,
+    _StreamlineBakingShader,
     _StreamtubeBakingShader,
 )
 
@@ -322,6 +324,35 @@ def test_streamline_shader_get_code():
     code = shader.get_code()
     assert isinstance(code, str)
     assert load_wgsl("streamline_render.wgsl", package_name="fury.wgsl") == code
+
+
+def test_streamline_baking_shader_updates_and_origin():
+    """_StreamlineBakingShader dispatch respects needs_gpu_update and roi_origin."""
+    lines = [
+        np.array([[0, 0, 0], [1, 0, 0]], dtype=np.float32),
+        np.array([[0, 1, 0], [1, 1, 0]], dtype=np.float32),
+    ]
+    lines_positions, lines_colors = line_buffer_separator(lines, color=(1, 0, 0))
+    wobject = Streamlines(
+        lines_positions,
+        colors=lines_colors,
+        roi_mask=np.ones((3, 3, 3), dtype=np.uint8),
+        roi_origin=(1.0, 2.0, 3.0),
+    )
+    shader = _StreamlineBakingShader(wobject)
+
+    first = shader.get_render_info(wobject, {})["indices"]
+    assert first[0] > 0
+    assert shader["roi_origin_x"] == pytest.approx(1.0)
+    assert shader["roi_origin_y"] == pytest.approx(2.0)
+    assert shader["roi_origin_z"] == pytest.approx(3.0)
+
+    second = shader.get_render_info(wobject, {})["indices"]
+    assert second == (0, 1, 1)
+
+    wobject._needs_gpu_update = True
+    third = shader.get_render_info(wobject, {})["indices"]
+    assert third[0] > 0
 
 
 def test_LineProjectionComputeShader_initialization():

--- a/fury/wgsl/streamline_compute.wgsl
+++ b/fury/wgsl/streamline_compute.wgsl
@@ -1,0 +1,152 @@
+{{ bindings_code }}
+
+const N_LINES = u32({{ n_lines }});
+const OUT_CAPACITY = u32({{ out_capacity }});
+const COLOR_CHANNELS = u32({{ color_channels }});
+const ROI_ENABLED = {{ roi_enabled }}u;
+const ROI_DIM = vec3<i32>({{ roi_dim_x }}, {{ roi_dim_y }}, {{ roi_dim_z }});
+const ROI_ORIGIN = vec3<f32>({{ roi_origin_x }}, {{ roi_origin_y }}, {{ roi_origin_z }});
+
+fn roi_enabled() -> bool {
+    return ROI_ENABLED == 1u;
+}
+
+fn world_to_grid(p: vec3<f32>) -> vec3<i32> {
+    return vec3<i32>(floor(p - ROI_ORIGIN + 0.5));
+}
+
+fn mask_idx_from_grid(g: vec3<i32>) -> i32 {
+    if (any(g < vec3<i32>(0)) || any(g >= ROI_DIM)) {
+        return -1;
+    }
+    return (g.z * ROI_DIM.y + g.y) * ROI_DIM.x + g.x;
+}
+
+fn mask_value(g: vec3<i32>) -> bool {
+    let idx = mask_idx_from_grid(g);
+    if (idx < 0) {
+        return false;
+    }
+    return s_roi_mask[u32(idx)] > 0u;
+}
+
+fn point_in_roi(p: vec3<f32>) -> bool {
+    if (any(ROI_DIM <= vec3<i32>(0))) {
+        return false;
+    }
+    return mask_value(world_to_grid(p));
+}
+
+fn load_position(flat_index: u32) -> vec3<f32> {
+    let base = flat_index * 3u;
+    if (base + 2u >= arrayLength(&s_line_positions)) {
+        return vec3<f32>(0.0);
+    }
+    return vec3<f32>(
+        s_line_positions[base],
+        s_line_positions[base + 1u],
+        s_line_positions[base + 2u],
+    );
+}
+
+fn load_color(flat_index: u32) -> vec4<f32> {
+    if (COLOR_CHANNELS == 0u) {
+        return vec4<f32>(1.0);
+    }
+    let base = flat_index * COLOR_CHANNELS;
+    if (base >= arrayLength(&s_line_colors)) {
+        return vec4<f32>(1.0);
+    }
+    var color = vec4<f32>(1.0);
+    color.x = s_line_colors[base];
+    if (COLOR_CHANNELS > 1u && base + 1u < arrayLength(&s_line_colors)) {
+        color.y = s_line_colors[base + 1u];
+    }
+    if (COLOR_CHANNELS > 2u && base + 2u < arrayLength(&s_line_colors)) {
+        color.z = s_line_colors[base + 2u];
+    }
+    if (COLOR_CHANNELS > 3u && base + 3u < arrayLength(&s_line_colors)) {
+        color.w = s_line_colors[base + 3u];
+    }
+    return color;
+}
+
+fn write_position(out_index: u32, value: vec3<f32>, capacity: u32) {
+    let base = out_index * 3u;
+    if (base + 2u >= capacity) {
+        return;
+    }
+    s_out_positions[base] = value.x;
+    s_out_positions[base + 1u] = value.y;
+    s_out_positions[base + 2u] = value.z;
+}
+
+fn write_color(out_index: u32, value: vec4<f32>, capacity: u32) {
+    if (COLOR_CHANNELS == 0u) {
+        return;
+    }
+    let base = out_index * COLOR_CHANNELS;
+    if (base >= capacity) {
+        return;
+    }
+    s_out_colors[base] = value.x;
+    if (COLOR_CHANNELS > 1u && base + 1u < capacity) {
+        s_out_colors[base + 1u] = value.y;
+    }
+    if (COLOR_CHANNELS > 2u && base + 2u < capacity) {
+        s_out_colors[base + 2u] = value.z;
+    }
+    if (COLOR_CHANNELS > 3u && base + 3u < capacity) {
+        s_out_colors[base + 3u] = value.w;
+    }
+}
+
+fn line_hits_roi(line_offset: u32, line_length: u32) -> bool {
+    if (!roi_enabled()) {
+        return true;
+    }
+    for (var i: u32 = 0u; i < line_length; i += 1u) {
+        let pos = load_position(line_offset + i);
+        if (point_in_roi(pos)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+@compute @workgroup_size({{ workgroup_size }})
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let line_idx = gid.x;
+    if (line_idx >= N_LINES) {
+        return;
+    }
+
+    let line_length = s_line_lengths[line_idx];
+    if (line_length == 0u) {
+        return;
+    }
+    let line_offset = s_line_offsets[line_idx];
+
+    let pos_capacity = arrayLength(&s_out_positions);
+    let color_capacity = arrayLength(&s_out_colors);
+    let nanf = bitcast<f32>(0x7fc00000u);
+    let nan3 = vec3<f32>(nanf);
+    let nan4 = vec4<f32>(nanf);
+    let keep_line = line_hits_roi(line_offset, line_length);
+
+    for (var i: u32 = 0u; i < line_length; i += 1u) {
+        let out_idx = line_offset + i;
+        if (out_idx >= OUT_CAPACITY) {
+            break;
+        }
+        let pos = load_position(out_idx);
+        let col = load_color(out_idx);
+        if (keep_line) {
+            write_position(out_idx, pos, pos_capacity);
+            write_color(out_idx, col, color_capacity);
+        } else {
+            write_position(out_idx, nan3, pos_capacity);
+            write_color(out_idx, nan4, color_capacity);
+        }
+    }
+}


### PR DESCRIPTION
### NF: Streamline based ROI filtering

**PR Contents**
- Added the baking strategy to pre-compute filtering.
- Later render will be normal as the regular streamline render.
- Added `StreamlineBakingMaterial` to distinguish between baking and
  regular rendering pass.
- Added the tutorial in valid_examples.
- Showcase roi_origin and mask based coverage.
- Added test cases for actor, material, shader

**Screenshots**
<img width="549" height="490" alt="image" src="https://github.com/user-attachments/assets/a0e7964c-f02f-4c01-838d-b09dbb407aaa" />

<img width="549" height="609" alt="image" src="https://github.com/user-attachments/assets/01f74659-8858-45bd-8deb-25772198eb5b" />

