### PR TITLE
Stremtubes GPU bug fix for issue #1067

### DIFF
--- a/docs/examples/viz_streamtube.py
+++ b/docs/examples/viz_streamtube.py
@@ -1,0 +1,169 @@
+"""
+Streamtube Colors
+=================
+
+Demonstrates streamtube color modes: single color, per-line colors,
+and direction-based RGB coloring computed on the GPU.
+"""
+
+import numpy as np
+
+import fury
+
+scene = fury.window.Scene()
+scene.background = (0.1, 0.1, 0.1)
+
+
+def make_helix(center, axis, n_points=100, radius=2.0, pitch=0.5, turns=3):
+    t = np.linspace(0, turns * 2 * np.pi, n_points)
+    if axis == "x":
+        pts = np.column_stack([
+            center[0] + pitch * t,
+            center[1] + radius * np.cos(t),
+            center[2] + radius * np.sin(t),
+        ])
+    elif axis == "y":
+        pts = np.column_stack([
+            center[0] + radius * np.cos(t),
+            center[1] + pitch * t,
+            center[2] + radius * np.sin(t),
+        ])
+    else:
+        pts = np.column_stack([
+            center[0] + radius * np.cos(t),
+            center[1] + radius * np.sin(t),
+            center[2] + pitch * t,
+        ])
+    return pts.astype(np.float32)
+
+
+def make_wave(start, end, n_points=80, amplitude=1.5, freq=3):
+    t = np.linspace(0, 1, n_points)
+    direction = np.array(end) - np.array(start)
+    length = np.linalg.norm(direction)
+    d = direction / length
+    perp = np.cross(d, [0, 1, 0])
+    if np.linalg.norm(perp) < 1e-6:
+        perp = np.cross(d, [1, 0, 0])
+    perp = perp / np.linalg.norm(perp)
+    pts = (
+        np.array(start)[None, :]
+        + np.outer(t, direction)
+        + amplitude * np.sin(freq * 2 * np.pi * t)[:, None] * perp[None, :]
+    )
+    return pts.astype(np.float32)
+
+
+lines_single = [
+    make_helix([-15, 0, 0], "x"),
+    make_helix([-15, 0, 4], "x", radius=1.5, pitch=0.6),
+    make_helix([-15, 0, -4], "x", radius=1.0, pitch=0.4),
+    make_wave([-15, 4, 2], [-5, 4, 2]),
+    make_wave([-15, -4, -2], [-5, -4, -2], amplitude=2.0),
+]
+
+tube_single = fury.actor.streamtube(
+    lines_single,
+    colors=(0.2, 0.7, 1.0),
+    radius=0.15,
+    segments=8,
+)
+scene.add(tube_single)
+
+lines_perline = [
+    make_helix([0, 0, 0], "y"),
+    make_helix([4, 0, 0], "y", radius=1.5, pitch=0.6),
+    make_helix([-4, 0, 0], "y", radius=1.0, pitch=0.4),
+    make_wave([2, -2, 3], [2, 12, 3]),
+    make_wave([-2, -2, -3], [-2, 12, -3], amplitude=2.0),
+]
+
+per_line_colors = np.array([
+    [1.0, 0.2, 0.2],
+    [0.2, 1.0, 0.2],
+    [0.2, 0.2, 1.0],
+    [1.0, 1.0, 0.2],
+    [1.0, 0.2, 1.0],
+], dtype=np.float32)
+
+tube_perline = fury.actor.streamtube(
+    lines_perline,
+    colors=per_line_colors,
+    radius=0.15,
+    segments=8,
+)
+scene.add(tube_perline)
+
+lines_rgb = [
+    make_helix([15, 0, 0], "z"),
+    make_helix([19, 0, 0], "z", radius=1.5, pitch=0.6),
+    make_helix([11, 0, 0], "z", radius=1.0, pitch=0.4),
+    make_wave([13, 2, -2], [13, 2, 12]),
+    make_wave([17, -2, -2], [17, -2, 12], amplitude=2.0),
+]
+
+tube_rgb = fury.actor.streamtube(
+    lines_rgb,
+    colors="rgb",
+    radius=0.15,
+    segments=8,
+)
+scene.add(tube_rgb)
+
+n = 50
+length = 10.0
+origin = np.array([0, -15, 0], dtype=np.float32)
+
+x_line = np.column_stack([
+    np.linspace(0, length, n),
+    np.zeros(n),
+    np.zeros(n),
+]).astype(np.float32) + origin
+
+y_line = np.column_stack([
+    np.zeros(n),
+    np.linspace(0, length, n),
+    np.zeros(n),
+]).astype(np.float32) + origin
+
+z_line = np.column_stack([
+    np.zeros(n),
+    np.zeros(n),
+    np.linspace(0, length, n),
+]).astype(np.float32) + origin
+
+diag_xy = np.column_stack([
+    np.linspace(0, length, n),
+    np.linspace(0, length, n),
+    np.zeros(n),
+]).astype(np.float32) + origin
+
+diag_xz = np.column_stack([
+    np.linspace(0, length, n),
+    np.zeros(n),
+    np.linspace(0, length, n),
+]).astype(np.float32) + origin
+
+diag_yz = np.column_stack([
+    np.zeros(n),
+    np.linspace(0, length, n),
+    np.linspace(0, length, n),
+]).astype(np.float32) + origin
+
+diag_xyz = np.column_stack([
+    np.linspace(0, length, n),
+    np.linspace(0, length, n),
+    np.linspace(0, length, n),
+]).astype(np.float32) + origin
+
+axes_rgb = fury.actor.streamtube(
+    [x_line, y_line, z_line, diag_xy, diag_xz, diag_yz, diag_xyz],
+    colors="rgb",
+    radius=0.2,
+    segments=8,
+)
+scene.add(axes_rgb)
+print(tube_perline.geometry.colors.data)
+
+showm = fury.window.ShowManager(scene=scene, size=(1400, 700))
+showm.start()

--- a/docs/examples/viz_streamtube.py
+++ b/docs/examples/viz_streamtube.py
@@ -17,23 +17,29 @@ scene.background = (0.1, 0.1, 0.1)
 def make_helix(center, axis, n_points=100, radius=2.0, pitch=0.5, turns=3):
     t = np.linspace(0, turns * 2 * np.pi, n_points)
     if axis == "x":
-        pts = np.column_stack([
-            center[0] + pitch * t,
-            center[1] + radius * np.cos(t),
-            center[2] + radius * np.sin(t),
-        ])
+        pts = np.column_stack(
+            [
+                center[0] + pitch * t,
+                center[1] + radius * np.cos(t),
+                center[2] + radius * np.sin(t),
+            ]
+        )
     elif axis == "y":
-        pts = np.column_stack([
-            center[0] + radius * np.cos(t),
-            center[1] + pitch * t,
-            center[2] + radius * np.sin(t),
-        ])
+        pts = np.column_stack(
+            [
+                center[0] + radius * np.cos(t),
+                center[1] + pitch * t,
+                center[2] + radius * np.sin(t),
+            ]
+        )
     else:
-        pts = np.column_stack([
-            center[0] + radius * np.cos(t),
-            center[1] + radius * np.sin(t),
-            center[2] + pitch * t,
-        ])
+        pts = np.column_stack(
+            [
+                center[0] + radius * np.cos(t),
+                center[1] + radius * np.sin(t),
+                center[2] + pitch * t,
+            ]
+        )
     return pts.astype(np.float32)
 
 
@@ -78,13 +84,16 @@ lines_perline = [
     make_wave([-2, -2, -3], [-2, 12, -3], amplitude=2.0),
 ]
 
-per_line_colors = np.array([
-    [1.0, 0.2, 0.2],
-    [0.2, 1.0, 0.2],
-    [0.2, 0.2, 1.0],
-    [1.0, 1.0, 0.2],
-    [1.0, 0.2, 1.0],
-], dtype=np.float32)
+per_line_colors = np.array(
+    [
+        [1.0, 0.2, 0.2],
+        [0.2, 1.0, 0.2],
+        [0.2, 0.2, 1.0],
+        [1.0, 1.0, 0.2],
+        [1.0, 0.2, 1.0],
+    ],
+    dtype=np.float32,
+)
 
 tube_perline = fury.actor.streamtube(
     lines_perline,
@@ -114,47 +123,82 @@ n = 50
 length = 10.0
 origin = np.array([0, -15, 0], dtype=np.float32)
 
-x_line = np.column_stack([
-    np.linspace(0, length, n),
-    np.zeros(n),
-    np.zeros(n),
-]).astype(np.float32) + origin
+x_line = (
+    np.column_stack(
+        [
+            np.linspace(0, length, n),
+            np.zeros(n),
+            np.zeros(n),
+        ]
+    ).astype(np.float32)
+    + origin
+)
 
-y_line = np.column_stack([
-    np.zeros(n),
-    np.linspace(0, length, n),
-    np.zeros(n),
-]).astype(np.float32) + origin
+y_line = (
+    np.column_stack(
+        [
+            np.zeros(n),
+            np.linspace(0, length, n),
+            np.zeros(n),
+        ]
+    ).astype(np.float32)
+    + origin
+)
 
-z_line = np.column_stack([
-    np.zeros(n),
-    np.zeros(n),
-    np.linspace(0, length, n),
-]).astype(np.float32) + origin
+z_line = (
+    np.column_stack(
+        [
+            np.zeros(n),
+            np.zeros(n),
+            np.linspace(0, length, n),
+        ]
+    ).astype(np.float32)
+    + origin
+)
 
-diag_xy = np.column_stack([
-    np.linspace(0, length, n),
-    np.linspace(0, length, n),
-    np.zeros(n),
-]).astype(np.float32) + origin
+diag_xy = (
+    np.column_stack(
+        [
+            np.linspace(0, length, n),
+            np.linspace(0, length, n),
+            np.zeros(n),
+        ]
+    ).astype(np.float32)
+    + origin
+)
 
-diag_xz = np.column_stack([
-    np.linspace(0, length, n),
-    np.zeros(n),
-    np.linspace(0, length, n),
-]).astype(np.float32) + origin
+diag_xz = (
+    np.column_stack(
+        [
+            np.linspace(0, length, n),
+            np.zeros(n),
+            np.linspace(0, length, n),
+        ]
+    ).astype(np.float32)
+    + origin
+)
 
-diag_yz = np.column_stack([
-    np.zeros(n),
-    np.linspace(0, length, n),
-    np.linspace(0, length, n),
-]).astype(np.float32) + origin
+diag_yz = (
+    np.column_stack(
+        [
+            np.zeros(n),
+            np.linspace(0, length, n),
+            np.linspace(0, length, n),
+        ]
+    ).astype(np.float32)
+    + origin
+)
 
-diag_xyz = np.column_stack([
-    np.linspace(0, length, n),
-    np.linspace(0, length, n),
-    np.linspace(0, length, n),
-]).astype(np.float32) + origin
+diag_xyz = (
+    np.column_stack(
+        [
+            np.linspace(0, length, n),
+            np.linspace(0, length, n),
+            np.linspace(0, length, n),
+        ]
+    ).astype(np.float32)
+    + origin
+)
 
 axes_rgb = fury.actor.streamtube(
     [x_line, y_line, z_line, diag_xy, diag_xz, diag_yz, diag_xyz],

--- a/fury/actor/curved.py
+++ b/fury/actor/curved.py
@@ -1333,22 +1333,20 @@ def _create_streamtube_baked(
 
     use_rgb_mode = isinstance(colors, str) and colors.lower() == "rgb"
 
-    _is_per_point = (
+    use_per_point_colors = (
         isinstance(colors, (list, tuple))
         and len(colors) > 0
         and isinstance(colors[0], np.ndarray)
         and colors[0].ndim == 2
     )
 
-    use_per_point_colors = False
     point_color_data = None
 
     if use_rgb_mode:
         color_components = 3
         line_colors = None
 
-    elif _is_per_point:
-        use_per_point_colors = True
+    elif use_per_point_colors:
         color_arrays = [np.asarray(c, dtype=np.float32) for c in colors]
 
         if len(color_arrays) != n_lines:
@@ -1380,7 +1378,7 @@ def _create_streamtube_baked(
         for idx, ca in enumerate(color_arrays):
             point_color_data[idx, : ca.shape[0]] = ca
 
-        line_colors = np.zeros((n_lines, color_components), dtype=np.float32)
+        line_colors = None
 
     else:
         if colors is None:

--- a/fury/actor/curved.py
+++ b/fury/actor/curved.py
@@ -1317,21 +1317,31 @@ def _create_streamtube_baked(
         line_data[idx, : line.shape[0]] = line
 
     use_rgb_mode = isinstance(colors, str) and colors.lower() == "rgb"
+
+    _is_per_point = (
+        isinstance(colors, (list, tuple))
+        and len(colors) > 0
+        and isinstance(colors[0], np.ndarray)
+        and colors[0].ndim == 2
+    )
+
     use_per_point_colors = False
+    point_color_data = None
 
     if use_rgb_mode:
-        line_colors = np.zeros((n_lines, 3), dtype=np.float32)
-        point_color_data = None
-    elif isinstance(colors, (list, tuple)) and len(colors) > 0 and isinstance(
-        colors[0], np.ndarray
-    ) and colors[0].ndim == 2:
+        color_components = 3
+        line_colors = None
+
+    elif _is_per_point:
         use_per_point_colors = True
         color_arrays = [np.asarray(c, dtype=np.float32) for c in colors]
+
         if len(color_arrays) != n_lines:
             raise ValueError(
                 f"Per-point colors list must have {n_lines} arrays, "
                 f"got {len(color_arrays)}"
             )
+
         color_components = color_arrays[0].shape[1]
         if color_components not in (3, 4):
             raise ValueError(
@@ -1341,20 +1351,23 @@ def _create_streamtube_baked(
         if color_components == 4:
             color_arrays = [c[:, :3] for c in color_arrays]
             color_components = 3
+
         for idx, (ca, ll) in enumerate(zip(color_arrays, line_lengths)):
             if ca.shape[0] != ll:
                 raise ValueError(
-                    f"Per-point color array {idx} has {ca.shape[0]} points but "
-                    f"line has {ll} points"
+                    f"Per-point color array {idx} has {ca.shape[0]} points "
+                    f"but line has {ll} points"
                 )
+
         point_color_data = np.zeros(
             (n_lines, max_line_length, color_components), dtype=np.float32
         )
         for idx, ca in enumerate(color_arrays):
             point_color_data[idx, : ca.shape[0]] = ca
+
         line_colors = np.zeros((n_lines, color_components), dtype=np.float32)
+
     else:
-        point_color_data = None
         if colors is None:
             colors = np.array([1.0, 1.0, 1.0], dtype=np.float32)
 
@@ -1393,12 +1406,11 @@ def _create_streamtube_baked(
                     f"(number of lines), got {colors.shape[0]}"
                 )
         else:
-            raise ValueError(
-                f"Colors must be 1D or 2D array, got {colors.ndim}D array"
-            )
+            raise ValueError(f"Colors must be 1D or 2D array, got {colors.ndim}D array")
 
-    line_colors = line_colors.astype(np.float32, copy=False)
-    color_components = line_colors.shape[1]
+    if line_colors is not None:
+        line_colors = line_colors.astype(np.float32, copy=False)
+        color_components = line_colors.shape[1]
 
     tube_sides = int(segments)
     segments_per_line = np.maximum(line_lengths - 1, 0).astype(np.uint32)
@@ -1442,9 +1454,9 @@ def _create_streamtube_baked(
                 colors_data[vertex_idx + n_pts * tube_sides] = point_color_data[
                     line_idx, 0
                 ]
-                colors_data[vertex_idx + n_pts * tube_sides + 1] = (
-                    point_color_data[line_idx, n_pts - 1]
-                )
+                colors_data[vertex_idx + n_pts * tube_sides + 1] = point_color_data[
+                    line_idx, n_pts - 1
+                ]
             vertex_idx += int(vertices_per_line[line_idx])
     elif not use_rgb_mode:
         vertex_idx = 0
@@ -1489,7 +1501,12 @@ def _create_streamtube_baked(
     mesh_obj._needs_gpu_update = True
     mesh_obj.line_buffer = Buffer(line_data.reshape(-1))
     mesh_obj.length_buffer = Buffer(line_lengths)
-    mesh_obj.color_buffer = Buffer(line_colors)
+    _color_buf = (
+        line_colors
+        if line_colors is not None
+        else np.zeros((n_lines, color_components), dtype=np.float32)
+    )
+    mesh_obj.color_buffer = Buffer(_color_buf)
     if use_per_point_colors:
         mesh_obj.point_color_buffer = Buffer(
             point_color_data.reshape(-1).astype(np.float32)

--- a/fury/actor/curved.py
+++ b/fury/actor/curved.py
@@ -1317,10 +1317,44 @@ def _create_streamtube_baked(
         line_data[idx, : line.shape[0]] = line
 
     use_rgb_mode = isinstance(colors, str) and colors.lower() == "rgb"
+    use_per_point_colors = False
 
     if use_rgb_mode:
         line_colors = np.zeros((n_lines, 3), dtype=np.float32)
+        point_color_data = None
+    elif isinstance(colors, (list, tuple)) and len(colors) > 0 and isinstance(
+        colors[0], np.ndarray
+    ) and colors[0].ndim == 2:
+        use_per_point_colors = True
+        color_arrays = [np.asarray(c, dtype=np.float32) for c in colors]
+        if len(color_arrays) != n_lines:
+            raise ValueError(
+                f"Per-point colors list must have {n_lines} arrays, "
+                f"got {len(color_arrays)}"
+            )
+        color_components = color_arrays[0].shape[1]
+        if color_components not in (3, 4):
+            raise ValueError(
+                "Per-point colors must have 3 (RGB) or 4 (RGBA) components, "
+                f"got {color_components}"
+            )
+        if color_components == 4:
+            color_arrays = [c[:, :3] for c in color_arrays]
+            color_components = 3
+        for idx, (ca, ll) in enumerate(zip(color_arrays, line_lengths)):
+            if ca.shape[0] != ll:
+                raise ValueError(
+                    f"Per-point color array {idx} has {ca.shape[0]} points but "
+                    f"line has {ll} points"
+                )
+        point_color_data = np.zeros(
+            (n_lines, max_line_length, color_components), dtype=np.float32
+        )
+        for idx, ca in enumerate(color_arrays):
+            point_color_data[idx, : ca.shape[0]] = ca
+        line_colors = np.zeros((n_lines, color_components), dtype=np.float32)
     else:
+        point_color_data = None
         if colors is None:
             colors = np.array([1.0, 1.0, 1.0], dtype=np.float32)
 
@@ -1395,7 +1429,24 @@ def _create_streamtube_baked(
     colors_data = np.zeros((total_vertices, color_components), dtype=np.float32)
     indices_data = np.zeros((total_triangles, 3), dtype=np.uint32)
 
-    if not use_rgb_mode:
+    if use_per_point_colors:
+        vertex_idx = 0
+        for line_idx in range(n_lines):
+            n_pts = int(line_lengths[line_idx])
+            for pt_idx in range(n_pts):
+                pt_color = point_color_data[line_idx, pt_idx]
+                start = vertex_idx + pt_idx * tube_sides
+                end = start + tube_sides
+                colors_data[start:end] = pt_color
+            if end_caps:
+                colors_data[vertex_idx + n_pts * tube_sides] = point_color_data[
+                    line_idx, 0
+                ]
+                colors_data[vertex_idx + n_pts * tube_sides + 1] = (
+                    point_color_data[line_idx, n_pts - 1]
+                )
+            vertex_idx += int(vertices_per_line[line_idx])
+    elif not use_rgb_mode:
         vertex_idx = 0
         for line_idx in range(n_lines):
             n_verts = int(vertices_per_line[line_idx])
@@ -1434,10 +1485,17 @@ def _create_streamtube_baked(
     mesh_obj.line_colors = line_colors
     mesh_obj.color_components = color_components
     mesh_obj.use_rgb_mode = use_rgb_mode
+    mesh_obj.use_per_point_colors = use_per_point_colors
     mesh_obj._needs_gpu_update = True
     mesh_obj.line_buffer = Buffer(line_data.reshape(-1))
     mesh_obj.length_buffer = Buffer(line_lengths)
     mesh_obj.color_buffer = Buffer(line_colors)
+    if use_per_point_colors:
+        mesh_obj.point_color_buffer = Buffer(
+            point_color_data.reshape(-1).astype(np.float32)
+        )
+    else:
+        mesh_obj.point_color_buffer = None
     mesh_obj.vertex_offset_buffer = Buffer(vertex_offsets)
     mesh_obj.triangle_offset_buffer = Buffer(triangle_offsets)
 
@@ -1515,6 +1573,15 @@ def _resolve_color_components_for_streamtube(colors, backend):
     """
     if isinstance(colors, str) and colors.lower() == "rgb" and backend != "gpu":
         raise ValueError("colors='rgb' requires backend='gpu'")
+
+    if (
+        isinstance(colors, (list, tuple))
+        and len(colors) > 0
+        and isinstance(colors[0], np.ndarray)
+        and colors[0].ndim == 2
+        and backend != "gpu"
+    ):
+        raise ValueError("Per-point colors (list of arrays) requires backend='gpu'")
 
     if backend == "gpu":
         return 3

--- a/fury/actor/curved.py
+++ b/fury/actor/curved.py
@@ -1367,7 +1367,7 @@ def _create_streamtube_baked(
             color_arrays = [c[:, :3] for c in color_arrays]
             color_components = 3
 
-        for idx, (ca, ll) in enumerate(zip(color_arrays, line_lengths)):
+        for idx, (ca, ll) in enumerate(zip(color_arrays, line_lengths, strict=False)):
             if ca.shape[0] != ll:
                 raise ValueError(
                     f"Per-point color array {idx} has {ca.shape[0]} points "
@@ -1587,6 +1587,7 @@ def _slice_colors_for_lines(colors, start_idx, end_idx):
     if colors_arr.ndim == 2 and colors_arr.shape[0] > 1:
         return colors_arr[start_idx:end_idx]
     return colors
+
 
 def _resolve_color_components_for_streamtube(colors, backend):
     """Infer the color channel count used for streamtube buffers.

--- a/fury/actor/curved.py
+++ b/fury/actor/curved.py
@@ -1316,10 +1316,13 @@ def _create_streamtube_baked(
     for idx, line in enumerate(lines_arr):
         line_data[idx, : line.shape[0]] = line
 
-    if colors is None:
-        colors = np.array([1.0, 1.0, 1.0], dtype=np.float32)
+    use_rgb_mode = isinstance(colors, str) and colors.lower() == "rgb"
 
-    colors = np.asarray(colors, dtype=np.float32)
+    if use_rgb_mode:
+        line_colors = np.zeros((n_lines, 3), dtype=np.float32)
+    else:
+        if colors is None:
+            colors = np.array([1.0, 1.0, 1.0], dtype=np.float32)
 
         colors = np.asarray(colors, dtype=np.float32)
 
@@ -1392,6 +1395,13 @@ def _create_streamtube_baked(
     colors_data = np.zeros((total_vertices, color_components), dtype=np.float32)
     indices_data = np.zeros((total_triangles, 3), dtype=np.uint32)
 
+    if not use_rgb_mode:
+        vertex_idx = 0
+        for line_idx in range(n_lines):
+            n_verts = int(vertices_per_line[line_idx])
+            colors_data[vertex_idx : vertex_idx + n_verts] = line_colors[line_idx]
+            vertex_idx += n_verts
+
     geometry = buffer_to_geometry(
         positions=positions_data,
         normals=normals_data,
@@ -1423,6 +1433,7 @@ def _create_streamtube_baked(
     mesh_obj.lines = lines_arr
     mesh_obj.line_colors = line_colors
     mesh_obj.color_components = color_components
+    mesh_obj.use_rgb_mode = use_rgb_mode
     mesh_obj._needs_gpu_update = True
     mesh_obj.line_buffer = Buffer(line_data.reshape(-1))
     mesh_obj.length_buffer = Buffer(line_lengths)
@@ -1487,7 +1498,6 @@ def _slice_colors_for_lines(colors, start_idx, end_idx):
         return colors_arr[start_idx:end_idx]
     return colors
 
-
 def _resolve_color_components_for_streamtube(colors, backend):
     """Infer the color channel count used for streamtube buffers.
 
@@ -1503,6 +1513,9 @@ def _resolve_color_components_for_streamtube(colors, backend):
     int
         Number of color channels (3 or 4) to allocate.
     """
+    if isinstance(colors, str) and colors.lower() == "rgb" and backend != "gpu":
+        raise ValueError("colors='rgb' requires backend='gpu'")
+
     if backend == "gpu":
         return 3
 

--- a/fury/actor/curved.py
+++ b/fury/actor/curved.py
@@ -1256,9 +1256,24 @@ def _create_streamtube_baked(
     ----------
     lines : sequence of array_like, shape (N_i, 3)
         Iterable of polylines representing streamline vertices.
-    colors : array_like or None, optional
-        Per-line colors. Accepts a single RGB/RGBA vector or an array of shape
-        (1, 3|4)/(n_lines, 3|4). Defaults to white per line when None.
+    colors : array_like, str, list of ndarray, or None, optional
+        Specifies how tubes are colored. The following modes are supported:
+
+        - None : All tubes are colored white (default).
+
+        - Single color : A tuple or 1-D array of 3 (RGB) or 4 (RGBA)
+          floats in [0, 1], e.g. (1, 0, 0). Applied uniformly to every tube.
+
+        - Per-line colors : A 2-D array of shape (n_lines, 3) or
+          (n_lines, 4) giving one color per streamline.
+
+        - Per-point colors : A list/tuple of n_lines arrays, each of
+          shape (N_i, 3) or (N_i, 4) where N_i matches the number of
+          points in the corresponding line. Each vertex receives its own color.
+
+        - "rgb" : Each vertex is colored by the absolute value of its
+          local tangent direction mapped to RGB channels
+          (orientation-based coloring).
     opacity : float, optional
         Opacity multiplier applied to the material. Valid range is [0, 1].
     radius : float, optional

--- a/fury/actor/curved.py
+++ b/fury/actor/curved.py
@@ -1321,40 +1321,44 @@ def _create_streamtube_baked(
 
     colors = np.asarray(colors, dtype=np.float32)
 
-    if colors.ndim == 1:
-        if colors.size == 3:
-            line_colors = np.tile(colors, (n_lines, 1))
-        elif colors.size == 4:
-            line_colors = np.tile(colors[:3], (n_lines, 1))
-        else:
-            raise ValueError(
-                "Single color must have 3 (RGB) or 4 (RGBA) components, "
-                f"got {colors.size}"
-            )
-    elif colors.ndim == 2:
-        if colors.shape[0] == 1:
-            if colors.shape[1] in (3, 4):
-                line_colors = np.tile(colors[0, :3], (n_lines, 1))
+        colors = np.asarray(colors, dtype=np.float32)
+
+        if colors.ndim == 1:
+            if colors.size == 3:
+                line_colors = np.tile(colors, (n_lines, 1))
+            elif colors.size == 4:
+                line_colors = np.tile(colors[:3], (n_lines, 1))
             else:
                 raise ValueError(
-                    "Color must have 3 (RGB) or 4 (RGBA) components, "
-                    f"got {colors.shape[1]}"
+                    "Single color must have 3 (RGB) or 4 (RGBA) components, "
+                    f"got {colors.size}"
                 )
-        elif colors.shape[0] == n_lines:
-            if colors.shape[1] in (3, 4):
-                line_colors = colors[:, :3].astype(np.float32)
+        elif colors.ndim == 2:
+            if colors.shape[0] == 1:
+                if colors.shape[1] in (3, 4):
+                    line_colors = np.tile(colors[0, :3], (n_lines, 1))
+                else:
+                    raise ValueError(
+                        "Color must have 3 (RGB) or 4 (RGBA) components, "
+                        f"got {colors.shape[1]}"
+                    )
+            elif colors.shape[0] == n_lines:
+                if colors.shape[1] in (3, 4):
+                    line_colors = colors[:, :3].astype(np.float32)
+                else:
+                    raise ValueError(
+                        "Color must have 3 (RGB) or 4 (RGBA) components, "
+                        f"got {colors.shape[1]}"
+                    )
             else:
                 raise ValueError(
-                    "Color must have 3 (RGB) or 4 (RGBA) components, "
-                    f"got {colors.shape[1]}"
+                    f"Color array first dimension must be 1 or {n_lines} "
+                    f"(number of lines), got {colors.shape[0]}"
                 )
         else:
             raise ValueError(
-                f"Color array first dimension must be 1 or {n_lines} "
-                f"(number of lines), got {colors.shape[0]}"
+                f"Colors must be 1D or 2D array, got {colors.ndim}D array"
             )
-    else:
-        raise ValueError(f"Colors must be 1D or 2D array, got {colors.ndim}D array")
 
     line_colors = line_colors.astype(np.float32, copy=False)
     color_components = line_colors.shape[1]

--- a/fury/actor/curved.py
+++ b/fury/actor/curved.py
@@ -1332,7 +1332,6 @@ def _create_streamtube_baked(
         line_data[idx, : line.shape[0]] = line
 
     use_rgb_mode = isinstance(colors, str) and colors.lower() == "rgb"
-
     use_per_point_colors = (
         isinstance(colors, (list, tuple))
         and len(colors) > 0
@@ -1341,49 +1340,12 @@ def _create_streamtube_baked(
     )
 
     point_color_data = None
+    line_colors = None
 
-    if use_rgb_mode:
-        color_components = 3
-        line_colors = None
+    if colors is None:
+        colors = np.array([1.0, 1.0, 1.0], dtype=np.float32)
 
-    elif use_per_point_colors:
-        color_arrays = [np.asarray(c, dtype=np.float32) for c in colors]
-
-        if len(color_arrays) != n_lines:
-            raise ValueError(
-                f"Per-point colors list must have {n_lines} arrays, "
-                f"got {len(color_arrays)}"
-            )
-
-        color_components = color_arrays[0].shape[1]
-        if color_components not in (3, 4):
-            raise ValueError(
-                "Per-point colors must have 3 (RGB) or 4 (RGBA) components, "
-                f"got {color_components}"
-            )
-        if color_components == 4:
-            color_arrays = [c[:, :3] for c in color_arrays]
-            color_components = 3
-
-        for idx, (ca, ll) in enumerate(zip(color_arrays, line_lengths, strict=False)):
-            if ca.shape[0] != ll:
-                raise ValueError(
-                    f"Per-point color array {idx} has {ca.shape[0]} points "
-                    f"but line has {ll} points"
-                )
-
-        point_color_data = np.zeros(
-            (n_lines, max_line_length, color_components), dtype=np.float32
-        )
-        for idx, ca in enumerate(color_arrays):
-            point_color_data[idx, : ca.shape[0]] = ca
-
-        line_colors = None
-
-    else:
-        if colors is None:
-            colors = np.array([1.0, 1.0, 1.0], dtype=np.float32)
-
+    if not use_rgb_mode and not use_per_point_colors:
         colors = np.asarray(colors, dtype=np.float32)
 
         if colors.ndim == 1:
@@ -1420,6 +1382,41 @@ def _create_streamtube_baked(
                 )
         else:
             raise ValueError(f"Colors must be 1D or 2D array, got {colors.ndim}D array")
+
+    elif use_per_point_colors:
+        color_arrays = [np.asarray(c, dtype=np.float32) for c in colors]
+
+        if len(color_arrays) != n_lines:
+            raise ValueError(
+                f"Per-point colors list must have {n_lines} arrays, "
+                f"got {len(color_arrays)}"
+            )
+
+        color_components = color_arrays[0].shape[1]
+        if color_components not in (3, 4):
+            raise ValueError(
+                "Per-point colors must have 3 (RGB) or 4 (RGBA) components, "
+                f"got {color_components}"
+            )
+        if color_components == 4:
+            color_arrays = [c[:, :3] for c in color_arrays]
+            color_components = 3
+
+        for idx, (ca, ll) in enumerate(zip(color_arrays, line_lengths, strict=False)):
+            if ca.shape[0] != ll:
+                raise ValueError(
+                    f"Per-point color array {idx} has {ca.shape[0]} points "
+                    f"but line has {ll} points"
+                )
+
+        point_color_data = np.zeros(
+            (n_lines, max_line_length, color_components), dtype=np.float32
+        )
+        for idx, ca in enumerate(color_arrays):
+            point_color_data[idx, : ca.shape[0]] = ca
+
+    elif use_rgb_mode:
+        color_components = 3
 
     if line_colors is not None:
         line_colors = line_colors.astype(np.float32, copy=False)

--- a/fury/shader.py
+++ b/fury/shader.py
@@ -736,6 +736,7 @@ class _StreamtubeBakingShader(BaseShader):
         self["workgroup_size"] = min(64, max(int(wobject.n_lines), 1))
         self["end_caps"] = 1 if getattr(wobject, "end_caps", False) else 0
         self["color_channels"] = getattr(wobject, "color_components", 3)
+        self["use_rgb_mode"] = 1 if getattr(wobject, "use_rgb_mode", False) else 0
 
     def get_render_info(self, wobject, _shared):
         """Return the dispatch dimensions for the compute shader.
@@ -804,6 +805,7 @@ class _StreamtubeBakingShader(BaseShader):
         self["workgroup_size"] = min(64, max(int(wobject.n_lines), 1))
         self["color_channels"] = getattr(wobject, "color_components", 3)
         self["end_caps"] = 1 if getattr(wobject, "end_caps", False) else 0
+        self["use_rgb_mode"] = 1 if getattr(wobject, "use_rgb_mode", False) else 0
 
         bindings = {
             0: Binding(

--- a/fury/shader.py
+++ b/fury/shader.py
@@ -737,6 +737,9 @@ class _StreamtubeBakingShader(BaseShader):
         self["end_caps"] = 1 if getattr(wobject, "end_caps", False) else 0
         self["color_channels"] = getattr(wobject, "color_components", 3)
         self["use_rgb_mode"] = 1 if getattr(wobject, "use_rgb_mode", False) else 0
+        self["use_per_point_colors"] = (
+            1 if getattr(wobject, "use_per_point_colors", False) else 0
+        )
 
     def get_render_info(self, wobject, _shared):
         """Return the dispatch dimensions for the compute shader.
@@ -806,6 +809,9 @@ class _StreamtubeBakingShader(BaseShader):
         self["color_channels"] = getattr(wobject, "color_components", 3)
         self["end_caps"] = 1 if getattr(wobject, "end_caps", False) else 0
         self["use_rgb_mode"] = 1 if getattr(wobject, "use_rgb_mode", False) else 0
+        self["use_per_point_colors"] = (
+            1 if getattr(wobject, "use_per_point_colors", False) else 0
+        )
 
         bindings = {
             0: Binding(
@@ -863,6 +869,15 @@ class _StreamtubeBakingShader(BaseShader):
                 "COMPUTE",
             ),
         }
+
+        if getattr(wobject, "point_color_buffer", None) is not None:
+            bindings[9] = Binding(
+                "s_point_colors",
+                "buffer/storage",
+                wobject.point_color_buffer,
+                "COMPUTE",
+            )
+
         self.define_bindings(0, bindings)
         return {0: bindings}
 
@@ -929,6 +944,7 @@ class _StreamtubeRenderShader(MeshPhongShader):
                     "line_buffer",
                     "length_buffer",
                     "color_buffer",
+                    "point_color_buffer",
                     "vertex_offset_buffer",
                     "triangle_offset_buffer",
                 ):

--- a/fury/wgsl/streamtube_compute.wgsl
+++ b/fury/wgsl/streamtube_compute.wgsl
@@ -8,6 +8,7 @@ const COLOR_CHANNELS = u32({{ color_channels }});
 const PI = 3.14159265359;
 
 const USE_END_CAPS = {{ end_caps }}u;
+const USE_RGB_MODE = {{ use_rgb_mode }}u;
 
 fn safe_normalize(v: vec3<f32>) -> vec3<f32> {
     let len_v = length(v);
@@ -170,6 +171,11 @@ $$ endif
         let binormal = binormals_arr[i];
 
         var vertex_color = line_color;
+        if (USE_RGB_MODE == 1u) {
+            let abs_t = abs(tangent);
+            vertex_color = vec4<f32>(abs_t.x, abs_t.y, abs_t.z, 1.0);
+        }
+
         for (var j = 0u; j < TUBE_SIDES; j++) {
             let angle = 2.0 * PI * f32(j) / f32(TUBE_SIDES);
             let cos_a = cos(angle);
@@ -190,7 +196,6 @@ $$ endif
                 s_vertex_normals[pos_base] = vertex_normal.x;
                 s_vertex_normals[pos_base + 1u] = vertex_normal.y;
                 s_vertex_normals[pos_base + 2u] = vertex_normal.z;
-                write_vertex_color(vertex_idx, line_color, color_len);
                 write_vertex_color(vertex_idx, vertex_color, color_len);
             }
         }

--- a/fury/wgsl/streamtube_compute.wgsl
+++ b/fury/wgsl/streamtube_compute.wgsl
@@ -9,6 +9,25 @@ const PI = 3.14159265359;
 
 const USE_END_CAPS = {{ end_caps }}u;
 const USE_RGB_MODE = {{ use_rgb_mode }}u;
+const USE_PER_POINT_COLORS = {{ use_per_point_colors }}u;
+
+$$ if use_per_point_colors
+fn load_point_color(line_idx: u32, point_idx: u32) -> vec4<f32> {
+    let base = (line_idx * MAX_LINE_LENGTH + point_idx) * COLOR_CHANNELS;
+    let buf_len = arrayLength(&s_point_colors);
+    if (base >= buf_len) {
+        return vec4<f32>(1.0, 1.0, 1.0, 1.0);
+    }
+    var r = s_point_colors[base];
+    var g = 0.0;
+    var b = 0.0;
+    var a = 1.0;
+    if (COLOR_CHANNELS > 1u && base + 1u < buf_len) { g = s_point_colors[base + 1u]; }
+    if (COLOR_CHANNELS > 2u && base + 2u < buf_len) { b = s_point_colors[base + 2u]; }
+    if (COLOR_CHANNELS > 3u && base + 3u < buf_len) { a = s_point_colors[base + 3u]; }
+    return vec4<f32>(r, g, b, a);
+}
+$$ endif
 
 fn safe_normalize(v: vec3<f32>) -> vec3<f32> {
     let len_v = length(v);
@@ -175,6 +194,9 @@ $$ endif
             let abs_t = abs(tangent);
             vertex_color = vec4<f32>(abs_t.x, abs_t.y, abs_t.z, 1.0);
         }
+$$ if use_per_point_colors
+        vertex_color = load_point_color(line_idx, i);
+$$ endif
 
         for (var j = 0u; j < TUBE_SIDES; j++) {
             let angle = 2.0 * PI * f32(j) / f32(TUBE_SIDES);
@@ -242,7 +264,14 @@ $$ endif
             s_vertex_normals[base + 1u] = start_normal.y;
             s_vertex_normals[base + 2u] = start_normal.z;
         }
-        write_vertex_color(start_center_idx, line_color, color_len);
+$$ if use_per_point_colors
+        let start_cap_color = load_point_color(line_idx, 0u);
+        let end_cap_color = load_point_color(line_idx, line_length - 1u);
+$$ else
+        let start_cap_color = line_color;
+        let end_cap_color = line_color;
+$$ endif
+        write_vertex_color(start_center_idx, start_cap_color, color_len);
 
         if (end_center_idx * 3u + 2u < pos_len && end_center_idx * 3u + 2u < norm_len) {
             let base = end_center_idx * 3u;
@@ -253,7 +282,7 @@ $$ endif
             s_vertex_normals[base + 1u] = end_normal.y;
             s_vertex_normals[base + 2u] = end_normal.z;
         }
-        write_vertex_color(end_center_idx, line_color, color_len);
+        write_vertex_color(end_center_idx, end_cap_color, color_len);
 
         let side_triangles = (line_length - 1u) * TUBE_SIDES * 2u;
         var tri_idx = base_triangle_idx + side_triangles;

--- a/fury/wgsl/streamtube_compute.wgsl
+++ b/fury/wgsl/streamtube_compute.wgsl
@@ -169,6 +169,7 @@ $$ endif
         let normal = normals_arr[i];
         let binormal = binormals_arr[i];
 
+        var vertex_color = line_color;
         for (var j = 0u; j < TUBE_SIDES; j++) {
             let angle = 2.0 * PI * f32(j) / f32(TUBE_SIDES);
             let cos_a = cos(angle);
@@ -190,6 +191,7 @@ $$ endif
                 s_vertex_normals[pos_base + 1u] = vertex_normal.y;
                 s_vertex_normals[pos_base + 2u] = vertex_normal.z;
                 write_vertex_color(vertex_idx, line_color, color_len);
+                write_vertex_color(vertex_idx, vertex_color, color_len);
             }
         }
 


### PR DESCRIPTION
Hello @m-agour @maharshi-gor
 In this pull request is a fix for the issue in #1067 
<img width="2691" height="1667" alt="image" src="https://github.com/user-attachments/assets/de6cc8f4-4df1-409e-9840-3c90b88c3c95" />

- streamtubes colors can be acssessed through actor.geometry.colors.data but not for rgb mode the reason is we do not need buffer for this mode.
- added simple example on how to use streamtubes with different colors modes

Thanks