### PR TITLE
Fix: save_image() now applies compression_type for TIFF files (#1162)

### DIFF
--- a/fury/io.py
+++ b/fury/io.py
@@ -237,7 +237,26 @@ def save_image(
         )
 
     im = Image.fromarray(arr)
-    im.save(filename, quality=compression_quality, dpi=dpi)
+
+    save_kwargs = {"dpi": dpi}
+
+    if extension in (".tiff", ".tif"):
+        if compression_type is not None:
+            compression_map = {
+                "lzw": "tiff_lzw",
+                "deflation": "tiff_deflate",
+            }
+            pil_compression = compression_map.get(compression_type)
+            if pil_compression is None:
+                raise OSError(
+                    f"Unknown compression type '{compression_type}'. "
+                    f"Supported types for TIFF: {list(compression_map.keys())}"
+                )
+            save_kwargs["compression"] = pil_compression
+    else:
+        save_kwargs["quality"] = compression_quality
+
+    im.save(filename, **save_kwargs)
 
 
 # def load_polydata(file_name):

--- a/fury/tests/test_io.py
+++ b/fury/tests/test_io.py
@@ -225,19 +225,43 @@ def test_save_load_image():
         dpi=(72, 72),
     )
 
-    compression_type = [None, "bits", "random"]
-
-    for ct in compression_type:
+    # Test valid TIFF compression types produce files
+    for ct in [None, "lzw", "deflation"]:
         with InTemporaryDirectory() as odir:
-            try:
-                data = np.random.randint(0, 255, size=(50, 3), dtype=np.uint8)
-                fname_path = pjoin(odir, f"{fname}.tif")
+            data = np.random.randint(0, 255, size=(50, 3), dtype=np.uint8)
+            fname_path = pjoin(odir, f"{fname}.tif")
 
-                save_image(data, fname_path, compression_type=ct)
-                npt.assert_equal(os.path.isfile(fname_path), True)
-                assert_greater(os.stat(fname_path).st_size, 0)
-            except OSError:
-                continue
+            save_image(data, fname_path, compression_type=ct)
+            npt.assert_equal(os.path.isfile(fname_path), True)
+            assert_greater(os.stat(fname_path).st_size, 0)
+
+    # Test that compression actually changes file output
+    with InTemporaryDirectory() as odir:
+        data = np.zeros((100, 100, 3), dtype=np.uint8)
+        path_none = pjoin(odir, "none.tiff")
+        path_lzw = pjoin(odir, "lzw.tiff")
+        path_deflate = pjoin(odir, "deflate.tiff")
+
+        save_image(data, path_none, compression_type=None)
+        save_image(data, path_lzw, compression_type="lzw")
+        save_image(data, path_deflate, compression_type="deflation")
+
+        size_none = os.stat(path_none).st_size
+        size_lzw = os.stat(path_lzw).st_size
+        size_deflate = os.stat(path_deflate).st_size
+
+        # Compressed files should be smaller than uncompressed for uniform data
+        assert size_lzw < size_none
+        assert size_deflate < size_none
+
+    # Test invalid compression type raises OSError
+    npt.assert_raises(
+        OSError,
+        save_image,
+        np.random.randint(0, 255, size=(50, 3), dtype=np.uint8),
+        "test.tiff",
+        compression_type="invalid",
+    )
 
 
 # @pytest.mark.skipif(


### PR DESCRIPTION
Fixes: #1162

The compression_type parameter was accepted but never passed to PIL, silently producing uncompressed output regardless of the value.
This pull request enhances TIFF image saving functionality in the `save_image` function by adding support for specific compression types and improves the associated tests to validate these changes. The main updates include support for "lzw" and "deflation" TIFF compression, error handling for invalid compression types, and more robust testing to ensure correct behavior.

TIFF Compression Support in Image Saving:

* Updated `save_image` in `fury/io.py` to add support for "lzw" and "deflation" TIFF compression types, mapping user-friendly names to Pillow's internal compression options and raising an `OSError` for unsupported types.

Testing Enhancements:

* Improved `test_save_load_image` in `fury/tests/test_io.py` to:
  - Test valid TIFF compression types ("lzw", "deflation", and None) and ensure output files are created.
  - Verify that compressed TIFF files are smaller than uncompressed ones for uniform data.
  - Assert that an invalid compression type raises an `OSError`.