### PR TITLE
ENH: support per-instance Ring2D actor features

### DIFF
--- a/fury/actor/planar.py
+++ b/fury/actor/planar.py
@@ -446,8 +446,7 @@ def marker(
         RGB or RGBA values in the range [0, 1].
     marker : str or MarkerShape, optional
         The shape of the marker.
-        Options are "●": "circle", "+": "plus", "x": "cross", "♥": "heart",
-        "✳": "asterix".
+        Options are "circle", "plus", "cross", "heart", "asterix".
     edge_color : str or tuple or Color, optional
         The color of line marking the edge of the markers.
     edge_width : float, optional
@@ -756,113 +755,6 @@ def ring(
     centers = np.asarray(centers)
     n_centers = len(centers)
 
-    def _as_per_center(values, *, value_name, cast=None):
-        """Normalize scalar or 1D input to per-center values.
-
-        Parameters
-        ----------
-        values : float or int or ndarray
-            Scalar-like or one-dimensional input values.
-        value_name : str
-            Name of the parameter, used in error messages.
-        cast : type, optional
-            Optional dtype constructor used to cast the output values.
-
-        Returns
-        -------
-        ndarray
-            One-dimensional array with one value per center.
-        """
-        arr = np.asarray(values)
-        if arr.ndim == 0:
-            arr = np.full(n_centers, arr.item())
-        elif arr.ndim == 1 and arr.size == 1:
-            arr = np.full(n_centers, arr.item())
-        elif arr.ndim == 1 and arr.size == n_centers:
-            pass
-        else:
-            raise ValueError(
-                f"{value_name} size should be 1 or equal to the numbers of centers"
-            )
-
-        if cast is not None:
-            arr = arr.astype(cast)
-        return arr
-
-    def _color_at(values, idx):
-        """Return color for one center from scalar-like or per-center colors.
-
-        Parameters
-        ----------
-        values : tuple or list or ndarray
-            Either one color (RGB/RGBA) or one color per center.
-        idx : int
-            Center index.
-
-        Returns
-        -------
-        ndarray
-            Color values for one center.
-        """
-        arr = np.asarray(values)
-        if arr.ndim == 1 and arr.size in (3, 4):
-            return arr
-        if arr.ndim == 2 and arr.shape[0] in (1, n_centers):
-            return arr[0] if arr.shape[0] == 1 else arr[idx]
-        raise ValueError("colors size should be 1 or equal to the numbers of centers")
-
-    def _direction_at(values, idx):
-        """Return direction for one center from scalar-like or per-center input.
-
-        Parameters
-        ----------
-        values : tuple or list or ndarray
-            Either one direction or one direction per center.
-        idx : int
-            Center index.
-
-        Returns
-        -------
-        ndarray
-            Direction vector for one center.
-        """
-        arr = np.asarray(values)
-        if arr.ndim == 1 and arr.size == 3:
-            return arr
-        if arr.ndim == 2 and arr.shape[0] in (1, n_centers):
-            return arr[0] if arr.shape[0] == 1 else arr[idx]
-        raise ValueError(
-            "directions size should be 1 or equal to the numbers of centers"
-        )
-
-    def _scale_at(values, idx):
-        """Return scale for one center from scalar-like or per-center scales.
-
-        Parameters
-        ----------
-        values : float or tuple or ndarray
-            Either one scale, one XYZ scale, or one scale per center.
-        idx : int
-            Center index.
-
-        Returns
-        -------
-        float or ndarray
-            Scale value(s) for one center.
-        """
-        arr = np.asarray(values)
-        if arr.ndim == 0:
-            return arr.item()
-        if arr.ndim == 1 and arr.size == 1:
-            return arr.item()
-        if arr.ndim == 1 and arr.size == 3:
-            return arr
-        if arr.ndim == 1 and arr.size == n_centers:
-            return arr[idx]
-        if arr.ndim == 2 and arr.shape[0] in (1, n_centers) and arr.shape[1] == 3:
-            return arr[0] if arr.shape[0] == 1 else arr[idx]
-        raise ValueError("scales size should be 1 or equal to the numbers of centers")
-
     if n_centers == 0:
         vertices = np.empty((0, 3), dtype=np.float32)
         faces = np.empty((0, 3), dtype=np.int32)
@@ -906,75 +798,61 @@ def ring(
             enable_picking=enable_picking,
         )
 
-    inner_radius_arr = _as_per_center(
-        inner_radius, value_name="inner_radius", cast=np.float64
-    )
-    outer_radius_arr = _as_per_center(
-        outer_radius, value_name="outer_radius", cast=np.float64
-    )
-    radial_segments_arr = _as_per_center(
-        radial_segments, value_name="radial_segments", cast=np.int64
-    )
-    circumferential_segments_arr = _as_per_center(
-        circumferential_segments,
-        value_name="circumferential_segments",
-        cast=np.int64,
-    )
+    # Per-instance ring parameters -- each ring may have different topology,
+    # so we generate each mesh separately and concatenate.
+    ring_params = {
+        "inner_radius": np.atleast_1d(np.asarray(inner_radius)),
+        "outer_radius": np.atleast_1d(np.asarray(outer_radius)),
+        "radial_segments": np.atleast_1d(np.asarray(radial_segments)),
+        "circumferential_segments": np.atleast_1d(np.asarray(circumferential_segments)),
+    }
+    for name, arr in ring_params.items():
+        if arr.size not in (1, n_centers):
+            raise ValueError(
+                f"{name} size should be 1 or equal to the numbers of centers"
+            )
+
+    inner_radius_arr = ring_params["inner_radius"]
+    outer_radius_arr = ring_params["outer_radius"]
+    radial_segments_arr = ring_params["radial_segments"]
+    circumferential_segments_arr = ring_params["circumferential_segments"]
 
     all_vertices = []
     all_faces = []
-    all_colors = []
     face_offset = 0
 
     for idx in range(n_centers):
-        vertices, faces = fp.prim_ring(
+        verts, tri = fp.prim_ring(
             inner_radius=float(inner_radius_arr[idx]),
             outer_radius=float(outer_radius_arr[idx]),
             radial_segments=int(radial_segments_arr[idx]),
             circumferential_segments=int(circumferential_segments_arr[idx]),
         )
 
-        vertices = vertices.copy()
-
-        # Scale
-        vertices *= _scale_at(scales, idx)
-
-        # Rotate according to direction
-        dirs = _direction_at(directions, idx)
-        dir_abs = np.linalg.norm(dirs)
-        if dir_abs:
-            normal = np.array([1.0, 0.0, 0.0])
-            dirs = dirs / dir_abs
-            v = np.cross(normal, dirs)
-            c = np.dot(normal, dirs)
-
-            vmat = np.array([[0, -v[2], v[1]], [v[2], 0, -v[0]], [-v[1], v[0], 0]])
-
-            if c == -1.0:
-                rotation_matrix = -np.eye(3, dtype=np.float64)
-            else:
-                h = 1 / (1 + c)
-                rotation_matrix = (
-                    np.eye(3, dtype=np.float64) + vmat + (vmat.dot(vmat) * h)
-                )
-        else:
-            rotation_matrix = np.identity(3)
-
-        vertices = np.dot(rotation_matrix[:3, :3], vertices.T).T
-
         # Translate to center
-        vertices += centers[idx]
+        verts = verts + centers[idx]
 
-        all_vertices.append(vertices)
-        all_faces.append(faces + face_offset)
-        color_i = _color_at(colors, idx)
-        all_colors.append(np.repeat(color_i[np.newaxis, :], len(vertices), axis=0))
-
-        face_offset += len(vertices)
+        all_vertices.append(verts)
+        all_faces.append(tri + face_offset)
+        face_offset += len(verts)
 
     big_vertices = np.concatenate(all_vertices, axis=0)
     big_faces = np.concatenate(all_faces, axis=0)
-    big_colors = np.concatenate(all_colors, axis=0)
+
+    # Expand colors to per-vertex
+    colors_arr = np.asarray(colors)
+    if colors_arr.ndim == 1 and colors_arr.size in (3, 4):
+        big_colors = np.tile(colors_arr, (len(big_vertices), 1))
+    elif colors_arr.ndim == 2 and colors_arr.shape[0] == n_centers:
+        per_ring_sizes = [len(v) for v in all_vertices]
+        big_colors = np.concatenate(
+            [np.tile(colors_arr[i], (per_ring_sizes[i], 1)) for i in range(n_centers)],
+            axis=0,
+        )
+    else:
+        big_colors = np.tile(
+            np.asarray([1, 1, 1], dtype=np.float32), (len(big_vertices), 1)
+        )
 
     obj = actor_from_primitive(
         big_vertices,

--- a/fury/actor/planar.py
+++ b/fury/actor/planar.py
@@ -706,14 +706,18 @@ def ring(
     ----------
     centers : ndarray, shape (N, 3)
         Ring positions.
-    inner_radius : float, optional
-        The inner radius of the ring (radius of the hole).
-    outer_radius : float, optional
-        The outer radius of the ring.
-    radial_segments : int, optional
-        Number of segments along the radial direction.
-    circumferential_segments : int, optional
-        Number of segments around the circumference.
+    inner_radius : float or ndarray, shape (N,), optional
+        The inner radius of the ring (radius of the hole). A single value
+        applies to all rings, while an array specifies one value per ring.
+    outer_radius : float or ndarray, shape (N,), optional
+        The outer radius of the ring. A single value applies to all rings,
+        while an array specifies one value per ring.
+    radial_segments : int or ndarray, shape (N,), optional
+        Number of segments along the radial direction. A single value applies
+        to all rings, while an array specifies one value per ring.
+    circumferential_segments : int or ndarray, shape (N,), optional
+        Number of segments around the circumference. A single value applies to
+        all rings, while an array specifies one value per ring.
     directions : ndarray, shape (N, 3) or tuple (3,), optional
         The orientation vector of the ring.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
@@ -748,23 +752,242 @@ def ring(
     >>> show_manager = window.ShowManager(scene=scene, size=(600, 600))
     >>> show_manager.start()
     """
-    vertices, faces = fp.prim_ring(
-        inner_radius=inner_radius,
-        outer_radius=outer_radius,
-        radial_segments=radial_segments,
-        circumferential_segments=circumferential_segments,
+
+    centers = np.asarray(centers)
+    n_centers = len(centers)
+
+    def _as_per_center(values, *, value_name, cast=None):
+        """Normalize scalar or 1D input to per-center values.
+
+        Parameters
+        ----------
+        values : float or int or ndarray
+            Scalar-like or one-dimensional input values.
+        value_name : str
+            Name of the parameter, used in error messages.
+        cast : type, optional
+            Optional dtype constructor used to cast the output values.
+
+        Returns
+        -------
+        ndarray
+            One-dimensional array with one value per center.
+        """
+        arr = np.asarray(values)
+        if arr.ndim == 0:
+            arr = np.full(n_centers, arr.item())
+        elif arr.ndim == 1 and arr.size == 1:
+            arr = np.full(n_centers, arr.item())
+        elif arr.ndim == 1 and arr.size == n_centers:
+            pass
+        else:
+            raise ValueError(
+                f"{value_name} size should be 1 or equal to the numbers of centers"
+            )
+
+        if cast is not None:
+            arr = arr.astype(cast)
+        return arr
+
+    def _color_at(values, idx):
+        """Return color for one center from scalar-like or per-center colors.
+
+        Parameters
+        ----------
+        values : tuple or list or ndarray
+            Either one color (RGB/RGBA) or one color per center.
+        idx : int
+            Center index.
+
+        Returns
+        -------
+        ndarray
+            Color values for one center.
+        """
+        arr = np.asarray(values)
+        if arr.ndim == 1 and arr.size in (3, 4):
+            return arr
+        if arr.ndim == 2 and arr.shape[0] in (1, n_centers):
+            return arr[0] if arr.shape[0] == 1 else arr[idx]
+        raise ValueError("colors size should be 1 or equal to the numbers of centers")
+
+    def _direction_at(values, idx):
+        """Return direction for one center from scalar-like or per-center input.
+
+        Parameters
+        ----------
+        values : tuple or list or ndarray
+            Either one direction or one direction per center.
+        idx : int
+            Center index.
+
+        Returns
+        -------
+        ndarray
+            Direction vector for one center.
+        """
+        arr = np.asarray(values)
+        if arr.ndim == 1 and arr.size == 3:
+            return arr
+        if arr.ndim == 2 and arr.shape[0] in (1, n_centers):
+            return arr[0] if arr.shape[0] == 1 else arr[idx]
+        raise ValueError(
+            "directions size should be 1 or equal to the numbers of centers"
+        )
+
+    def _scale_at(values, idx):
+        """Return scale for one center from scalar-like or per-center scales.
+
+        Parameters
+        ----------
+        values : float or tuple or ndarray
+            Either one scale, one XYZ scale, or one scale per center.
+        idx : int
+            Center index.
+
+        Returns
+        -------
+        float or ndarray
+            Scale value(s) for one center.
+        """
+        arr = np.asarray(values)
+        if arr.ndim == 0:
+            return arr.item()
+        if arr.ndim == 1 and arr.size == 1:
+            return arr.item()
+        if arr.ndim == 1 and arr.size == 3:
+            return arr
+        if arr.ndim == 1 and arr.size == n_centers:
+            return arr[idx]
+        if arr.ndim == 2 and arr.shape[0] in (1, n_centers) and arr.shape[1] == 3:
+            return arr[0] if arr.shape[0] == 1 else arr[idx]
+        raise ValueError("scales size should be 1 or equal to the numbers of centers")
+
+    if n_centers == 0:
+        vertices = np.empty((0, 3), dtype=np.float32)
+        faces = np.empty((0, 3), dtype=np.int32)
+        return actor_from_primitive(
+            vertices,
+            faces,
+            centers=np.array([[0.0, 0.0, 0.0]]),
+            colors=np.empty((0, 3), dtype=np.float32),
+            opacity=opacity,
+            material=material,
+            enable_picking=enable_picking,
+            repeat_primitive=False,
+        )
+
+    has_per_instance_ring_features = any(
+        np.asarray(param).ndim > 0
+        for param in (
+            inner_radius,
+            outer_radius,
+            radial_segments,
+            circumferential_segments,
+        )
     )
-    return actor_from_primitive(
-        vertices,
-        faces,
-        centers=centers,
-        colors=colors,
-        scales=scales,
-        directions=directions,
+
+    if not has_per_instance_ring_features:
+        vertices, faces = fp.prim_ring(
+            inner_radius=float(inner_radius),
+            outer_radius=float(outer_radius),
+            radial_segments=int(radial_segments),
+            circumferential_segments=int(circumferential_segments),
+        )
+        return actor_from_primitive(
+            vertices,
+            faces,
+            centers=centers,
+            colors=colors,
+            scales=scales,
+            directions=directions,
+            opacity=opacity,
+            material=material,
+            enable_picking=enable_picking,
+        )
+
+    inner_radius_arr = _as_per_center(
+        inner_radius, value_name="inner_radius", cast=np.float64
+    )
+    outer_radius_arr = _as_per_center(
+        outer_radius, value_name="outer_radius", cast=np.float64
+    )
+    radial_segments_arr = _as_per_center(
+        radial_segments, value_name="radial_segments", cast=np.int64
+    )
+    circumferential_segments_arr = _as_per_center(
+        circumferential_segments,
+        value_name="circumferential_segments",
+        cast=np.int64,
+    )
+
+    all_vertices = []
+    all_faces = []
+    all_colors = []
+    face_offset = 0
+
+    for idx in range(n_centers):
+        vertices, faces = fp.prim_ring(
+            inner_radius=float(inner_radius_arr[idx]),
+            outer_radius=float(outer_radius_arr[idx]),
+            radial_segments=int(radial_segments_arr[idx]),
+            circumferential_segments=int(circumferential_segments_arr[idx]),
+        )
+
+        vertices = vertices.copy()
+
+        # Scale
+        vertices *= _scale_at(scales, idx)
+
+        # Rotate according to direction
+        dirs = _direction_at(directions, idx)
+        dir_abs = np.linalg.norm(dirs)
+        if dir_abs:
+            normal = np.array([1.0, 0.0, 0.0])
+            dirs = dirs / dir_abs
+            v = np.cross(normal, dirs)
+            c = np.dot(normal, dirs)
+
+            vmat = np.array([[0, -v[2], v[1]], [v[2], 0, -v[0]], [-v[1], v[0], 0]])
+
+            if c == -1.0:
+                rotation_matrix = -np.eye(3, dtype=np.float64)
+            else:
+                h = 1 / (1 + c)
+                rotation_matrix = (
+                    np.eye(3, dtype=np.float64) + vmat + (vmat.dot(vmat) * h)
+                )
+        else:
+            rotation_matrix = np.identity(3)
+
+        vertices = np.dot(rotation_matrix[:3, :3], vertices.T).T
+
+        # Translate to center
+        vertices += centers[idx]
+
+        all_vertices.append(vertices)
+        all_faces.append(faces + face_offset)
+        color_i = _color_at(colors, idx)
+        all_colors.append(np.repeat(color_i[np.newaxis, :], len(vertices), axis=0))
+
+        face_offset += len(vertices)
+
+    big_vertices = np.concatenate(all_vertices, axis=0)
+    big_faces = np.concatenate(all_faces, axis=0)
+    big_colors = np.concatenate(all_colors, axis=0)
+
+    obj = actor_from_primitive(
+        big_vertices,
+        big_faces,
+        centers=np.array([[0.0, 0.0, 0.0]]),
+        colors=big_colors,
         opacity=opacity,
         material=material,
         enable_picking=enable_picking,
+        repeat_primitive=False,
     )
+    obj.prim_count = n_centers
+    return obj
 
 
 class LineProjection(Points):

--- a/fury/actor/tests/test_planar.py
+++ b/fury/actor/tests/test_planar.py
@@ -5,6 +5,7 @@ import pytest
 
 from fury import actor, window
 from fury.actor.tests._helpers import validate_actors
+import fury.primitive as fp
 
 
 def test_square():
@@ -67,6 +68,86 @@ def test_ring():
     assert mean_g == 0 and mean_b == 0
 
     scene.remove(ring_actor_1)
+
+
+def test_ring_per_instance_actor_features():
+    centers = np.array([[0.0, 0.0, 0.0], [5.0, 0.0, 0.0]])
+    colors = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+    inner_radius = np.array([0.2, 0.6])
+    outer_radius = np.array([1.0, 1.8])
+    radial_segments = np.array([1, 2])
+    circumferential_segments = np.array([16, 24])
+
+    ring_actor = actor.ring(
+        centers=centers,
+        colors=colors,
+        inner_radius=inner_radius,
+        outer_radius=outer_radius,
+        radial_segments=radial_segments,
+        circumferential_segments=circumferential_segments,
+    )
+
+    npt.assert_equal(ring_actor.prim_count, 2)
+
+    verts_0, _ = fp.prim_ring(
+        inner_radius=inner_radius[0],
+        outer_radius=outer_radius[0],
+        radial_segments=radial_segments[0],
+        circumferential_segments=circumferential_segments[0],
+    )
+    verts_1, _ = fp.prim_ring(
+        inner_radius=inner_radius[1],
+        outer_radius=outer_radius[1],
+        radial_segments=radial_segments[1],
+        circumferential_segments=circumferential_segments[1],
+    )
+
+    n_verts_0 = len(verts_0)
+    n_verts_1 = len(verts_1)
+
+    positions = ring_actor.geometry.positions.view
+    colors_view = ring_actor.geometry.colors.view
+
+    ring0 = positions[:n_verts_0]
+    ring1 = positions[n_verts_0 : n_verts_0 + n_verts_1]
+
+    ring0_dist = np.sqrt(
+        (ring0[:, 0] - centers[0, 0]) ** 2 + (ring0[:, 1] - centers[0, 1]) ** 2
+    )
+    ring1_dist = np.sqrt(
+        (ring1[:, 0] - centers[1, 0]) ** 2 + (ring1[:, 1] - centers[1, 1]) ** 2
+    )
+
+    npt.assert_almost_equal(np.min(ring0_dist), inner_radius[0], decimal=6)
+    npt.assert_almost_equal(np.max(ring0_dist), outer_radius[0], decimal=6)
+    npt.assert_almost_equal(np.min(ring1_dist), inner_radius[1], decimal=6)
+    npt.assert_almost_equal(np.max(ring1_dist), outer_radius[1], decimal=6)
+
+    npt.assert_array_equal(
+        np.unique(colors_view[:n_verts_0], axis=0), np.array([[1.0, 0.0, 0.0]])
+    )
+    npt.assert_array_equal(
+        np.unique(colors_view[n_verts_0 : n_verts_0 + n_verts_1], axis=0),
+        np.array([[0.0, 1.0, 0.0]]),
+    )
+
+
+def test_ring_per_instance_actor_features_invalid_input():
+    centers = np.array([[0.0, 0.0, 0.0], [5.0, 0.0, 0.0]])
+
+    with pytest.raises(ValueError, match="inner_radius size should be 1 or equal"):
+        actor.ring(centers=centers, inner_radius=np.array([0.1, 0.2, 0.3]))
+
+    with pytest.raises(ValueError, match="outer_radius size should be 1 or equal"):
+        actor.ring(centers=centers, outer_radius=np.array([1.0, 2.0, 3.0]))
+
+    with pytest.raises(ValueError, match="radial_segments size should be 1 or equal"):
+        actor.ring(centers=centers, radial_segments=np.array([1, 2, 3]))
+
+    with pytest.raises(
+        ValueError, match="circumferential_segments size should be 1 or equal"
+    ):
+        actor.ring(centers=centers, circumferential_segments=np.array([16, 24, 32]))
 
 
 def test_point():


### PR DESCRIPTION
## Summary
This PR addresses issue #1091 by updating Ring2D to support per-instance actor-specific parameters when creating multiple rings in one actor.

## What changed
- Added support for scalar or ndarray inputs for:
  - `inner_radius`
  - `outer_radius`
  - `radial_segments`
  - `circumferential_segments`
- Preserved existing behavior when scalar values are provided (single shared ring geometry path).
- Added validation for array-size mismatches (must be size 1 or match number of centers).

## Tests
- Added tests for per-instance Ring2D feature inputs.
- Added tests for invalid per-instance input sizes.
- Verified:
  - Ring-focused tests pass.
  - Planar actor test module passes.

## Motivation
Previously, multiple ring instances could differ by position/color/direction/scale, but ring-specific geometry parameters were shared across all instances. This PR enables per-instance geometry control for Ring2D, as discussed in the issue thread.

## Scope
- This PR intentionally focuses on Ring2D as a first step.
- It does not change other actors (e.g., cone height/other per-instance actor-specific properties).

## Branch/Target
- Source branch: `feature-ring2d-instance-features`
- Target branch: `v2`

## Checklist
- [x] Feature implemented
- [x] Tests added/updated
- [x] Existing related tests pass
- [x] Pre-commit checks addressed