### PR TITLE
BF/MTN: Bounding box for gpu streamtube actor

### DIFF
--- a/fury/actor/curved.py
+++ b/fury/actor/curved.py
@@ -1508,6 +1508,16 @@ def _create_streamtube_baked(
     normals_data = np.zeros((total_vertices, 3), dtype=np.float32)
     colors_data = np.zeros((total_vertices, color_components), dtype=np.float32)
     indices_data = np.zeros((total_triangles, 3), dtype=np.uint32)
+    min_point = max_point = np.zeros(3, dtype=np.float32)
+    for line in lines_arr:
+        if line.size == 0:
+            continue
+        line_min = line.min(axis=0)
+        line_max = line.max(axis=0)
+        min_point = np.minimum(min_point, line_min)
+        max_point = np.maximum(max_point, line_max)
+    positions_data[0] = min_point
+    positions_data[1] = max_point
 
     if use_per_point_colors:
         vertex_idx = 0

--- a/fury/actor/tests/test_curved.py
+++ b/fury/actor/tests/test_curved.py
@@ -421,6 +421,34 @@ def test_streamlines_filtered_streamlines_and_copy_src_usage(monkeypatch):
     assert calls == [wobj.geometry.positions, wobj.geometry.positions]
 
 
+def test_streamtube_geometry_min_max_bounds():
+    """Test that streamtube geometry stores min/max points correctly."""
+    lines = [
+        np.array([[0.0, 0.0, 0.0], [1.0, 2.0, 3.0], [2.0, 4.0, 6.0]], dtype=np.float32),
+        np.array([[-5.0, -2.0, -1.0], [0.5, 1.0, 1.5]], dtype=np.float32),
+        np.array([[3.0, 8.0, 4.0], [4.0, 10.0, 5.0]], dtype=np.float32),
+    ]
+
+    mesh = actor.streamtube(
+        lines, colors=(1.0, 0.0, 0.0), radius=0.1, segments=6, backend="gpu"
+    )
+
+    positions = mesh.geometry.positions.data
+
+    expected_min = np.array([-5.0, -2.0, -1.0], dtype=np.float32)
+    expected_max = np.array([4.0, 10.0, 6.0], dtype=np.float32)
+
+    actual_min = positions[0]
+    actual_max = positions[1]
+
+    assert np.allclose(actual_min, expected_min), (
+        f"Min point mismatch: expected {expected_min}, got {actual_min}"
+    )
+    assert np.allclose(actual_max, expected_max), (
+        f"Max point mismatch: expected {expected_max}, got {actual_max}"
+    )
+
+
 def test_actor_from_primitive_wireframe():
     """Test wireframe and wireframe_thickness for primitive actors."""
     sphere_actor = actor.sphere(

--- a/fury/shader.py
+++ b/fury/shader.py
@@ -76,7 +76,7 @@ class VectorFieldComputeShader(BaseShader):
         """
         return {}
 
-    def get_bindings(self, wobject, _shared):
+    def get_bindings(self, wobject, _shared, _scene):
         """Get the bindings for the vector field compute shader.
 
         Parameters
@@ -85,6 +85,8 @@ class VectorFieldComputeShader(BaseShader):
             The vector field object to be rendered.
         _shared : dict
             Shared information for the shader.
+        _scene : Scene
+            The scene containing the object to be rendered.
 
         Returns
         -------
@@ -315,7 +317,7 @@ class _StreamlineBakingShader(BaseShader):
         """
         return {}
 
-    def get_bindings(self, wobject, _shared):
+    def get_bindings(self, wobject, _shared, _scene):
         """Get the bindings for the streamline baking compute shader.
 
         Parameters
@@ -324,6 +326,8 @@ class _StreamlineBakingShader(BaseShader):
             The streamline object to be rendered.
         _shared : dict
             Shared information for the shader.
+        _scene : Scene
+            The scene containing the object to be rendered.
 
         Returns
         -------
@@ -488,7 +492,7 @@ class SphGlyphComputeShader(BaseShader):
         """
         return {}
 
-    def get_bindings(self, wobject, _shared):
+    def get_bindings(self, wobject, _shared, _scene):
         """Get the bindings for the spherical harmonic glyph compute shader.
 
         Parameters
@@ -497,6 +501,8 @@ class SphGlyphComputeShader(BaseShader):
             The spherical glyph object to be rendered.
         _shared : dict
             Shared information for the shader.
+        _scene : Scene
+            The scene containing the object to be rendered.
 
         Returns
         -------
@@ -606,7 +612,7 @@ class LineProjectionComputeShader(BaseShader):
             "indices": (n, 1, 1),
         }
 
-    def get_bindings(self, wobject, _shared):
+    def get_bindings(self, wobject, _shared, _scene):
         """Get the bindings for the line projection compute shader.
 
         Parameters
@@ -615,6 +621,8 @@ class LineProjectionComputeShader(BaseShader):
             The line projection object to be rendered.
         _shared : dict
             Shared information for the shader.
+        _scene : Scene
+            The scene containing the object to be rendered.
 
         Returns
         -------
@@ -783,7 +791,7 @@ class _StreamtubeBakingShader(BaseShader):
 
         return {}
 
-    def get_bindings(self, wobject, _shared):
+    def get_bindings(self, wobject, _shared, _scene):
         """Describe storage buffers used by the compute shader.
 
         Parameters
@@ -792,6 +800,8 @@ class _StreamtubeBakingShader(BaseShader):
             Mesh whose buffers are bound to the compute shader.
         _shared : dict
             Shared pipeline state (unused).
+        _scene : Scene
+            The scene containing the object to be rendered (unused).
 
         Returns
         -------

--- a/fury/tests/test_shader.py
+++ b/fury/tests/test_shader.py
@@ -238,7 +238,7 @@ def test__StreamtubeBakingShader_setup_and_bindings():
     render_info = shader.get_render_info(wobject, {})
     assert render_info["indices"] == (expected_groups, 1, 1)
 
-    bindings = shader.get_bindings_info(wobject, {})
+    bindings = shader.get_bindings_info(wobject, {}, None)
     assert set(bindings.keys()) == {0}
     assert set(bindings[0].keys()) == {0, 1, 2, 3, 4, 5, 6, 7, 8}
     assert bindings[0][0].resource is wobject.line_buffer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "pillow>=10.4.0",
     "packaging>=23.0",
     "lazy_loader>=0.4",
-    "pygfx>=0.14.0",
+    "pygfx>=0.16.0",
     "glfw>=2.7.0",
     "aiohttp"
 ]

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -5,6 +5,6 @@ scipy>=1.13.0
 pillow>=10.4.0
 packaging>=23.0
 lazy_loader>=0.4
-pygfx>=0.14.0
+pygfx>=0.16.0
 glfw>=2.7.0
 aiohttp


### PR DESCRIPTION
The positions were calculated in gpu thus making compute incorrect bounding box.
Showing incorrect position of the camera. You can test `viz_streamtube.py` in example with and without changes from this PR.
The hidden failure was from the new pygfx version. updated the codebase and test cases for the same.

