### PR TITLE
Fix: Billboard bounding box not accounting for visual size

### DIFF
--- a/fury/actor/_billboard.py
+++ b/fury/actor/_billboard.py
@@ -152,6 +152,36 @@ class Billboard(Mesh):
         self._billboard_centers = np.empty((0, 3), dtype=np.float32)
         self._billboard_sizes = np.empty((0, 2), dtype=np.float32)
 
+    def get_bounding_box(self):
+        """Compute the axis-aligned bounding box including billboard visual size.
+
+        Returns
+        -------
+        ndarray, shape (2, 3), or None
+            Axis-aligned bounding box as ``[[min, min, min], [max, max, max]]``.
+        """
+        centers = self._billboard_centers
+        sizes = self._billboard_sizes
+
+        if centers.size == 0 or sizes.size == 0:
+            return super().get_bounding_box()
+
+        half_extents = sizes.max(axis=1) / 2.0
+
+        expanded_min = centers - half_extents[:, np.newaxis]
+        expanded_max = centers + half_extents[:, np.newaxis]
+
+        aabb = np.empty((2, 3), dtype=np.float64)
+        aabb[0] = expanded_min.min(axis=0)
+        aabb[1] = expanded_max.max(axis=0)
+
+        parent_aabb = super().get_bounding_box()
+        if parent_aabb is not None:
+            aabb[0] = np.minimum(aabb[0], parent_aabb[0])
+            aabb[1] = np.maximum(aabb[1], parent_aabb[1])
+
+        return aabb
+
     @property
     def billboard_count(self):
         """Get the number of billboards in this actor.

--- a/fury/actor/tests/test_billboard.py
+++ b/fury/actor/tests/test_billboard.py
@@ -223,3 +223,59 @@ def _assert_red_visible(image):
     has_red = np.any(red > 50)
     if not has_red:
         raise AssertionError("No visible red pixels found in rendered billboard")
+
+
+def test_billboard_bounding_box():
+    bb = actor.billboard(
+        centers=np.array([[0.0, 0.0, 0.0]]),
+        sizes=(4.0, 4.0),
+    )
+    aabb = bb.get_bounding_box()
+    npt.assert_allclose(aabb[0], [-2, -2, -2])
+    npt.assert_allclose(aabb[1], [2, 2, 2])
+
+
+def test_billboard_sphere_bounding_box():
+    centers = np.array(
+        [[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [5.0, 5.0, 5.0]],
+        dtype=np.float32,
+    )
+    radii = np.array([2.0, 3.0, 1.0], dtype=np.float32)
+
+    bb = actor.sphere(centers, radii=radii, impostor=True)
+    aabb = bb.get_bounding_box()
+
+    npt.assert_allclose(aabb[0], [-2, -3, -3])
+    npt.assert_allclose(aabb[1], [13, 6, 6])
+
+
+def test_billboard_bounding_box_single_sphere():
+    bb = actor.sphere(
+        centers=np.array([[0.0, 0.0, 0.0]]),
+        radii=5.0,
+        impostor=True,
+    )
+    bsphere = bb.get_world_bounding_sphere()
+
+    npt.assert_allclose(bsphere[:3], [0, 0, 0], atol=1e-6)
+    npt.assert_allclose(bsphere[3], 5.0 * np.sqrt(3), atol=0.01)
+
+
+def test_billboard_bounding_box_camera_framing():
+    scene = window.Scene()
+    scene.background = (0, 0, 0)
+
+    bb = actor.sphere(
+        centers=np.array([[0.0, 0.0, 0.0]]),
+        colors=np.array([[1.0, 0.0, 0.0]]),
+        radii=5.0,
+        impostor=True,
+    )
+    scene.add(bb)
+
+    arr = window.snapshot(scene=scene, return_array=True)
+    assert arr is not None
+
+    _assert_red_visible(arr)
+
+    scene.clear()


### PR DESCRIPTION
Fixes #1145

Billboard actors did not include the visual quad/impostor size in their bounding box, causing the camera to frame them incorrectly (excessive zoom on initial display).

This update:

- Overrides `get_bounding_box` in `Billboard` to expand by each billboard's visual size
- Ensures `camera.show_object` computes correct framing for billboard spheres.
- Adds tests for bounding box correctness and camera framing

### Before


<img width="378" height="323" alt="Image" src="https://github.com/user-attachments/assets/2d0a9063-bb5b-4de3-ae50-b659fc2a03bd" />
<img width="372" height="326" alt="Image" src="https://github.com/user-attachments/assets/915d7135-93f2-48dd-a0a8-b085452a2925" />
<img width="373" height="336" alt="Image" src="https://github.com/user-attachments/assets/3af9f6d7-4b5c-4bf4-8581-4fcd51a0dc0c" />


### After

<img width="371" height="423" alt="Screenshot 2026-03-05 235239" src="https://github.com/user-attachments/assets/22ebd826-2064-487d-84a5-4847ac43f231" />
<img width="371" height="422" alt="Screenshot 2026-03-05 235406" src="https://github.com/user-attachments/assets/459ec09e-5b79-4bb7-8c40-a88014a6b97a" />
<img width="375" height="428" alt="Screenshot 2026-03-05 235458" src="https://github.com/user-attachments/assets/b5a91a80-6241-4921-9315-45f93c8349a3" />
