### PR TITLE
Fix: TextBlock2D text positioning due to stale pygfx bounding box

### DIFF
--- a/fury/ui/core.py
+++ b/fury/ui/core.py
@@ -992,11 +992,11 @@ class TextBlock2D(UI):
         self.have_bg = bool(bg_color)
         self.color = color
         self.background_color = bg_color
-        self.font_family = font_family
         self.bold = bold
         self.italic = italic
-        self.message = text
+        self.font_family = font_family
         self.font_size = font_size
+        self.message = text
 
         self.update_bounding_box()
 
@@ -1112,6 +1112,7 @@ class TextBlock2D(UI):
             Text font size.
         """
         self.actor.font_size = size
+        self._refresh_text_layout()
         if self.dynamic_bbox:
             self.update_bounding_box()
 
@@ -1136,6 +1137,7 @@ class TextBlock2D(UI):
             The font family.
         """
         self.actor.family = family
+        self._refresh_text_layout()
         if self.dynamic_bbox:
             self.update_bounding_box()
 
@@ -1371,6 +1373,14 @@ class TextBlock2D(UI):
     def _update_actors_position(self):
         """Update the position of the internal actors."""
         self.update_bounding_box()
+
+    def _refresh_text_layout(self):
+        """Force recalculation of the text bounding box.
+
+        Re-sets the markdown text so that pygfx recomputes its internal
+        layout metrics after property changes like font_size or font_family.
+        """
+        self.actor.set_markdown(self.get_formatted_text(self._message))
 
     def get_text_actor_size(self):
         """Get the rendered size of the text actor.

--- a/fury/ui/tests/test_core.py
+++ b/fury/ui/tests/test_core.py
@@ -464,6 +464,41 @@ def test_textblock2d_resize():
     npt.assert_equal(tb.boundingbox[3] - tb.boundingbox[1], new_size[1])
 
 
+def test_textblock2d_text_positioning():
+    """Test that text actor size reflects font_size and positioning is correct.
+
+    Regression test for https://github.com/fury-gl/fury/issues/838.
+    pygfx Text._aabb was not recalculated when font_size was changed after
+    construction, causing get_text_actor_size() to return stale values
+    and misposition text within the bounding box.
+    """
+    tb = ui.TextBlock2D(text="HI", size=(300, 150), font_size=80)
+    w, h = tb.get_text_actor_size()
+
+    # Text actor size should scale with font_size, not stay at default (~12px)
+    assert w > 50, f"Text width {w} too small for font_size=80"
+    assert h > 50, f"Text height {h} too small for font_size=80"
+
+    # Changing font_size dynamically should update text actor size
+    tb.font_size = 40
+    w2, h2 = tb.get_text_actor_size()
+    assert w2 < w, "Halving font_size should reduce text width"
+    assert h2 < h, "Halving font_size should reduce text height"
+
+    # Left/top justification: actor x should be offset inward by half text width
+    tb_lt = ui.TextBlock2D(
+        text="HI",
+        size=(300, 150),
+        font_size=60,
+        position=(100, 100),
+        justification="left",
+        vertical_justification="top",
+    )
+    text_w, _ = tb_lt.get_text_actor_size()
+    expected_x = tb_lt.boundingbox[0] + text_w // 2
+    npt.assert_almost_equal(tb_lt.actor.local.x, expected_x)
+
+
 def test_textblock2d_visual_snapshot():
     """
     Visual test for TextBlock2D.


### PR DESCRIPTION
pygfx Text._aabb is not recalculated when font_size or font_family is changed after construction. Since TextBlock2D creates the text actor with defaults and sets properties afterward, get_text_actor_size() returned stale values, causing text to be mispositioned for all non-center justifications.

Fix by re-setting the markdown text after font_size/font_family changes to force pygfx to recompute its layout metrics, and reorder __init__ so message (which calls set_markdown) runs last with final property values.

Closes #838
This pull request addresses a regression in the `TextBlock2D` UI component where changes to `font_size` or `font_family` after construction did not update the text layout and bounding box, leading to incorrect sizing and positioning. The fix ensures that the text layout is refreshed whenever these properties are changed, and adds a regression test to verify correct behavior.

**Bug Fixes and Improvements to Text Layout:**

* Added a private method `_refresh_text_layout` to `TextBlock2D` that forces recalculation of the text bounding box by resetting the markdown text. This method is now called whenever `font_size` or `font_family` is updated, ensuring the rendered text size and positioning are always accurate. [[1]](diffhunk://#diff-b2cc6095d447746c62a6bba581af84a9727e75acdaca37bfd31202a5a42d9b57R1377-R1384) [[2]](diffhunk://#diff-b2cc6095d447746c62a6bba581af84a9727e75acdaca37bfd31202a5a42d9b57R1115) [[3]](diffhunk://#diff-b2cc6095d447746c62a6bba581af84a9727e75acdaca37bfd31202a5a42d9b57R1140)

**Testing and Regression Coverage:**

* Added a new test `test_textblock2d_text_positioning` to verify that the text actor size correctly reflects changes in `font_size` and that text is properly positioned within its bounding box. This test guards against regressions related to text sizing and layout.

**Code Organization:**

* Minor reordering in the `__init__` method of `TextBlock2D` to maintain consistent initialization order for attributes.