### PR TITLE
BF: Slicer flickering in the nearest interpolation.

### DIFF
--- a/fury/actor/tests/test_slicer.py
+++ b/fury/actor/tests/test_slicer.py
@@ -36,8 +36,10 @@ def test_valid_4d_data(channels):
     assert len(slicer_obj.children) == 3
     assert all(child.visible for child in slicer_obj.children)
 
-    expected_slices = np.array([shape[0] // 2, shape[1] // 2, shape[2] // 2])
-    np.testing.assert_array_equal(get_slices(slicer_obj), expected_slices)
+    expected_slices = np.array([shape[0] // 2, shape[1] // 2, shape[2] // 2]) + 1e-3
+    np.testing.assert_array_equal(
+        get_slices(slicer_obj), expected_slices.astype(np.float32)
+    )
 
     swapped_shape = (shape[2], shape[1], shape[0], channels)
     expected_range = (float(data.min()), float(data.max()))
@@ -78,11 +80,13 @@ def test_custom_initial_slices():
     slicer_obj = actor.data_slicer(data, initial_slices=(5, 10, 15))
 
     # Verify slice positions match input
-    assert np.array_equal(get_slices(slicer_obj), [5, 10, 15])
+    slices = np.asarray([5, 10, 15]) + 1e-3
+    assert np.array_equal(get_slices(slicer_obj), slices.astype(np.float32))
 
     # Verify positions update correctly
     show_slices(slicer_obj, (2, 4, 6))
-    assert np.array_equal(get_slices(slicer_obj), [2, 4, 6])
+    slices = np.asarray([2, 4, 6]) + 1e-3
+    assert np.array_equal(get_slices(slicer_obj), slices.astype(np.float32))
 
 
 def test_visibility_control():

--- a/fury/actor/tests/test_utils.py
+++ b/fury/actor/tests/test_utils.py
@@ -181,23 +181,27 @@ def test_show_slices_valid(group_slicer, group_line_projection):
     position = (10, 20, 30)
     show_slices(group_slicer, position)
     for i, child in enumerate(group_slicer.children):
-        expected_plane = (1, 2, 3, position[i])
-        np.testing.assert_equal(child.material.plane, expected_plane)
+        expected_plane = (1, 2, 3, position[i] + 1e-3)
+        np.testing.assert_equal(
+            child.material.plane, np.asarray(expected_plane, dtype=np.float32)
+        )
 
     for child in group_line_projection.children:
         child.plane = (1, 2, 3, 0)
     position = (10, 20, 30)
     show_slices(group_line_projection, position)
     for i, child in enumerate(group_line_projection.children):
-        expected_plane = (1, 2, 3, position[i])
-        np.testing.assert_equal(child.plane, expected_plane)
+        expected_plane = (1, 2, 3, position[i] + 1e-3)
+        np.testing.assert_equal(
+            child.plane, np.asarray(expected_plane, dtype=np.float32)
+        )
 
 
 def test_show_slices_with_list(group_slicer):
     position = [5, 6, 7]
     show_slices(group_slicer, position)
     for i, child in enumerate(group_slicer.children):
-        assert child.material.plane[-1] == position[i]
+        assert child.material.plane[-1] == position[i] + 1e-3
 
 
 def test_apply_affine_to_actor_valid_input():

--- a/fury/actor/utils.py
+++ b/fury/actor/utils.py
@@ -130,11 +130,13 @@ def get_slices(group):
 def show_slices(group, position):
     """Show the slices at the specified position.
 
+    Added with a small offset to avoid boundary issues.
+
     Parameters
     ----------
     group : Group
         The group of actors to get the slices from.
-    position : tuple
+    position : tuple or list or ndarray
         A tuple containing the positions of the slices in the 3D space.
     """
     validate_slices_group(group)
@@ -142,10 +144,10 @@ def show_slices(group, position):
     for i, child in enumerate(group.children):
         if hasattr(child, "plane"):
             a, b, c, _ = child.plane
-            child.plane = (a, b, c, position[i])
+            child.plane = (a, b, c, position[i] + 1e-3)
         else:
             a, b, c, _ = child.material.plane
-            child.material.plane = (a, b, c, position[i])
+            child.material.plane = (a, b, c, position[i] + 1e-3)
 
 
 def apply_affine_to_group(group, affine):


### PR DESCRIPTION
**Context**
The slicer used to `flicker` on the `middle-slice` in `nearest` interpolation, after applying the affine on some devices.

**Understanding the issue**
The middle value of the visualization falls on specific value which is exactly on a boundary of two voxels. Thus, it is required to choose from the nearing voxel in the `nearest` interpolation. Which creates conflicts on some devices and alternates between the neighbors based on the rounding of the value.

|--------| < middle value > |--------|

**Why only after applying the affine?**
Now the million dollar question is why not on the regular data and only after applying the affine?

The answer to that lies in how the pygfx calculates the bounding box and center. The bounding box ranges from origin - 0.5 to size - 0.5. Which is in regular cases lands in the decimal range which we never reach in the case of native coordinates.

**Solution**
The solution is pretty simple just push the center to decide on of the other by simply adding a small value to plane equation in slow slices function. This will push just a little so we do not end up in boundary and will not show incorrect data as we will never change the voxel. As boundary conditions are usually due to the index being exact integer.

**Note**
I am sorry for the whole file change as this was configured to be CRLF that I changed to LF. We soon need to implement this change in pre-commit.
mypy does it but just checks if it is valid does not enforce LF or CRLF.