### PR TITLE
Fix: Handle tuple colors in point() function (#1092)

### DIFF
--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1825,8 +1825,6 @@ def point(points, colors=None, *, point_radius=0.1, phi=8, theta=8, opacity=1.0)
         opacity=opacity,
     )
 
-
-
 @warn_on_args_to_kwargs()
 def sphere(
     centers,

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1802,18 +1802,17 @@ def point(points, colors, *, point_radius=0.1, phi=8, theta=8, opacity=1.0):
 
     """
 if colors is not None:
-            colors = np.asarray(colors)    
-    
-        return sphere(
-        centers=points,
-        colors=colors,
-        radii=point_radius,
-        phi=phi,
-        theta=theta,
-        vertices=None,
-        faces=None,
-        opacity=opacity,
-    )
+    colors = np.asarray(colors)
+
+return sphere(
+    points,
+    colors=colors,
+    radii=point_radius,
+    phi=8,
+    theta=8,
+    opacity=opacity,
+)
+
 
 
 @warn_on_args_to_kwargs()

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1767,17 +1767,17 @@ def dot(points, *, colors=None, opacity=None, dot_size=5):
 
     return poly_actor
 
-
+  )
 @warn_on_args_to_kwargs()
-def point(points, colors, *, point_radius=0.1, phi=8, theta=8, opacity=1.0):
+def point(points, colors=None, *, point_radius=0.1, phi=8, theta=8, opacity=1.0):
     """Visualize one or many points.
 
     Parameters
     ----------
     points : ndarray, shape (N, 3)
         Points positions.
-    colors : ndarray (N, 3) or tuple (3,)
-        RGB values in the range [0, 1].
+    colors : ndarray, shape (N, 3) or (N, 4) or array-like of shape (3,) or (4,), optional
+        RGB or RGBA values in the range [0, 1].
     point_radius : float
         Point radius.
     phi : int
@@ -1793,20 +1793,28 @@ def point(points, colors, *, point_radius=0.1, phi=8, theta=8, opacity=1.0):
 
     See Also
     --------
-    :func:`fury.actor.dot`
-    :func:`fury.actor.sphere`
-
-    Examples
-    --------
-    >>> from fury import window, actor
-    >>> scene = window.Scene()
-    >>> pts = np.random.rand(5, 3)
-    >>> point_actor = actor.point(pts, window.colors.coral)
-    >>> scene.add(point_actor)
-    >>> # window.show(scene)
+    sphere
     """
-    if colors is not None:
+    if colors is None:
+        # Default color: red
+        colors = np.array([[1.0, 0.0, 0.0]], dtype=float)
+    else:
         colors = np.asarray(colors)
+
+        if colors.ndim == 1:
+            if colors.shape[0] not in (3, 4):
+                raise ValueError(
+                    "colors must be a 1D array-like of length 3 (RGB) or 4 (RGBA)"
+                )
+            colors = colors[np.newaxis, :]
+
+        elif colors.ndim == 2:
+            if colors.shape[1] not in (3, 4):
+                raise ValueError(
+                    "Last dimension of colors must be 3 (RGB) or 4 (RGBA)"
+                )
+        else:
+            raise ValueError("colors must be 1D or 2D array-like")
 
     return sphere(
         centers=points,
@@ -1814,10 +1822,10 @@ def point(points, colors, *, point_radius=0.1, phi=8, theta=8, opacity=1.0):
         radii=point_radius,
         phi=phi,
         theta=theta,
-        vertices=None,
-        faces=None,
         opacity=opacity,
     )
+
+
 
 @warn_on_args_to_kwargs()
 def sphere(

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1770,21 +1770,26 @@ def dot(points, *, colors=None, opacity=None, dot_size=5):
 
 @warn_on_args_to_kwargs()
 def point(points, colors, *, point_radius=0.1, phi=8, theta=8, opacity=1.0):
-    """Visualize points as sphere glyphs.
+    """Visualize one or many points.
 
     Parameters
     ----------
     points : ndarray, shape (N, 3)
-    colors : ndarray (N,3) or tuple (3,)
+        Points positions.
+    colors : ndarray (N, 3) or tuple (3,)
+        RGB values in the range [0, 1].
     point_radius : float
+        Point radius.
     phi : int
+        Number of points in the latitude direction.
     theta : int
+        Number of points in the longitude direction.
     opacity : float, optional
         Takes values from 0 (fully transparent) to 1 (opaque). Default is 1.
 
     Returns
     -------
-    point_actor: Actor
+    point_actor : Actor
 
     See Also
     --------
@@ -1799,19 +1804,22 @@ def point(points, colors, *, point_radius=0.1, phi=8, theta=8, opacity=1.0):
     >>> point_actor = actor.point(pts, window.colors.coral)
     >>> scene.add(point_actor)
     >>> # window.show(scene)
-
     """
-if colors is not None:
-    colors = np.asarray(colors)
+    if colors is not None:
+        colors = np.asarray(colors)
 
-return sphere(
-    points,
-    colors=colors,
-    radii=point_radius,
-    phi=8,
-    theta=8,
-    opacity=opacity,
-)
+    return sphere(
+        centers=points,
+        colors=colors,
+        radii=point_radius,
+        phi=phi,
+        theta=theta,
+        vertices=None,
+        faces=None,
+        opacity=opacity,
+    )
+
+
 
 
 

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1801,8 +1801,10 @@ def point(points, colors, *, point_radius=0.1, phi=8, theta=8, opacity=1.0):
     >>> # window.show(scene)
 
     """
-        colors = np.asarray(colors)
-    return sphere(
+if colors is not None:
+            colors = np.asarray(colors)    
+    
+        return sphere(
         centers=points,
         colors=colors,
         radii=point_radius,

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1801,6 +1801,7 @@ def point(points, colors, *, point_radius=0.1, phi=8, theta=8, opacity=1.0):
     >>> # window.show(scene)
 
     """
+        colors = np.asarray(colors)
     return sphere(
         centers=points,
         colors=colors,

--- a/fury/actor.py
+++ b/fury/actor.py
@@ -1819,10 +1819,6 @@ def point(points, colors, *, point_radius=0.1, phi=8, theta=8, opacity=1.0):
         opacity=opacity,
     )
 
-
-
-
-
 @warn_on_args_to_kwargs()
 def sphere(
     centers,


### PR DESCRIPTION
Convert colors to numpy array before passing to sphere() function. This fixes the issue where point() fails when colors is passed as a tuple. The downstream code expects colors to have .astype() method which tuples don't have.

Closes #1092