### PR TITLE
Fix: Panel2D crashes when used without borders (#1155)

### DIFF
--- a/fury/ui/containers.py
+++ b/fury/ui/containers.py
@@ -1,6 +1,6 @@
 """UI container module."""
 
-from warnings import warn
+import logging
 
 import numpy as np
 
@@ -414,7 +414,7 @@ class Panel2D(UI):
         """
 
         if not self.has_border:
-            warn("Border is not present, border color is not available.", stacklevel=2)
+            logging.warning("Border is not present, border color is not available.")
             return []
         return [self.borders[side].color for side in self.border_sides]
 
@@ -433,9 +433,8 @@ class Panel2D(UI):
             raise ValueError(f"{side} not a valid border side")
 
         if not self.has_border:
-            warn(
-                "Border is not present, setting border color will be ignored.",
-                stacklevel=2,
+            logging.warning(
+                "Border is not present, setting border color will be ignored."
             )
             return
 
@@ -453,7 +452,7 @@ class Panel2D(UI):
         """
 
         if not self.has_border:
-            warn("Border is not present, border width is not available.", stacklevel=2)
+            logging.warning("Border is not present, border width is not available.")
             return []
 
         widths = []
@@ -479,9 +478,8 @@ class Panel2D(UI):
         side, border_width = side_width
 
         if not self.has_border:
-            warn(
-                "Border is not present, setting border width will be ignored.",
-                stacklevel=2,
+            logging.warning(
+                "Border is not present, setting border width will be ignored."
             )
             return
 

--- a/fury/ui/containers.py
+++ b/fury/ui/containers.py
@@ -1,6 +1,6 @@
 """UI container module."""
 
-# from warnings import warn
+from warnings import warn
 
 import numpy as np
 
@@ -414,6 +414,7 @@ class Panel2D(UI):
         """
 
         if not self.has_border:
+            warn("Border is not present, border color is not available.", stacklevel=2)
             return []
         return [self.borders[side].color for side in self.border_sides]
 
@@ -432,6 +433,10 @@ class Panel2D(UI):
             raise ValueError(f"{side} not a valid border side")
 
         if not self.has_border:
+            warn(
+                "Border is not present, setting border color will be ignored.",
+                stacklevel=2,
+            )
             return
 
         self.borders[side].color = color
@@ -448,6 +453,7 @@ class Panel2D(UI):
         """
 
         if not self.has_border:
+            warn("Border is not present, border width is not available.", stacklevel=2)
             return []
 
         widths = []
@@ -473,6 +479,10 @@ class Panel2D(UI):
         side, border_width = side_width
 
         if not self.has_border:
+            warn(
+                "Border is not present, setting border width will be ignored.",
+                stacklevel=2,
+            )
             return
 
         if side.lower() in ["left", "right"]:

--- a/fury/ui/containers.py
+++ b/fury/ui/containers.py
@@ -134,8 +134,9 @@ class Panel2D(UI):
         actors = []
 
         actors.extend(self.background.actors)
-        for border in self.borders.values():
-            actors.extend(border.actors)
+        if self.has_border:
+            for border in self.borders.values():
+                actors.extend(border.actors)
 
         return actors
 
@@ -185,7 +186,7 @@ class Panel2D(UI):
         for element, offset in self.element_offsets:
             if element == self.background:
                 element.z_order = self.z_order
-            elif element in self.borders.values():
+            elif self.has_border and element in self.borders.values():
                 element.z_order = self.z_order + 1
             else:
                 element.z_order = self.z_order + 2
@@ -395,6 +396,8 @@ class Panel2D(UI):
 
     def update_border_coords(self):
         """Update the coordinates of the borders."""
+        if not self.has_border:
+            return
 
         for key in self.borders.keys():
             self.update_element(self.borders[key], self.border_coords[key])
@@ -410,6 +413,8 @@ class Panel2D(UI):
             borders, respectively.
         """
 
+        if not self.has_border:
+            return []
         return [self.borders[side].color for side in self.border_sides]
 
     @border_color.setter
@@ -426,6 +431,9 @@ class Panel2D(UI):
         if side.lower() not in ["left", "right", "top", "bottom"]:
             raise ValueError(f"{side} not a valid border side")
 
+        if not self.has_border:
+            return
+
         self.borders[side].color = color
 
     @property
@@ -438,6 +446,9 @@ class Panel2D(UI):
             A list containing the width (for left/right) and height (for top/bottom)
             of the borders.
         """
+
+        if not self.has_border:
+            return []
 
         widths = []
 
@@ -460,6 +471,9 @@ class Panel2D(UI):
             Iterable `[side, width]` containing the side (str) and the width (float).
         """
         side, border_width = side_width
+
+        if not self.has_border:
+            return
 
         if side.lower() in ["left", "right"]:
             self.borders[side].width = border_width

--- a/fury/ui/tests/test_containers.py
+++ b/fury/ui/tests/test_containers.py
@@ -1,7 +1,6 @@
 """Test containers module."""
 
 from os.path import join as pjoin
-import warnings
 
 from PIL import Image
 import numpy as np
@@ -133,12 +132,9 @@ def test_panel2d_no_border_actors_and_scene():
     panel.add_element(child, (0.5, 0.5))
     panel._update_actors_position()
 
-    # Border properties should warn and return empty when has_border=False
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        assert panel.border_color == []
-        assert panel.border_width == []
-        assert len(w) == 2
+    # Border properties should return empty when has_border=False
+    assert panel.border_color == []
+    assert panel.border_width == []
     panel.update_border_coords()
     panel.resize((300, 300))
 

--- a/fury/ui/tests/test_containers.py
+++ b/fury/ui/tests/test_containers.py
@@ -112,6 +112,33 @@ def test_panel2d_add_remove_element():
         panel.remove_element(mock_child)
 
 
+def test_panel2d_no_border_actors_and_scene():
+    """Test Panel2D without borders can return actors and be added to a scene."""
+    panel = ui.Panel2D(size=(200, 200))
+
+    # _get_actors should work without borders
+    actors = panel.actors
+    assert len(actors) > 0
+
+    # _update_actors_position should work without borders
+    panel.set_position((10, 10))
+
+    # Adding to a scene should not raise
+    scene = window.Scene()
+    scene.add(panel)
+
+    # Adding child elements should also work
+    child = ui.Rectangle2D(size=(20, 20))
+    panel.add_element(child, (0.5, 0.5))
+    panel._update_actors_position()
+
+    # Border properties should not raise when has_border=False
+    assert panel.border_color == []
+    assert panel.border_width == []
+    panel.update_border_coords()
+    panel.resize((300, 300))
+
+
 def test_panel2d_z_ordering():
     """Test that internal Z-ordering is set correctly by _update_actors_position."""
     panel = ui.Panel2D(size=(100, 100), has_border=True, border_width=1)

--- a/fury/ui/tests/test_containers.py
+++ b/fury/ui/tests/test_containers.py
@@ -1,6 +1,7 @@
 """Test containers module."""
 
 from os.path import join as pjoin
+import warnings
 
 from PIL import Image
 import numpy as np
@@ -132,9 +133,12 @@ def test_panel2d_no_border_actors_and_scene():
     panel.add_element(child, (0.5, 0.5))
     panel._update_actors_position()
 
-    # Border properties should not raise when has_border=False
-    assert panel.border_color == []
-    assert panel.border_width == []
+    # Border properties should warn and return empty when has_border=False
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert panel.border_color == []
+        assert panel.border_width == []
+        assert len(w) == 2
     panel.update_border_coords()
     panel.resize((300, 300))
 


### PR DESCRIPTION
Fixes #1155 

This pull request improves the robustness of the `Panel2D` UI container when borders are disabled (`has_border=False`). Several methods now safely handle the absence of borders, preventing potential errors and ensuring consistent behavior. Additionally, a new test verifies that `Panel2D` functions correctly without borders.

**Robustness improvements for borderless `Panel2D`:**

* Guard clauses were added to methods such as `_get_actors`, `_update_actors_position`, `update_border_coords`, `border_color`, and `border_width` to ensure they handle the case where `has_border` is `False`, returning empty lists or exiting early as appropriate. [[1]](diffhunk://#diff-53918b2a3199d9c46ad955f4e1c36bd0c776fd5228674415f4be2306080f23bdR137) [[2]](diffhunk://#diff-53918b2a3199d9c46ad955f4e1c36bd0c776fd5228674415f4be2306080f23bdL188-R189) [[3]](diffhunk://#diff-53918b2a3199d9c46ad955f4e1c36bd0c776fd5228674415f4be2306080f23bdR399-R400) [[4]](diffhunk://#diff-53918b2a3199d9c46ad955f4e1c36bd0c776fd5228674415f4be2306080f23bdR416-R417) [[5]](diffhunk://#diff-53918b2a3199d9c46ad955f4e1c36bd0c776fd5228674415f4be2306080f23bdR434-R436) [[6]](diffhunk://#diff-53918b2a3199d9c46ad955f4e1c36bd0c776fd5228674415f4be2306080f23bdR450-R452) [[7]](diffhunk://#diff-53918b2a3199d9c46ad955f4e1c36bd0c776fd5228674415f4be2306080f23bdR475-R477)

**Testing improvements:**

* Added `test_panel2d_no_border_actors_and_scene` to verify that `Panel2D` can be used without borders, including adding actors, updating positions, adding to a scene, and accessing border properties without errors.Guard all self.borders references with self.has_border checks in _get_actors, _update_actors_position, update_border_coords, border_color, and border_width properties.