### PR TITLE
Fix: Opacity/alpha transparency not applied in primitive actors

### DIFF
--- a/fury/actor/core.py
+++ b/fury/actor/core.py
@@ -422,6 +422,13 @@ def actor_from_primitive(
         else:
             big_colors[:, 3] *= opacity
 
+    # Detect transparency from explicit opacity or from vertex alpha channel
+    is_transparent = False
+    if isinstance(opacity, (int, float)) and opacity < 1.0:
+        is_transparent = True
+    elif big_colors.shape[1] == 4 and np.any(big_colors[:, 3] < 1.0):
+        is_transparent = True
+
     geo = buffer_to_geometry(
         indices=big_faces.astype("int32"),
         positions=big_vertices.astype("float32"),
@@ -435,6 +442,9 @@ def actor_from_primitive(
         flat_shading=not smooth,
         wireframe=wireframe,
         wireframe_thickness=wireframe_thickness,
+        opacity=opacity if isinstance(opacity, (int, float)) else 1.0,
+        alpha_mode="weighted_blend" if is_transparent else "blend",
+        depth_write=not is_transparent,
     )
     obj = create_mesh(geometry=geo, material=mat)
     if not repeat_primitive:

--- a/fury/actor/core.py
+++ b/fury/actor/core.py
@@ -442,7 +442,6 @@ def actor_from_primitive(
         flat_shading=not smooth,
         wireframe=wireframe,
         wireframe_thickness=wireframe_thickness,
-        opacity=opacity if isinstance(opacity, (int, float)) else 1.0,
         alpha_mode="weighted_blend" if is_transparent else "blend",
         depth_write=not is_transparent,
     )

--- a/fury/actor/core.py
+++ b/fury/actor/core.py
@@ -442,7 +442,7 @@ def actor_from_primitive(
         flat_shading=not smooth,
         wireframe=wireframe,
         wireframe_thickness=wireframe_thickness,
-        alpha_mode="weighted_blend" if is_transparent else "blend",
+        alpha_mode="weighted_blend" if is_transparent else "auto",
         depth_write=not is_transparent,
     )
     obj = create_mesh(geometry=geo, material=mat)

--- a/fury/actor/core.py
+++ b/fury/actor/core.py
@@ -422,7 +422,6 @@ def actor_from_primitive(
         else:
             big_colors[:, 3] *= opacity
 
-    # Detect transparency from explicit opacity or from vertex alpha channel
     is_transparent = False
     if isinstance(opacity, (int, float)) and opacity < 1.0:
         is_transparent = True

--- a/fury/actor/tests/test_core.py
+++ b/fury/actor/tests/test_core.py
@@ -211,3 +211,75 @@ def test_actor_from_primitive_position(sphere_prim):
     np.testing.assert_array_equal(
         obj.local.position, np.array([5, 10, 15], dtype=np.float32)
     )
+
+
+def test_actor_from_primitive_transparency(sphere_prim):
+    vertices, faces = sphere_prim
+    centers = np.array([[0, 0, 0]], dtype=np.float32)
+    rgb = np.array([[1, 0, 0]])
+    rgba_opaque = np.array([[1, 0, 0, 1.0]])
+    rgba_transparent = np.array([[1, 0, 1, 0.3]])
+
+    obj = actor_from_primitive(vertices, faces, centers, colors=rgb)
+    assert obj.material.alpha_mode == "auto"
+    assert obj.material.depth_write is True
+
+    obj = actor_from_primitive(vertices, faces, centers, colors=rgb, opacity=1.0)
+    assert obj.material.alpha_mode == "auto"
+    assert obj.material.depth_write is True
+
+    obj = actor_from_primitive(vertices, faces, centers, colors=rgba_opaque)
+    assert obj.material.alpha_mode == "auto"
+    assert obj.material.depth_write is True
+
+    obj = actor_from_primitive(vertices, faces, centers, colors=rgb, opacity=0.5)
+    assert obj.material.alpha_mode == "weighted_blend"
+    assert obj.material.depth_write is False
+
+    obj = actor_from_primitive(vertices, faces, centers, colors=rgba_transparent)
+    assert obj.material.alpha_mode == "weighted_blend"
+    assert obj.material.depth_write is False
+
+    obj = actor_from_primitive(vertices, faces, centers, colors=rgb, opacity=0.4)
+    np.testing.assert_allclose(obj.geometry.colors.data[:, 3], 0.4, atol=0.01)
+
+    rgba_half = np.array([[1, 0, 0, 0.5]])
+    obj = actor_from_primitive(vertices, faces, centers, colors=rgba_half, opacity=0.5)
+    np.testing.assert_allclose(obj.geometry.colors.data[:, 3], 0.25, atol=0.01)
+    assert obj.material.alpha_mode == "weighted_blend"
+    assert obj.material.depth_write is False
+    
+def test_actor_from_primitive_transparency_visual(sphere_prim):
+    vertices, faces = sphere_prim
+    centers = np.array([[0, 0, 0]], dtype=np.float32)
+    colors = np.array([[1, 0, 0]])
+
+    scene = window.Scene(background=(0, 1, 0))
+
+    opaque = actor_from_primitive(vertices, faces, centers, colors=colors)
+    scene.add(opaque)
+    fname = "transparency_opaque_test.png"
+    window.snapshot(scene=scene, fname=fname)
+    img_array_op = np.array(Image.open(fname))
+    mid = img_array_op[img_array_op.shape[0] // 2, img_array_op.shape[1] // 2]
+    assert mid[0] > mid[1] and mid[0] > mid[2]
+    scene.remove(opaque)
+
+    transparent = actor_from_primitive(
+        vertices, faces, centers, colors=colors, opacity=0.5
+    )
+    scene.add(transparent)
+    fname = "transparency_semi_test.png"
+    window.snapshot(scene=scene, fname=fname)
+    img_array_tr = np.array(Image.open(fname))
+    mean_r_tr, mean_g_tr, mean_b_tr, _ = np.mean(
+        img_array_tr.reshape(-1, img_array_tr.shape[2]), axis=0
+    )
+    assert mean_r_tr > 0
+    
+    mean_r_op, mean_g_op, mean_b_op, _ = np.mean(
+        img_array_op.reshape(-1, img_array_op.shape[2]), axis=0
+    )
+    assert mean_r_op > 0
+    assert mean_g_tr > mean_g_op
+    scene.remove(transparent)

--- a/fury/actor/tests/test_core.py
+++ b/fury/actor/tests/test_core.py
@@ -248,7 +248,8 @@ def test_actor_from_primitive_transparency(sphere_prim):
     np.testing.assert_allclose(obj.geometry.colors.data[:, 3], 0.25, atol=0.01)
     assert obj.material.alpha_mode == "weighted_blend"
     assert obj.material.depth_write is False
-    
+
+
 def test_actor_from_primitive_transparency_visual(sphere_prim):
     vertices, faces = sphere_prim
     centers = np.array([[0, 0, 0]], dtype=np.float32)
@@ -276,7 +277,7 @@ def test_actor_from_primitive_transparency_visual(sphere_prim):
         img_array_tr.reshape(-1, img_array_tr.shape[2]), axis=0
     )
     assert mean_r_tr > 0
-    
+
     mean_r_op, mean_g_op, mean_b_op, _ = np.mean(
         img_array_op.reshape(-1, img_array_op.shape[2]), axis=0
     )


### PR DESCRIPTION
Fixes #1119

`actor_from_primitive` did not configure transparency-related properties when creating mesh materials, causing incorrect rendering for RGBA colors and explicit opacity.

This update:

-   Detects transparency (alpha \< 1 or opacity \< 1)
-   Passes `opacity`
-   Sets `alpha_mode="weighted_blend"` for transparent actors
-   Sets `depth_write=False` to prevent depth artifacts

## Before

Sphere with `colors=(1, 0, 1, 0.3)` incorrect transparency rendering.

<img width="400" height="427" alt="Screenshot 2026-02-22 162008" src="https://github.com/user-attachments/assets/eed353b3-c2d0-4cc8-ad66-88a62153c231" />

## After

Sphere renders semi-transparent smoothly as expected.

<img width="401" height="425" alt="Screenshot 2026-02-22 162113" src="https://github.com/user-attachments/assets/7cafd928-9ede-44fc-8129-7438dd1ae737" />

