### PR TITLE
BF: peaks slicer not showing correct center

### DIFF
--- a/fury/actor/bio.py
+++ b/fury/actor/bio.py
@@ -134,11 +134,13 @@ def peaks_slicer(
 
     if affine is not None:
         apply_affine_to_actor(obj, affine)
-        bounds = get_transformed_cube_bounds(
-            affine, np.zeros((3,)), np.asarray(obj.field_shape)
+        bounds = obj.get_bounding_box()
+        obj.bounds = get_transformed_cube_bounds(
+            affine,
+            bounds[0],
+            bounds[1],
         )
-        obj.get_bounding_box = lambda: bounds
-        obj.cross_section = np.asarray(bounds).mean(axis=0)
+        obj.cross_section = np.asarray(obj.bounds).mean(axis=0)
 
     return obj
 

--- a/fury/actor/slicer.py
+++ b/fury/actor/slicer.py
@@ -304,7 +304,7 @@ class VectorField(WorldObject, Actor):
         if len(value) != 3:
             raise ValueError(f"Cross section must have length 3, but got {len(value)}")
         value = np.asarray(value, dtype=np.float32)
-        bounds = self.get_bounding_box()
+        bounds = self.bounds if hasattr(self, "bounds") else self.get_bounding_box()
         value = np.maximum(bounds[0], value)
         value = np.minimum(bounds[1], value)
         self.material.cross_section = value.astype(np.int32)

--- a/fury/actor/tests/test_bio.py
+++ b/fury/actor/tests/test_bio.py
@@ -71,6 +71,8 @@ def test_peaks_slicer_basic_functionality():
 
     assert result is not None
     assert hasattr(result, "get_bounding_box")
+    assert np.all(result.get_bounding_box() == np.array([[0, 0, 0], [4, 4, 4]]))
+    assert np.all(result.cross_section == np.array([2, 2, 2]))
     assert result.material.opacity == 1.0  # Default value
 
 
@@ -84,6 +86,11 @@ def test_peaks_slicer_with_affine_transform():
     assert result is not None
     # Verify bounding box was transformed
     assert hasattr(result, "get_bounding_box")
+    assert hasattr(result, "bounds")
+    assert np.allclose(result.get_bounding_box()[0], (0, 0, 0))
+    assert np.allclose(result.bounds[0], np.array([10, 20, 30]))
+    assert np.allclose(result.bounds[1], np.array([12, 22, 32]))
+    assert np.allclose(result.cross_section, np.array([11, 21, 31]))
 
 
 def test_peaks_slicer_invalid_peak_dirs_shape():


### PR DESCRIPTION
**PR Context**

The peaks slicer was showing little off from the center when passed an affine.
We were overriding the get_bounding_box api which was internally used by pygfx to do so.

Which created issues in centering the element while rendering. This PR introduces a new variable to store the bounds and works as expected.

Added some test cases as well for the same.