### PR TITLE
Relax VTK constraint for Python 3.14 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,13 +38,16 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
 ]
 
 dependencies = [
     "numpy>=1.15",
 	"scipy>=1.0",
-    "vtk>=9.1.0, <9.4.0",
+    "vtk>=9.1.0",
     "pillow>=5.4.1",
     "packaging >=17.0",
     "pygltflib>=1.15.3",


### PR DESCRIPTION
## Summary
Enables FURY to install on Python 3.14 (and newer) by relaxing the VTK version constraint.

## Problem
- `pyproject.toml` currently requires `vtk>=9.1.0, <9.4.0`
- PyPI only offers VTK 9.6.0 for Python 3.14
- Installation fails with: `No matching distribution found for vtk<9.4.0,>=9.1.0`

## Solution
- Remove upper bound: `vtk>=9.1.0`
- Add Python 3.12, 3.13, 3.14 to classifiers

## Testing
- `pip install -e .` succeeds on Python 3.14 with VTK 9.6.0
- `import fury` works
- No runtime issues observed in basic usage

Closes: N/A (improvement, not tied to an issue)