### PR TITLE
Remove the `_frame_count == 2` workaround previously used to trigger

### DIFF
--- a/fury/ui/core.py
+++ b/fury/ui/core.py
@@ -965,6 +965,7 @@ class TextBlock2D(UI):
         self._bg_size = size
 
         self._last_rendered_size = (0, 0)
+        self._layout_dirty = True
 
         if self._bg_size is None and not self.dynamic_bbox:
             raise ValueError("TextBlock size is required as it is not dynamic.")
@@ -999,11 +1000,15 @@ class TextBlock2D(UI):
         size : (int, int)
             The new (width, height) in pixels.
         """
+        self._bg_size = size
         self.actor.max_width = size[1]
         self.update_bounding_box(size=size)
+        self.mark_layout_dirty()
 
     def update_layout(self):
         """Update the component layout based on current text dimensions."""
+        self._layout_dirty = False
+
         current_w, current_h = self.get_text_actor_size()
         last_w, last_h = self._last_rendered_size
 
@@ -1014,6 +1019,10 @@ class TextBlock2D(UI):
                 self.update_bounding_box()
             else:
                 self.update_alignment()
+
+    def mark_layout_dirty(self):
+        """Mark this component as needing a layout update on the next frame."""
+        self._layout_dirty = True
 
     def _get_actors(self):
         """Get the actors composing this UI component.
@@ -1071,8 +1080,7 @@ class TextBlock2D(UI):
         """
         self._message = text
         self.actor.set_markdown(self.get_formatted_text(text))
-        if self.dynamic_bbox:
-            self.update_bounding_box()
+        self.mark_layout_dirty()
 
     @property
     def font_size(self):
@@ -1095,8 +1103,7 @@ class TextBlock2D(UI):
             Text font size.
         """
         self.actor.font_size = size
-        if self.dynamic_bbox:
-            self.update_bounding_box()
+        self.mark_layout_dirty()
 
     @property
     def font_family(self):
@@ -1119,8 +1126,7 @@ class TextBlock2D(UI):
             The font family.
         """
         self.actor.family = family
-        if self.dynamic_bbox:
-            self.update_bounding_box()
+        self.mark_layout_dirty()
 
     @property
     def justification(self):
@@ -1142,8 +1148,11 @@ class TextBlock2D(UI):
         justification : str
             Possible values are left, center, right.
         """
+        if justification.lower() not in ("left", "center", "right"):
+            msg = "Text can only be justified left, center and right."
+            raise ValueError(msg)
         self._justification = justification
-        self.update_alignment()
+        self.mark_layout_dirty()
 
     @property
     def vertical_justification(self):
@@ -1165,8 +1174,11 @@ class TextBlock2D(UI):
         vertical_justification : str
             Possible values are top, middle, bottom.
         """
+        if vertical_justification.lower() not in ("top", "middle", "bottom"):
+            msg = "Vertical justification must be: top, middle or bottom."
+            raise ValueError(msg)
         self._vertical_justification = vertical_justification
-        self.update_alignment()
+        self.mark_layout_dirty()
 
     @property
     def bold(self):
@@ -1290,8 +1302,7 @@ class TextBlock2D(UI):
             If True, the bounding box resizes to content.
         """
         self._dynamic_bbox = flag
-        if flag:
-            self.update_bounding_box()
+        self.mark_layout_dirty()
 
     def update_alignment(self):
         """Update the text actor alignment within the bounding box."""

--- a/fury/window.py
+++ b/fury/window.py
@@ -308,6 +308,21 @@ def remove_ui_from_scene(ui_scene, ui_obj):
         remove_ui_from_scene(ui_scene, child)
 
 
+def _update_layout_recursive(ui_obj):
+    """Recursively call update_layout on UI elements marked as dirty.
+
+    Parameters
+    ----------
+    ui_obj : UI
+        The UI element to check and update, along with all its children.
+    """
+    if hasattr(ui_obj, "update_layout") and getattr(ui_obj, "_layout_dirty", False):
+        ui_obj.update_layout()
+
+    for child in ui_obj._children:
+        _update_layout_recursive(child)
+
+
 def create_screen(
     renderer, *, rect=None, scene=None, camera=None, controller=None, camera_light=True
 ):
@@ -395,7 +410,7 @@ def update_viewports(screens, screen_bbs):
         update_camera(screen.camera, screen.size, screen.scene)
 
 
-def render_screens(renderer, screens, stats=None, is_dirty=False):
+def render_screens(renderer, screens, stats=None):
     """Render multiple screens within a single renderer update cycle.
 
     Parameters
@@ -405,19 +420,15 @@ def render_screens(renderer, screens, stats=None, is_dirty=False):
     screens : list of Screen
         The list of Screen objects to render.
     stats : Stats, optional
-        Stats helper to display FPS overlay.
-    is_dirty : bool, optional
-        If True, triggers layout recalculations for UI elements."""
+        Stats helper to display FPS overlay."""
     if stats is not None:
         stats.start()
 
     for screen in screens:
         scene_root = screen.scene
 
-        if is_dirty:
-            for ui_element in scene_root.ui_elements:
-                if hasattr(ui_element, "update_layout"):
-                    ui_element.update_layout()
+        for ui_element in scene_root.ui_elements:
+            _update_layout_recursive(ui_element)
 
         screen.viewport.render(scene_root.main_scene, screen.camera, flush=False)
         screen.viewport.render(scene_root.ui_scene, scene_root.ui_camera, flush=False)
@@ -628,7 +639,6 @@ class ShowManager:
         self._is_initial_resize = None
         self._show_fps = show_fps
         self._max_fps = max_fps
-        self._frame_count = 0
         self._window_type = self._setup_window(window_type)
         self._is_dragging = False
         self._drag_target = None
@@ -1132,11 +1142,7 @@ class ShowManager:
             self._stats = Stats(self.renderer)
             self._stats_initialized = True
 
-        self._frame_count += 1
-        update_layout = True if self._frame_count == 2 else False
-        render_screens(
-            self.renderer, self.screens, stats=self._stats, is_dirty=update_layout
-        )
+        render_screens(self.renderer, self.screens, stats=self._stats)
         self._imgui and self._imgui.render()
         self.window.request_draw()
 


### PR DESCRIPTION
## Summary

Removes the `_frame_count == 2` layout workaround and replaces it with a per-element `_layout_dirty` flag in `TextBlock2D`.

## Problem

The previous frame-based logic recalculated layout only during initial render and did not correctly handle runtime changes such as updates to `message`, `font_size`, or `justification`.

## Solution

Layout-affecting setters now mark the element as dirty.  
During rendering, `render_screens` recursively traverses the UI tree and calls `update_layout()` only for elements where `_layout_dirty` is `True`, once `_aabb` becomes valid.

## Tests

Added a regression test verifying that updating `TextBlock2D.message` at runtime triggers a layout recalculation.

Closes #1090