### PR TITLE
RF: Introduced correct opacity attribute

### DIFF
--- a/fury/actor/__init__.pyi
+++ b/fury/actor/__init__.pyi
@@ -54,6 +54,7 @@ __all__ = [
     "Volume",
     "Actor",
     "set_group_opacity",
+    "set_opacity",
     "set_group_visibility",
     "apply_affine_to_group",
     "apply_affine_to_actor",
@@ -124,5 +125,6 @@ from .utils import (
     get_slices,
     set_group_opacity,
     set_group_visibility,
+    set_opacity,
     show_slices,
 )

--- a/fury/actor/core.py
+++ b/fury/actor/core.py
@@ -5,6 +5,7 @@ from PIL import Image as PILImage
 import numpy as np
 from scipy.spatial.transform import Rotation as Rot
 
+from fury.actor import set_opacity
 from fury.geometry import (
     buffer_to_geometry,
     line_buffer_separator,
@@ -98,6 +99,22 @@ class Actor:
             raise ValueError("Transformation matrix must be of shape (4, 4).")
         self.local.matrix = matrix
 
+    @property
+    def opacity(self):
+        """Get the opacity of the actor.
+
+        Returns
+        -------
+        float
+            Opacity value between 0 (fully transparent) and 1 (fully opaque).
+        """
+        if isinstance(self, Group):
+            if len(self.children) == 0:
+                return 1.0
+            return self.children[0].material.opacity
+        return self.material.opacity
+
+    @opacity.setter
     def opacity(self, opacity):
         """Set the opacity of the actor.
 
@@ -106,11 +123,7 @@ class Actor:
         opacity : float
             Opacity value between 0 (fully transparent) and 1 (fully opaque).
         """
-        if isinstance(opacity, (int, float)) is False:
-            raise ValueError("Opacity must be a float value between 0 and 1.")
-        if not (0.0 <= opacity <= 1.0):
-            raise ValueError("Opacity must be between 0 and 1.")
-        self.material.opacity = opacity
+        set_opacity(self, opacity)
 
     @staticmethod
     def _euler_to_quaternion(rotation):

--- a/fury/actor/tests/test_core.py
+++ b/fury/actor/tests/test_core.py
@@ -90,8 +90,7 @@ def test_actor_transform_invalid_matrix_shape(sphere_actor, invalid_matrix):
     [0, 0.5, 1],
 )
 def test_actor_opacity_sets_material(sphere_actor, opacity):
-    sphere_actor.opacity(opacity)
-
+    sphere_actor.opacity = opacity
     assert sphere_actor.material.opacity == opacity
 
 
@@ -104,7 +103,7 @@ def test_actor_opacity_sets_material(sphere_actor, opacity):
 )
 def test_actor_opacity_invalid_values_raise(sphere_actor, invalid_opacity):
     with pytest.raises(ValueError, match="Opacity must be"):
-        sphere_actor.opacity(invalid_opacity)
+        sphere_actor.opacity = invalid_opacity
 
 
 def test_create_mesh():

--- a/fury/actor/tests/test_utils.py
+++ b/fury/actor/tests/test_utils.py
@@ -11,14 +11,21 @@ from fury.actor import (
     line_projection,
     set_group_opacity,
     set_group_visibility,
+    set_opacity,
     show_slices,
 )
-from fury.lib import AffineTransform, RecursiveTransform, WorldObject
+from fury.lib import (
+    AffineTransform,
+    Geometry,
+    Material,
+    RecursiveTransform,
+    WorldObject,
+)
 
 
 @pytest.fixture
 def actor():
-    return Mesh()
+    return Mesh(Geometry(), Material())
 
 
 @pytest.fixture
@@ -92,15 +99,48 @@ def test_set_group_visibility_tuple(group_slicer):
         assert actor.visible == vis
 
 
-def test_set_opacity_type_error():
+def test_set_group_visibility_gfx_group(group_slicer):
+    visibility = (True, False)
+    with pytest.raises(ValueError):
+        set_group_visibility(group_slicer, visibility)
+
+
+def test_set_group_opacity_type_error():
     with pytest.raises(TypeError):
         set_group_opacity("not a group", 0.5)
 
 
-def test_set_opacity_valid(group_slicer):
+def test_set_group_opacity_valid(group_slicer):
     set_group_opacity(group_slicer, 0.7)
     for child in group_slicer.children:
         assert round(child.material.opacity, 2) == 0.7
+
+
+def test_set_group_opacity_with_gfx_group(group_slicer):
+    set_group_opacity(group_slicer, 0.42)
+    for child in group_slicer.children:
+        assert round(child.material.opacity, 2) == 0.42
+
+
+def test_set_opacity_type_error_for_invalid_actor():
+    with pytest.raises(TypeError, match="actor must be an instance of WorldObject"):
+        set_opacity("not an actor", 0.5)
+
+
+def test_set_opacity_on_actor(actor):
+    set_opacity(actor, 0.4)
+    assert round(actor.opacity, 2) == 0.4
+
+
+def test_set_opacity_on_gfx_group(group_slicer):
+    set_opacity(group_slicer, 0.35)
+    for child in group_slicer.children:
+        assert round(child.material.opacity, 2) == 0.35
+
+
+def test_set_opacity_invalid_value(actor):
+    with pytest.raises(ValueError):
+        set_opacity(actor, 1.5)
 
 
 def test_get_slices_type_error():

--- a/fury/actor/utils.py
+++ b/fury/actor/utils.py
@@ -2,8 +2,7 @@
 
 import numpy as np
 
-from fury.actor import Group
-from fury.lib import AffineTransform, RecursiveTransform, WorldObject
+from fury.lib import AffineTransform, GfxGroup, RecursiveTransform, WorldObject
 from fury.material import validate_opacity
 
 
@@ -19,7 +18,7 @@ def set_group_visibility(group, visibility):
         actors in the group. If a tuple or list is provided, it sets the
         visibility for each actor in the group individually.
     """
-    if not isinstance(group, Group):
+    if not isinstance(group, GfxGroup):
         raise TypeError("group must be an instance of Group.")
 
     if not isinstance(visibility, (tuple, list)):
@@ -41,13 +40,35 @@ def set_group_opacity(group, opacity):
         The opacity value to set for the group of actors,
         ranging from 0 (fully transparent) to 1 (opaque).
     """
-    if not isinstance(group, Group):
+    if not isinstance(group, GfxGroup):
         raise TypeError("group must be an instance of Group.")
 
     opacity = validate_opacity(opacity)
 
     for child in group.children:
         child.material.opacity = opacity
+
+
+def set_opacity(actor, opacity):
+    """Set the opacity of an actor.
+
+    Parameters
+    ----------
+    actor : WorldObject
+        The actor to set opacity for.
+    opacity : float
+        The opacity value to set for the actor,
+        ranging from 0 (fully transparent) to 1 (opaque).
+    """
+    if not isinstance(actor, WorldObject):
+        raise TypeError("actor must be an instance of WorldObject.")
+
+    if isinstance(actor, GfxGroup):
+        set_group_opacity(actor, opacity)
+        return
+
+    opacity = validate_opacity(opacity)
+    actor.material.opacity = opacity
 
 
 def validate_slices_group(group):
@@ -67,7 +88,7 @@ def validate_slices_group(group):
     AttributeError
         If the children do not have the required material plane attribute.
     """
-    if not isinstance(group, Group):
+    if not isinstance(group, GfxGroup):
         raise TypeError("group must be an instance of Group.")
 
     if len(group.children) != 3:
@@ -132,7 +153,7 @@ def apply_affine_to_group(group, affine):
     affine : ndarray, shape (4, 4)
         The transformation to apply to the actors in the group.
     """
-    if not isinstance(group, Group):
+    if not isinstance(group, GfxGroup):
         raise TypeError("group must be an instance of Group.")
 
     if not isinstance(affine, np.ndarray) or affine.shape != (4, 4):

--- a/fury/actor/utils.py
+++ b/fury/actor/utils.py
@@ -25,6 +25,11 @@ def set_group_visibility(group, visibility):
         group.visible = visibility
         return
 
+    if len(visibility) != len(group.children):
+        raise ValueError(
+            "Length of visibility must match the number of actors in the group."
+        )
+
     for idx, actor in enumerate(group.children):
         actor.visible = visibility[idx]
 

--- a/fury/lib.py
+++ b/fury/lib.py
@@ -67,7 +67,7 @@ if have_py_qt6:
 if have_py_qt5:
     from PyQt5 import QtWidgets
 
-
+GfxGroup = gfx.Group
 Texture = gfx.Texture
 TextureMap = gfx.TextureMap
 VolumeSliceMaterial = gfx.VolumeSliceMaterial


### PR DESCRIPTION
- Updated the `opacity` from a function to an attribute.
- Use the function from utils to make single source for updating the actor.
- Updated the `GfxGroup` in the `lib` to avoid circular dependencies.
- Visibility for a `Group` will also check the length of children in the group and visibility tuple provided.