### PR TITLE
fix: correct typo in boys2rgb - z4 should be z2*z2 not z*z2 #857

### DIFF
--- a/fury/colormap.py
+++ b/fury/colormap.py
@@ -144,7 +144,7 @@ def boys2rgb(v):
     y3 = y * y2
     z3 = z * z2
 
-    z4 = z * z2
+    z4 = z2 * z2
 
     xy = x * y
     xz = x * z


### PR DESCRIPTION
Fixes #857 

The variable `z4` in `boys2rgb` was incorrectly computed as `z * z2` 
(which equals z³) instead of `z2 * z2` (which equals z⁴). 

This can be verified against the original MATLAB code:
https://cagataydemiralp.io/projects/boys/line2rgb.m