### PR TITLE
 Allow create_text to accept multiple texts and materials fixes #1012

### DIFF
--- a/docs/examples/_valid_examples.toml
+++ b/docs/examples/_valid_examples.toml
@@ -21,6 +21,7 @@ files = [
     "viz_multi_screen.py",
     "viz_show.py",
     "viz_imgui.py",
+    "viz_text.py"
 
 ]
 

--- a/docs/examples/viz_text.py
+++ b/docs/examples/viz_text.py
@@ -1,0 +1,50 @@
+"""
+=========================
+3D Text Actor
+=========================
+
+This example shows how to use ``actor.text`` to render single and multiple
+3D text objects in a scene.
+"""
+
+##############################################################################
+# First, let's import the necessary modules.
+
+from fury import actor, window
+
+##############################################################################
+# Creating a Scene
+
+scene = window.Scene()
+
+##############################################################################
+# Render a single text actor.
+
+single = actor.text(
+    "Hello, FURY!",
+    colors=(1.0, 1.0, 1.0),
+    position=(0.0, 2.0, 0.0),
+    font_size=0.5,
+)
+scene.add(single)
+
+##############################################################################
+# Render multiple text actors with per-item positions and colors.
+
+labels = ["X", "Y", "Z"]
+positions = [(3.0, 0.0, 0.0), (0.0, 3.0, 0.0), (0.0, 0.0, 3.0)]
+colors = [(1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)]
+
+axes_labels = actor.text(
+    labels,
+    colors=colors,
+    position=positions,
+    font_size=0.4,
+)
+scene.add(axes_labels)
+
+##############################################################################
+# Show the scene.
+
+show_manager = window.ShowManager(scene=scene, size=(800, 600))
+show_manager.start()

--- a/fury/actor/core.py
+++ b/fury/actor/core.py
@@ -282,6 +282,11 @@ def create_text(text, material, **kwargs):
     ------
     TypeError
         If text is not a string or material is not an instance of TextMaterial.
+
+    Examples
+    --------
+    >>> mat = TextMaterial()
+    >>> t = create_text("Hello", mat)
     """
     if not isinstance(text, str):
         raise TypeError("text must be a string.")
@@ -289,8 +294,7 @@ def create_text(text, material, **kwargs):
     if not isinstance(material, TextMaterial):
         raise TypeError("material must be an instance of TextMaterial.")
 
-    text = Text(text=text, material=material, **kwargs)
-    return text
+    return Text(text=text, material=material, **kwargs)
 
 
 def create_image(image_input, material, **kwargs):

--- a/fury/actor/planar.py
+++ b/fury/actor/planar.py
@@ -7,6 +7,7 @@ import numpy as np
 from scipy.spatial.transform import Rotation as R
 
 from fury.actor import (
+    Group,
     Points,
     actor_from_primitive,
     create_image,
@@ -513,14 +514,17 @@ def text(
 
     Parameters
     ----------
-    text : str or list[str]
-        The plain text to render.
-        The text is split in one TextBlock per line,
-        unless a list is given, in which case each (str) item becomes a TextBlock.
-    colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA values in the range [0, 1].
-    position : tuple, optional
-        The (x, y, z) coordinates to place the text in 3D space.
+    text : str or list of str
+        The plain text to render. When a list is given, each item becomes
+        a separate text actor and a Group is returned.
+    colors : tuple (3,) or tuple (4,) or list of tuple, optional
+        RGB or RGBA values in the range [0, 1]. When ``text`` is a list,
+        this can be a single color applied to all actors, or a list of
+        colors (one per text item).
+    position : tuple (3,) or list of tuple (3,), optional
+        The (x, y, z) coordinates to place the text in 3D space. When
+        ``text`` is a list, this can be a single position applied to all
+        actors, or a list of positions (one per text item).
     font_size : float, optional
         The size of the font, in object coordinates or pixel screen coordinates.
     family : str, optional
@@ -548,9 +552,17 @@ def text(
 
     Returns
     -------
-    Actor
-        A text actor containing the generated text with the specified material
-        and properties.
+    Text or Group
+        A single Text actor if ``text`` is a string, or a Group of Text
+        actors if ``text`` is a list.
+
+    Raises
+    ------
+    TypeError
+        If ``text`` is not a string or list of strings.
+    ValueError
+        If ``colors`` or ``position`` is a list whose length does not match
+        the length of ``text``.
 
     Examples
     --------
@@ -561,6 +573,65 @@ def text(
     >>> show_manager = window.ShowManager(scene=scene, size=(600, 600))
     >>> show_manager.start()
     """
+    if isinstance(text, (list, tuple)):
+        if not all(isinstance(t, str) for t in text):
+            raise TypeError("All items in text list must be strings.")
+
+        n = len(text)
+
+        is_color_seq = (
+            isinstance(colors, (list, tuple))
+            and len(colors) > 0
+            and isinstance(colors[0], (list, tuple))
+        )
+        if is_color_seq:
+            if len(colors) != n:
+                raise ValueError(
+                    "Length of colors list must match length of text list."
+                )
+            colors_list = colors
+        else:
+            colors_list = [colors] * n
+
+        is_pos_seq = (
+            isinstance(position, (list, tuple))
+            and len(position) > 0
+            and isinstance(position[0], (list, tuple))
+        )
+        if is_pos_seq:
+            if len(position) != n:
+                raise ValueError(
+                    "Length of position list must match length of text list."
+                )
+            position_list = position
+        else:
+            position_list = [position] * n
+
+        group = Group()
+        for t, c, p in zip(text, colors_list, position_list, strict=True):
+            mat = _create_text_material(
+                color=c,
+                opacity=opacity,
+                outline_color=outline_color,
+                outline_thickness=outline_thickness,
+            )
+            obj = create_text(
+                text=t,
+                material=mat,
+                font_size=font_size,
+                family=family,
+                anchor=anchor,
+                max_width=max_width,
+                line_height=line_height,
+                text_align=text_align,
+            )
+            obj.local.position = p
+            group.add(obj)
+        return group
+
+    if not isinstance(text, str):
+        raise TypeError("text must be a string.")
+
     mat = _create_text_material(
         color=colors,
         opacity=opacity,

--- a/fury/actor/tests/test_planar.py
+++ b/fury/actor/tests/test_planar.py
@@ -4,6 +4,7 @@ import numpy.testing as npt
 import pytest
 
 from fury import actor, window
+from fury.actor import Group
 from fury.actor.tests._helpers import validate_actors
 
 
@@ -202,6 +203,75 @@ def test_text():
     assert 0 < mean_b < 255
 
     scene.remove(text_actor_1)
+
+
+def test_text_list_returns_group():
+    texts = ["Hello", "World", "FURY"]
+    positions = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (2.0, 0.0, 0.0)]
+    group = actor.text(text=texts, position=positions)
+    assert isinstance(group, Group)
+    assert len(group.children) == 3
+    for child, pos in zip(group.children, positions, strict=True):
+        npt.assert_array_equal(child.local.position, np.array(pos))
+
+
+def test_text_list_shared_position():
+    texts = ["Hello", "World"]
+    group = actor.text(text=texts)
+    assert isinstance(group, Group)
+    assert len(group.children) == 2
+
+
+def test_text_list_per_color():
+    texts = ["Hello", "World"]
+    colors = [(1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+    group = actor.text(text=texts, colors=colors)
+    assert isinstance(group, Group)
+    assert len(group.children) == 2
+
+
+def test_text_list_invalid_items_raises():
+    with pytest.raises(TypeError):
+        actor.text(text=["Hello", 123])
+
+
+def test_text_list_position_length_mismatch_raises():
+    with pytest.raises(ValueError):
+        actor.text(
+            text=["Hello", "World", "FURY"],
+            position=[(0.0, 0.0, 0.0), (1.0, 0.0, 0.0)],
+        )
+
+
+def test_text_list_colors_length_mismatch_raises():
+    with pytest.raises(ValueError):
+        actor.text(
+            text=["Hello", "World", "FURY"],
+            colors=[(1.0, 0.0, 0.0), (0.0, 1.0, 0.0)],
+        )
+
+
+def test_text_tuple_of_strings():
+    texts = ("Hello", "World")
+    group = actor.text(text=texts)
+    assert isinstance(group, Group)
+    assert len(group.children) == 2
+
+
+def test_text_tuple_of_positions():
+    texts = ["Hello", "World"]
+    positions = ((0.0, 0.0, 0.0), (1.0, 0.0, 0.0))
+    group = actor.text(text=texts, position=positions)
+    assert isinstance(group, Group)
+    assert len(group.children) == 2
+
+
+def test_text_tuple_of_colors():
+    texts = ["Hello", "World"]
+    colors = ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0))
+    group = actor.text(text=texts, colors=colors)
+    assert isinstance(group, Group)
+    assert len(group.children) == 2
 
 
 def test_image():


### PR DESCRIPTION
Fixes #1012

## Changes

- Updated `text()` in `fury/actor/planar.py` to accept a list of strings,
  returning a `Group` of Text actors
- `create_text()` in `fury/actor/core.py` is unchanged (single string only)
- Added tests in `fury/actor/tests/test_planar.py`

## Usage
```python
# Single text (unchanged behavior)
t = actor.text("Hello")

# Multiple texts, shared position and color
t = actor.text(["Hello", "World", "FURY"])

# Multiple texts with per-item positions
t = actor.text(
    ["Hello", "World", "FURY"],
    position=[(0, 0, 0), (1, 0, 0), (2, 0, 0)],
)

# Multiple texts with per-item colors
t = actor.text(
    ["Hello", "World"],
    colors=[(1, 0, 0), (0, 1, 0)],
)
```