### PR TITLE
gh-940 : Improves warn_on_args_to_kwargs

### DIFF
--- a/fury/decorators.py
+++ b/fury/decorators.py
@@ -219,7 +219,7 @@ def warn_on_args_to_kwargs(
                                 func.__name__, func.__name__, func_params_sample
                             ),
                             UserWarning,
-                            stacklevel=3,
+                            stacklevel=2,
                         )
 
                     # if the current version of fury is less than from_version,


### PR DESCRIPTION
- Ran all tutorial examples and verified they execute successfully with the current version of `NumPy` and `FURY`.
- Adjusted the `stacklevel` in `warn_on_args_to_kwargs` so warnings point to the user code instead of resolving to `<sys>:0`, making debugging easier.
- Fixes #940 