### PR TITLE
ENH: Support per-instance geometry parameters for actors

### DIFF
--- a/fury/actor/core.py
+++ b/fury/actor/core.py
@@ -537,13 +537,14 @@ def arrow(
     tip_radius_arr = fp._normalize_geom_param(tip_radius, n_centers, "tip_radius")
     shaft_radius_arr = fp._normalize_geom_param(shaft_radius, n_centers, "shaft_radius")
 
-    # Fast path: all uniform
-    if (
+    all_uniform = (
         np.all(height_arr == height_arr[0])
         and np.all(tip_length_arr == tip_length_arr[0])
         and np.all(tip_radius_arr == tip_radius_arr[0])
         and np.all(shaft_radius_arr == shaft_radius_arr[0])
-    ):
+    )
+
+    if all_uniform:
         vertices, faces = fp.prim_arrow(
             height=height_arr[0],
             resolution=resolution,
@@ -563,7 +564,6 @@ def arrow(
             enable_picking=enable_picking,
         )
 
-    # Slow path: per-instance geometry
     _, faces = fp.prim_arrow(
         height=height_arr[0],
         resolution=resolution,

--- a/fury/actor/core.py
+++ b/fury/actor/core.py
@@ -355,6 +355,7 @@ def actor_from_primitive(
     smooth=False,
     enable_picking=True,
     repeat_primitive=True,
+    have_tiled_verts=False,
     wireframe=False,
     wireframe_thickness=1.0,
 ):
@@ -388,6 +389,9 @@ def actor_from_primitive(
     repeat_primitive : bool, optional
         Whether to repeat the primitive for each center. If False,
         only one instance of the primitive is created at the first center.
+    have_tiled_verts : bool, optional
+        If True, vertices are already tiled (one set per center) and should
+        not be duplicated again inside ``repeat_primitive``.
     wireframe : bool, optional
         Whether to render the mesh as a wireframe.
     wireframe_thickness : float, optional
@@ -408,6 +412,7 @@ def actor_from_primitive(
             directions=directions,
             colors=colors,
             scales=scales,
+            have_tiled_verts=have_tiled_verts,
         )
         big_vertices, big_faces, big_colors, _ = res
 
@@ -480,17 +485,21 @@ def arrow(
         The orientation vector of the arrow.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
         RGB or RGBA (for opacity) R, G, B, and A should be in the range [0, 1].
-    height : float, optional
-        The total height of the arrow, including the shaft and tip.
+    height : float or ndarray, shape (N,), optional
+        The total height of the arrow, including the shaft and tip. A single
+        value applies to all arrows, while an array specifies a value per arrow.
     resolution : int, optional
         The number of divisions along the arrow's circular cross-sections.
         Higher values produce smoother arrows.
-    tip_length : float, optional
-        The length of the arrowhead tip relative to the total height.
-    tip_radius : float, optional
-        The radius of the arrowhead tip.
-    shaft_radius : float, optional
-        The radius of the arrow shaft.
+    tip_length : float or ndarray, shape (N,), optional
+        The length of the arrowhead tip relative to the total height. A single
+        value applies to all arrows, while an array specifies a value per arrow.
+    tip_radius : float or ndarray, shape (N,), optional
+        The radius of the arrowhead tip. A single value applies to all arrows,
+        while an array specifies a value per arrow.
+    shaft_radius : float or ndarray, shape (N,), optional
+        The radius of the arrow shaft. A single value applies to all arrows,
+        while an array specifies a value per arrow.
     scales : ndarray, shape (N, 3) or tuple (3,) or float, optional
         The size of the arrow in each dimension. If a single value is
         provided, the same size will be used for all arrows.
@@ -522,13 +531,57 @@ def arrow(
     >>> show_manager.start()
     """
 
-    vertices, faces = fp.prim_arrow(
-        height=height,
+    n_centers = len(centers)
+    height_arr = fp._normalize_geom_param(height, n_centers, "height")
+    tip_length_arr = fp._normalize_geom_param(tip_length, n_centers, "tip_length")
+    tip_radius_arr = fp._normalize_geom_param(tip_radius, n_centers, "tip_radius")
+    shaft_radius_arr = fp._normalize_geom_param(shaft_radius, n_centers, "shaft_radius")
+
+    # Fast path: all uniform
+    if (
+        np.all(height_arr == height_arr[0])
+        and np.all(tip_length_arr == tip_length_arr[0])
+        and np.all(tip_radius_arr == tip_radius_arr[0])
+        and np.all(shaft_radius_arr == shaft_radius_arr[0])
+    ):
+        vertices, faces = fp.prim_arrow(
+            height=height_arr[0],
+            resolution=resolution,
+            tip_length=tip_length_arr[0],
+            tip_radius=tip_radius_arr[0],
+            shaft_radius=shaft_radius_arr[0],
+        )
+        return actor_from_primitive(
+            vertices,
+            faces,
+            centers=centers,
+            colors=colors,
+            scales=scales,
+            directions=directions,
+            opacity=opacity,
+            material=material,
+            enable_picking=enable_picking,
+        )
+
+    # Slow path: per-instance geometry
+    _, faces = fp.prim_arrow(
+        height=height_arr[0],
         resolution=resolution,
-        tip_length=tip_length,
-        tip_radius=tip_radius,
-        shaft_radius=shaft_radius,
+        tip_length=tip_length_arr[0],
+        tip_radius=tip_radius_arr[0],
+        shaft_radius=shaft_radius_arr[0],
     )
+    all_verts = [
+        fp.prim_arrow(
+            height=height_arr[i],
+            resolution=resolution,
+            tip_length=tip_length_arr[i],
+            tip_radius=tip_radius_arr[i],
+            shaft_radius=shaft_radius_arr[i],
+        )[0]
+        for i in range(n_centers)
+    ]
+    vertices = np.concatenate(all_verts)
     return actor_from_primitive(
         vertices,
         faces,
@@ -539,6 +592,7 @@ def arrow(
         opacity=opacity,
         material=material,
         enable_picking=enable_picking,
+        have_tiled_verts=True,
     )
 
 

--- a/fury/actor/curved.py
+++ b/fury/actor/curved.py
@@ -374,8 +374,11 @@ def cylinder(
     radii_arr = fp._normalize_geom_param(radii, n_centers, "radii")
     height_arr = fp._normalize_geom_param(height, n_centers, "height")
 
-    # Fast path: all uniform
-    if np.all(radii_arr == radii_arr[0]) and np.all(height_arr == height_arr[0]):
+    all_uniform = np.all(radii_arr == radii_arr[0]) and np.all(
+        height_arr == height_arr[0]
+    )
+
+    if all_uniform:
         vertices, faces = fp.prim_cylinder(
             radius=radii_arr[0], height=height_arr[0], sectors=sectors, capped=capped
         )
@@ -393,7 +396,6 @@ def cylinder(
             wireframe_thickness=wireframe_thickness,
         )
 
-    # Slow path: per-instance geometry
     _, faces = fp.prim_cylinder(
         radius=radii_arr[0], height=height_arr[0], sectors=sectors, capped=capped
     )
@@ -492,8 +494,11 @@ def cone(
     radii_arr = fp._normalize_geom_param(radii, n_centers, "radii")
     height_arr = fp._normalize_geom_param(height, n_centers, "height")
 
-    # Fast path: all uniform
-    if np.all(radii_arr == radii_arr[0]) and np.all(height_arr == height_arr[0]):
+    all_uniform = np.all(radii_arr == radii_arr[0]) and np.all(
+        height_arr == height_arr[0]
+    )
+
+    if all_uniform:
         vertices, faces = fp.prim_cone(
             radius=radii_arr[0], height=height_arr[0], sectors=sectors
         )
@@ -511,7 +516,6 @@ def cone(
             wireframe_thickness=wireframe_thickness,
         )
 
-    # Slow path: per-instance geometry
     _, faces = fp.prim_cone(radius=radii_arr[0], height=height_arr[0], sectors=sectors)
     all_verts = [
         fp.prim_cone(radius=radii_arr[i], height=height_arr[i], sectors=sectors)[0]

--- a/fury/actor/curved.py
+++ b/fury/actor/curved.py
@@ -322,8 +322,9 @@ def cylinder(
         Cylinder positions.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
         RGB or RGBA (for opacity) R, G, B, and A should be in the range [0, 1].
-    height : float, optional
-        The height of the cylinder.
+    height : float or ndarray, shape (N,), optional
+        The height of the cylinder. A single value applies to all cylinders,
+        while an array specifies a height for each cylinder individually.
     sectors : int, optional
         The number of divisions around the cylinder's circumference.
         Higher values produce smoother cylinders.
@@ -369,10 +370,40 @@ def cylinder(
     >>> show_manager = window.ShowManager(scene=scene, size=(600, 600))
     >>> show_manager.start()
     """
+    n_centers = len(centers)
+    radii_arr = fp._normalize_geom_param(radii, n_centers, "radii")
+    height_arr = fp._normalize_geom_param(height, n_centers, "height")
 
-    vertices, faces = fp.prim_cylinder(
-        radius=radii, height=height, sectors=sectors, capped=capped
+    # Fast path: all uniform
+    if np.all(radii_arr == radii_arr[0]) and np.all(height_arr == height_arr[0]):
+        vertices, faces = fp.prim_cylinder(
+            radius=radii_arr[0], height=height_arr[0], sectors=sectors, capped=capped
+        )
+        return actor_from_primitive(
+            vertices,
+            faces,
+            centers=centers,
+            colors=colors,
+            scales=scales,
+            directions=directions,
+            opacity=opacity,
+            material=material,
+            enable_picking=enable_picking,
+            wireframe=wireframe,
+            wireframe_thickness=wireframe_thickness,
+        )
+
+    # Slow path: per-instance geometry
+    _, faces = fp.prim_cylinder(
+        radius=radii_arr[0], height=height_arr[0], sectors=sectors, capped=capped
     )
+    all_verts = [
+        fp.prim_cylinder(
+            radius=radii_arr[i], height=height_arr[i], sectors=sectors, capped=capped
+        )[0]
+        for i in range(n_centers)
+    ]
+    vertices = np.concatenate(all_verts)
     return actor_from_primitive(
         vertices,
         faces,
@@ -385,6 +416,7 @@ def cylinder(
         enable_picking=enable_picking,
         wireframe=wireframe,
         wireframe_thickness=wireframe_thickness,
+        have_tiled_verts=True,
     )
 
 
@@ -411,8 +443,9 @@ def cone(
         Cone positions.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
         RGB or RGBA (for opacity) R, G, B, and A should be in the range [0, 1].
-    height : float, optional
-        The height of the cone.
+    height : float or ndarray, shape (N,), optional
+        The height of the cone. A single value applies to all cones,
+        while an array specifies a height for each cone individually.
     sectors : int, optional
         The number of divisions around the cone's circumference.
         Higher values produce smoother cones.
@@ -455,8 +488,36 @@ def cone(
     >>> show_manager = window.ShowManager(scene=scene, size=(600, 600))
     >>> show_manager.start()
     """
+    n_centers = len(centers)
+    radii_arr = fp._normalize_geom_param(radii, n_centers, "radii")
+    height_arr = fp._normalize_geom_param(height, n_centers, "height")
 
-    vertices, faces = fp.prim_cone(radius=radii, height=height, sectors=sectors)
+    # Fast path: all uniform
+    if np.all(radii_arr == radii_arr[0]) and np.all(height_arr == height_arr[0]):
+        vertices, faces = fp.prim_cone(
+            radius=radii_arr[0], height=height_arr[0], sectors=sectors
+        )
+        return actor_from_primitive(
+            vertices,
+            faces,
+            centers=centers,
+            colors=colors,
+            scales=scales,
+            directions=directions,
+            opacity=opacity,
+            material=material,
+            enable_picking=enable_picking,
+            wireframe=wireframe,
+            wireframe_thickness=wireframe_thickness,
+        )
+
+    # Slow path: per-instance geometry
+    _, faces = fp.prim_cone(radius=radii_arr[0], height=height_arr[0], sectors=sectors)
+    all_verts = [
+        fp.prim_cone(radius=radii_arr[i], height=height_arr[i], sectors=sectors)[0]
+        for i in range(n_centers)
+    ]
+    vertices = np.concatenate(all_verts)
     return actor_from_primitive(
         vertices,
         faces,
@@ -469,6 +530,7 @@ def cone(
         enable_picking=enable_picking,
         wireframe=wireframe,
         wireframe_thickness=wireframe_thickness,
+        have_tiled_verts=True,
     )
 
 

--- a/fury/actor/planar.py
+++ b/fury/actor/planar.py
@@ -248,8 +248,9 @@ def disk(
     n_centers = len(centers)
     radii_arr = fp._normalize_geom_param(radii, n_centers, "radii")
 
-    # Fast path: all uniform
-    if np.all(radii_arr == radii_arr[0]):
+    all_uniform = np.all(radii_arr == radii_arr[0])
+
+    if all_uniform:
         vertices, faces = fp.prim_disk(radius=radii_arr[0], sectors=sectors)
         return actor_from_primitive(
             vertices,
@@ -265,7 +266,6 @@ def disk(
             wireframe_thickness=wireframe_thickness,
         )
 
-    # Slow path: per-instance geometry
     _, faces = fp.prim_disk(radius=radii_arr[0], sectors=sectors)
     all_verts = [
         fp.prim_disk(radius=radii_arr[i], sectors=sectors)[0] for i in range(n_centers)
@@ -850,8 +850,11 @@ def ring(
     inner_arr = fp._normalize_geom_param(inner_radius, n_centers, "inner_radius")
     outer_arr = fp._normalize_geom_param(outer_radius, n_centers, "outer_radius")
 
-    # Fast path: all uniform – single primitive, no tiling needed
-    if np.all(inner_arr == inner_arr[0]) and np.all(outer_arr == outer_arr[0]):
+    all_uniform = np.all(inner_arr == inner_arr[0]) and np.all(
+        outer_arr == outer_arr[0]
+    )
+
+    if all_uniform:
         vertices, faces = fp.prim_ring(
             inner_radius=inner_arr[0],
             outer_radius=outer_arr[0],
@@ -870,7 +873,6 @@ def ring(
             enable_picking=enable_picking,
         )
 
-    # Slow path: per-instance geometry
     _, faces = fp.prim_ring(
         inner_radius=inner_arr[0],
         outer_radius=outer_arr[0],

--- a/fury/actor/planar.py
+++ b/fury/actor/planar.py
@@ -245,8 +245,32 @@ def disk(
     >>> show_manager = window.ShowManager(scene=scene, size=(600, 600))
     >>> show_manager.start()
     """
+    n_centers = len(centers)
+    radii_arr = fp._normalize_geom_param(radii, n_centers, "radii")
 
-    vertices, faces = fp.prim_disk(radius=radii, sectors=sectors)
+    # Fast path: all uniform
+    if np.all(radii_arr == radii_arr[0]):
+        vertices, faces = fp.prim_disk(radius=radii_arr[0], sectors=sectors)
+        return actor_from_primitive(
+            vertices,
+            faces,
+            centers=centers,
+            colors=colors,
+            scales=scales,
+            directions=directions,
+            opacity=opacity,
+            material=material,
+            enable_picking=enable_picking,
+            wireframe=wireframe,
+            wireframe_thickness=wireframe_thickness,
+        )
+
+    # Slow path: per-instance geometry
+    _, faces = fp.prim_disk(radius=radii_arr[0], sectors=sectors)
+    all_verts = [
+        fp.prim_disk(radius=radii_arr[i], sectors=sectors)[0] for i in range(n_centers)
+    ]
+    vertices = np.concatenate(all_verts)
     return actor_from_primitive(
         vertices,
         faces,
@@ -259,6 +283,7 @@ def disk(
         enable_picking=enable_picking,
         wireframe=wireframe,
         wireframe_thickness=wireframe_thickness,
+        have_tiled_verts=True,
     )
 
 
@@ -777,10 +802,12 @@ def ring(
     ----------
     centers : ndarray, shape (N, 3)
         Ring positions.
-    inner_radius : float, optional
-        The inner radius of the ring (radius of the hole).
-    outer_radius : float, optional
-        The outer radius of the ring.
+    inner_radius : float or ndarray, shape (N,), optional
+        The inner radius of the ring (radius of the hole). A single value
+        applies to all rings, while an array specifies a value per ring.
+    outer_radius : float or ndarray, shape (N,), optional
+        The outer radius of the ring. A single value applies to all rings,
+        while an array specifies a value per ring.
     radial_segments : int, optional
         Number of segments along the radial direction.
     circumferential_segments : int, optional
@@ -819,12 +846,47 @@ def ring(
     >>> show_manager = window.ShowManager(scene=scene, size=(600, 600))
     >>> show_manager.start()
     """
-    vertices, faces = fp.prim_ring(
-        inner_radius=inner_radius,
-        outer_radius=outer_radius,
+    n_centers = len(centers)
+    inner_arr = fp._normalize_geom_param(inner_radius, n_centers, "inner_radius")
+    outer_arr = fp._normalize_geom_param(outer_radius, n_centers, "outer_radius")
+
+    # Fast path: all uniform – single primitive, no tiling needed
+    if np.all(inner_arr == inner_arr[0]) and np.all(outer_arr == outer_arr[0]):
+        vertices, faces = fp.prim_ring(
+            inner_radius=inner_arr[0],
+            outer_radius=outer_arr[0],
+            radial_segments=radial_segments,
+            circumferential_segments=circumferential_segments,
+        )
+        return actor_from_primitive(
+            vertices,
+            faces,
+            centers=centers,
+            colors=colors,
+            scales=scales,
+            directions=directions,
+            opacity=opacity,
+            material=material,
+            enable_picking=enable_picking,
+        )
+
+    # Slow path: per-instance geometry
+    _, faces = fp.prim_ring(
+        inner_radius=inner_arr[0],
+        outer_radius=outer_arr[0],
         radial_segments=radial_segments,
         circumferential_segments=circumferential_segments,
     )
+    all_verts = [
+        fp.prim_ring(
+            inner_radius=inner_arr[i],
+            outer_radius=outer_arr[i],
+            radial_segments=radial_segments,
+            circumferential_segments=circumferential_segments,
+        )[0]
+        for i in range(n_centers)
+    ]
+    vertices = np.concatenate(all_verts)
     return actor_from_primitive(
         vertices,
         faces,
@@ -835,6 +897,7 @@ def ring(
         opacity=opacity,
         material=material,
         enable_picking=enable_picking,
+        have_tiled_verts=True,
     )
 
 

--- a/fury/actor/tests/test_core.py
+++ b/fury/actor/tests/test_core.py
@@ -291,6 +291,70 @@ def test_actor_from_primitive_transparency_visual(sphere_prim):
     scene.remove(transparent)
 
 
+def test_arrow_per_instance_geometry():
+    """Test arrow actor with per-instance geometry parameters."""
+    centers = np.array([[0, 0, 0], [2, 0, 0], [4, 0, 0]])
+    colors = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+    # Per-instance height, tip_length, tip_radius, shaft_radius
+    heights = np.array([1.0, 1.5, 2.0])
+    tip_lengths = np.array([0.3, 0.4, 0.5])
+    tip_radii = np.array([0.08, 0.1, 0.12])
+    shaft_radii = np.array([0.02, 0.03, 0.04])
+    arrow_actor = actor.arrow(
+        centers=centers,
+        colors=colors,
+        height=heights,
+        tip_length=tip_lengths,
+        tip_radius=tip_radii,
+        shaft_radius=shaft_radii,
+    )
+    assert arrow_actor.prim_count == 3
+
+    # Verify geometry varies: per-instance vertex height extents differ
+    verts = arrow_actor.geometry.positions.view
+    n_verts_per = len(verts) // 3
+    y_extents = []
+    for i in range(3):
+        chunk = verts[i * n_verts_per : (i + 1) * n_verts_per] - centers[i]
+        y_extents.append(chunk[:, 0].max() - chunk[:, 0].min())
+    # Larger heights should yield larger extents
+    assert y_extents[0] < y_extents[1] < y_extents[2]
+
+    # Scalar (backward compat)
+    arrow_actor_scalar = actor.arrow(centers=centers, colors=colors, height=1.0)
+    assert arrow_actor_scalar.prim_count == 3
+
+    # Wrong-size array raises ValueError
+    with pytest.raises(ValueError, match="height"):
+        actor.arrow(
+            centers=centers,
+            colors=colors,
+            height=np.array([1.0, 1.5]),
+        )
+
+    with pytest.raises(ValueError, match="tip_length"):
+        actor.arrow(
+            centers=centers,
+            colors=colors,
+            tip_length=np.array([0.3, 0.4]),
+        )
+
+    with pytest.raises(ValueError, match="tip_radius"):
+        actor.arrow(
+            centers=centers,
+            colors=colors,
+            tip_radius=np.array([0.08, 0.1]),
+        )
+
+    with pytest.raises(ValueError, match="shaft_radius"):
+        actor.arrow(
+            centers=centers,
+            colors=colors,
+            shaft_radius=np.array([0.02, 0.03]),
+        )
+
+
 def test_create_axes_helper_structure():
     helper = create_axes_helper()
 

--- a/fury/actor/tests/test_curved.py
+++ b/fury/actor/tests/test_curved.py
@@ -424,6 +424,94 @@ def test_streamtube_geometry_min_max_bounds():
     )
 
 
+def test_cone_per_instance_geometry():
+    """Test cone actor with per-instance radii and height."""
+    centers = np.array([[0, 0, 0], [2, 0, 0], [4, 0, 0]])
+    colors = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+    # Per-instance radii and height
+    radii = np.array([0.3, 0.5, 0.7])
+    heights = np.array([1.0, 1.5, 2.0])
+    cone_actor = actor.cone(centers=centers, colors=colors, radii=radii, height=heights)
+    assert cone_actor.prim_count == 3
+
+    # Verify geometry varies: per-instance vertex extents differ
+    verts = cone_actor.geometry.positions.view
+    n_verts_per = len(verts) // 3
+    extents = []
+    for i in range(3):
+        chunk = verts[i * n_verts_per : (i + 1) * n_verts_per] - centers[i]
+        extents.append(chunk[:, 0].max() - chunk[:, 0].min())
+    # Larger radii should yield wider extents
+    assert extents[0] < extents[1] < extents[2]
+
+    # Scalar (backward compat)
+    cone_actor_scalar = actor.cone(
+        centers=centers, colors=colors, radii=0.5, height=1.0
+    )
+    assert cone_actor_scalar.prim_count == 3
+
+    # Wrong-size array raises ValueError
+    with pytest.raises(ValueError, match="radii"):
+        actor.cone(
+            centers=centers,
+            colors=colors,
+            radii=np.array([0.3, 0.5]),
+        )
+
+    with pytest.raises(ValueError, match="height"):
+        actor.cone(
+            centers=centers,
+            colors=colors,
+            height=np.array([1.0, 1.5]),
+        )
+
+
+def test_cylinder_per_instance_geometry():
+    """Test cylinder actor with per-instance radii and height."""
+    centers = np.array([[0, 0, 0], [2, 0, 0], [4, 0, 0]])
+    colors = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+    # Per-instance radii and height
+    radii = np.array([0.3, 0.5, 0.7])
+    heights = np.array([1.0, 1.5, 2.0])
+    cyl_actor = actor.cylinder(
+        centers=centers, colors=colors, radii=radii, height=heights
+    )
+    assert cyl_actor.prim_count == 3
+
+    # Verify geometry varies: per-instance vertex extents differ
+    verts = cyl_actor.geometry.positions.view
+    n_verts_per = len(verts) // 3
+    extents = []
+    for i in range(3):
+        chunk = verts[i * n_verts_per : (i + 1) * n_verts_per] - centers[i]
+        extents.append(chunk[:, 0].max() - chunk[:, 0].min())
+    # Larger radii should yield wider extents
+    assert extents[0] < extents[1] < extents[2]
+
+    # Scalar (backward compat)
+    cyl_actor_scalar = actor.cylinder(
+        centers=centers, colors=colors, radii=0.5, height=1.0
+    )
+    assert cyl_actor_scalar.prim_count == 3
+
+    # Wrong-size array raises ValueError
+    with pytest.raises(ValueError, match="radii"):
+        actor.cylinder(
+            centers=centers,
+            colors=colors,
+            radii=np.array([0.3, 0.5]),
+        )
+
+    with pytest.raises(ValueError, match="height"):
+        actor.cylinder(
+            centers=centers,
+            colors=colors,
+            height=np.array([1.0, 1.5]),
+        )
+
+
 def test_actor_from_primitive_wireframe():
     """Test wireframe and wireframe_thickness for primitive actors."""
     sphere_actor = actor.sphere(

--- a/fury/actor/tests/test_planar.py
+++ b/fury/actor/tests/test_planar.py
@@ -293,6 +293,80 @@ def test_star():
     validate_actors(centers=centers, colors=colors, actor_type="star")
 
 
+def test_ring_per_instance_geometry():
+    """Test ring actor with per-instance inner_radius and outer_radius."""
+    centers = np.array([[0, 0, 0], [2, 0, 0], [4, 0, 0]])
+    colors = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+    # Per-instance inner/outer radius arrays
+    inner = np.array([0.2, 0.3, 0.4])
+    outer = np.array([0.8, 1.0, 1.2])
+    ring_actor = actor.ring(
+        centers=centers, colors=colors, inner_radius=inner, outer_radius=outer
+    )
+    assert ring_actor.prim_count == 3
+
+    # Verify geometry actually varies: compute per-instance vertex extents
+    verts = ring_actor.geometry.positions.view
+    n_verts_per = len(verts) // 3
+    for i in range(3):
+        chunk = verts[i * n_verts_per : (i + 1) * n_verts_per] - centers[i]
+        dists = np.sqrt(chunk[:, 0] ** 2 + chunk[:, 1] ** 2)
+        npt.assert_almost_equal(dists.max(), outer[i], decimal=2)
+
+    # Scalar values (backward compat)
+    ring_actor_scalar = actor.ring(
+        centers=centers, colors=colors, inner_radius=0.5, outer_radius=1.0
+    )
+    assert ring_actor_scalar.prim_count == 3
+
+    # Wrong-size array raises ValueError
+    with pytest.raises(ValueError, match="inner_radius"):
+        actor.ring(
+            centers=centers,
+            colors=colors,
+            inner_radius=np.array([0.2, 0.3]),
+        )
+
+    with pytest.raises(ValueError, match="outer_radius"):
+        actor.ring(
+            centers=centers,
+            colors=colors,
+            outer_radius=np.array([0.8, 1.0]),
+        )
+
+
+def test_disk_per_instance_radii():
+    """Test disk actor with per-instance radii."""
+    centers = np.array([[0, 0, 0], [2, 0, 0], [4, 0, 0]])
+    colors = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+    # Per-instance radii
+    radii = np.array([0.3, 0.5, 0.7])
+    disk_actor = actor.disk(centers=centers, colors=colors, radii=radii)
+    assert disk_actor.prim_count == 3
+
+    # Verify geometry actually varies: check max distance from center per instance
+    verts = disk_actor.geometry.positions.view
+    n_verts_per = len(verts) // 3
+    for i in range(3):
+        chunk = verts[i * n_verts_per : (i + 1) * n_verts_per] - centers[i]
+        dists = np.sqrt(chunk[:, 0] ** 2 + chunk[:, 1] ** 2)
+        npt.assert_almost_equal(dists.max(), radii[i], decimal=2)
+
+    # Scalar (backward compat)
+    disk_actor_scalar = actor.disk(centers=centers, colors=colors, radii=0.5)
+    assert disk_actor_scalar.prim_count == 3
+
+    # Wrong-size array raises ValueError
+    with pytest.raises(ValueError, match="radii"):
+        actor.disk(
+            centers=centers,
+            colors=colors,
+            radii=np.array([0.3, 0.5]),
+        )
+
+
 def test_line_projection():
     """Test line_projection function with default parameters."""
     lines = [

--- a/fury/primitive.py
+++ b/fury/primitive.py
@@ -50,6 +50,38 @@ def faces_from_sphere_vertices(vertices):
         return faces
 
 
+def _normalize_geom_param(param, n_centers, param_name="parameter"):
+    """Normalize a geometry parameter to an array of length n_centers.
+
+    Accepts a scalar or array-like. A scalar or single-element value is
+    broadcast to all centers. An array of length ``n_centers`` is returned
+    as-is. Any other length raises ``ValueError``.
+
+    Parameters
+    ----------
+    param : float or array-like
+        The geometry parameter value(s).
+    n_centers : int
+        Number of primitive instances (centers).
+    param_name : str, optional
+        Name used in error messages.
+
+    Returns
+    -------
+    ndarray, shape (n_centers,)
+        The parameter broadcast to length ``n_centers``.
+    """
+    arr = np.atleast_1d(np.asarray(param, dtype=np.float64)).ravel()
+    if arr.size == 1:
+        return np.full(n_centers, arr[0])
+    if arr.size == n_centers:
+        return arr
+    raise ValueError(
+        f"{param_name} must be a scalar or an array of length {n_centers} "
+        f"(got length {arr.size})."
+    )
+
+
 @warn_on_args_to_kwargs()
 def repeat_primitive_function(
     func, centers, *, func_args=None, directions=(1, 0, 0), colors=(1, 0, 0), scales=1

--- a/fury/tests/test_primitive.py
+++ b/fury/tests/test_primitive.py
@@ -425,6 +425,58 @@ def test_prim_ring_vertices_and_triangles():
     )
 
 
+def test_normalize_geom_param():
+    import pytest
+
+    # Scalar float broadcasts to all centers
+    result = fp._normalize_geom_param(0.5, 3, "test")
+    npt.assert_array_equal(result, [0.5, 0.5, 0.5])
+    assert result.shape == (3,)
+
+    # Scalar int
+    result = fp._normalize_geom_param(2, 4, "test")
+    npt.assert_array_equal(result, [2.0, 2.0, 2.0, 2.0])
+
+    # Numpy scalar
+    result = fp._normalize_geom_param(np.float64(1.5), 2, "test")
+    npt.assert_array_equal(result, [1.5, 1.5])
+
+    # Single-element list broadcasts
+    result = fp._normalize_geom_param([0.7], 3, "test")
+    npt.assert_array_equal(result, [0.7, 0.7, 0.7])
+
+    # Single-element tuple broadcasts
+    result = fp._normalize_geom_param((0.7,), 3, "test")
+    npt.assert_array_equal(result, [0.7, 0.7, 0.7])
+
+    # Single-element ndarray broadcasts
+    result = fp._normalize_geom_param(np.array([0.7]), 3, "test")
+    npt.assert_array_equal(result, [0.7, 0.7, 0.7])
+
+    # Array of correct length returned as-is
+    result = fp._normalize_geom_param(np.array([1.0, 2.0, 3.0]), 3, "test")
+    npt.assert_array_equal(result, [1.0, 2.0, 3.0])
+
+    # List of correct length
+    result = fp._normalize_geom_param([1.0, 2.0], 2, "test")
+    npt.assert_array_equal(result, [1.0, 2.0])
+
+    # N=1 with scalar
+    result = fp._normalize_geom_param(0.5, 1, "test")
+    npt.assert_array_equal(result, [0.5])
+
+    # Wrong-size array raises ValueError with param name
+    with pytest.raises(ValueError, match="my_param"):
+        fp._normalize_geom_param(np.array([1.0, 2.0]), 3, "my_param")
+
+    with pytest.raises(ValueError, match="radius"):
+        fp._normalize_geom_param([1.0, 2.0, 3.0], 5, "radius")
+
+    # dtype is float64
+    result = fp._normalize_geom_param(1, 2, "test")
+    assert result.dtype == np.float64
+
+
 def test_prim_ring_error_handling():
     with npt.assert_raises(ValueError):
         fp.prim_ring(radial_segments=0)


### PR DESCRIPTION
  Closes #1091

Allow ring, disk, cone, cylinder, and arrow actors to accept per-instance geometry parameters (e.g. radii, height, inner_radius) as ndarray in addition to scalar values. Also fixes a bug where disk, cone, and cylinder documented ndarray support for radii but passed it directly to prim functions expecting a scalar.
This pull request introduces support for per-instance geometry parameters for several primitive actor functions in the `fury.actor` module, allowing properties like height and radius to be specified as arrays for each instance rather than just as scalars. This enables more flexible and varied rendering of primitives such as arrows, cylinders, cones, disks, and rings. The changes also include improvements to the internal logic for efficiently handling both uniform and per-instance geometry, and comprehensive tests for the new functionality.

**Support for per-instance geometry parameters:**

* Updated `arrow`, `cylinder`, `cone`, `disk`, and `ring` actor functions to accept geometry parameters (e.g., `height`, `radii`, `tip_length`, `tip_radius`, `shaft_radius`, `inner_radius`, `outer_radius`) as either scalars or arrays, enabling per-instance customization. The docstrings were updated to reflect these changes. [[1]](diffhunk://#diff-617222f9136febde936fe929a4e4f975e848b39554dd734ef68de870bd86a4c4L479-R498) [[2]](diffhunk://#diff-833e9c0540fa4a5eac47e1e1f9e1a6bc835704fbb03bbe60460d8030c7d04bfeL325-R327) [[3]](diffhunk://#diff-833e9c0540fa4a5eac47e1e1f9e1a6bc835704fbb03bbe60460d8030c7d04bfeL414-R448) [[4]](diffhunk://#diff-aa5c00574844974e2fca98de7ae59a6ffdfb1ba2a4b1659657c4fba286ea71cfL709-R739)

* Added logic to each actor function to efficiently handle the case where all parameters are uniform (fast path) versus when they vary per instance (slow path), including tiling of vertices and correct face indexing. Introduced the `have_tiled_verts` parameter to `actor_from_primitive` to avoid redundant tiling. [[1]](diffhunk://#diff-617222f9136febde936fe929a4e4f975e848b39554dd734ef68de870bd86a4c4R354) [[2]](diffhunk://#diff-617222f9136febde936fe929a4e4f975e848b39554dd734ef68de870bd86a4c4R411) [[3]](diffhunk://#diff-617222f9136febde936fe929a4e4f975e848b39554dd734ef68de870bd86a4c4R530-R548) [[4]](diffhunk://#diff-617222f9136febde936fe929a4e4f975e848b39554dd734ef68de870bd86a4c4R562-R593) [[5]](diffhunk://#diff-833e9c0540fa4a5eac47e1e1f9e1a6bc835704fbb03bbe60460d8030c7d04bfeR373-R380) [[6]](diffhunk://#diff-833e9c0540fa4a5eac47e1e1f9e1a6bc835704fbb03bbe60460d8030c7d04bfeR396-R421) [[7]](diffhunk://#diff-833e9c0540fa4a5eac47e1e1f9e1a6bc835704fbb03bbe60460d8030c7d04bfeR491-R520) [[8]](diffhunk://#diff-833e9c0540fa4a5eac47e1e1f9e1a6bc835704fbb03bbe60460d8030c7d04bfeR533) [[9]](diffhunk://#diff-aa5c00574844974e2fca98de7ae59a6ffdfb1ba2a4b1659657c4fba286ea71cfR247-R252) [[10]](diffhunk://#diff-aa5c00574844974e2fca98de7ae59a6ffdfb1ba2a4b1659657c4fba286ea71cfR267-R287) [[11]](diffhunk://#diff-aa5c00574844974e2fca98de7ae59a6ffdfb1ba2a4b1659657c4fba286ea71cfR778-R818) [[12]](diffhunk://#diff-aa5c00574844974e2fca98de7ae59a6ffdfb1ba2a4b1659657c4fba286ea71cfR829)

**Testing and validation:**

* Added comprehensive tests for per-instance geometry in `arrow`, `cone`, and `cylinder` actors, verifying that geometry varies as expected and that incorrect parameter array sizes raise appropriate errors. [[1]](diffhunk://#diff-9ca7edb65a36b259fe5a7a5e6a552b53554018d9ac75c23f0e447999d85a9099R294-R357) [[2]](diffhunk://#diff-f736a5bae0ace95699b65fa9052cea244ecc819b006289fe834adffde0fc6f42R452-R539)

**Demo:**
Each row shows 3 instances of the same actor with **different** per-instance geometry parameters (increasing left to right):

<img width="1000" height="1000" alt="per_instance_geometry_demo" src="https://github.com/user-attachments/assets/5a067bab-2e33-41fa-a9e8-75ad44a54b60" />
