### PR TITLE
Fix progress bar to update in-place on Windows terminals

### DIFF
--- a/fury/data/fetcher.py
+++ b/fury/data/fetcher.py
@@ -54,12 +54,16 @@ class FetcherError(Exception):
     pass
 
 
+_last_line_length = 0
+
+
 def update_progressbar(progress, total_length):
     """Show progressbar.
 
     Takes a number between 0 and 1 to indicate progress from 0 to 100%.
     """
-    # Try to set the bar_length according to the console size
+    global _last_line_length
+
     try:
         if os.name == "nt":
             bar_length = 20
@@ -69,15 +73,29 @@ def update_progressbar(progress, total_length):
         if bar_length < 1:
             bar_length = 20
     except Exception:
-        # Default value if determination of console size fails
         bar_length = 20
+
     block = int(round(bar_length * progress))
     size_string = "{0:.2f} MB".format(float(total_length) / (1024 * 1024))
-    text = "\rDownload Progress: [{0}] {1:.2f}%  of {2}\n".format(
-        "#" * block + "-" * (bar_length - block), progress * 100, size_string
+
+    line = (
+        f"Download Progress: "
+        f"[{'#' * block}{'-' * (bar_length - block)}] "
+        f"{progress * 100:.2f}%  of {size_string}"
     )
-    sys.stdout.write(text)
+
+    # Clear previous line and rewrite
+    sys.stdout.write("\r" + " " * _last_line_length)
+    sys.stdout.write("\r" + line)
     sys.stdout.flush()
+
+    _last_line_length = len(line)
+
+    if progress >= 1.0:
+        sys.stdout.write("\n")
+        _last_line_length = 0
+
+
 
 
 @warn_on_args_to_kwargs()


### PR DESCRIPTION
On Windows terminals , fetch_viz_models() prints the download progress on a new line for each update instead of updating the same line in-place. This results in cluttered and unreadable output during model downloads.

This PR fixes the progress bar behavior by explicitly clearing the previously printed line before writing the updated progress. A newline is printed only once after the download completes, ensuring consistent and clean progress rendering.

#Changes

Clear the previously printed progress line before updating it

Ensure the progress bar updates in-place instead of printing new lines

Print a newline only once after completion

Works consistently across Windows, Linux, and macOS terminals

#Notes

Fix is based on the v2 branch as per the current development direction

No changes to the download logic or public API