### PR TITLE
ENH: Add normalize_colors() utility for standardized color input (#1089)

### DIFF
--- a/fury/__init__.pyi
+++ b/fury/__init__.pyi
@@ -164,6 +164,7 @@ from .colormap import (
     lab2rgb as lab2rgb,
     lab2xyz as lab2xyz,
     line_colors as line_colors,
+    normalize_colors as normalize_colors,
     orient2rgb as orient2rgb,
     rgb2hsv as rgb2hsv,
     rgb2lab as rgb2lab,

--- a/fury/actor/core.py
+++ b/fury/actor/core.py
@@ -370,7 +370,9 @@ def actor_from_primitive(
     centers : ndarray, shape (N, 3)
         Primitive positions.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA (for opacity) R, G, B, and A should be in the range [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     scales : ndarray, shape (N, 3) or tuple (3,) or float, optional
         The size of the primitive in each dimension. If a single value is provided,
         the same size will be used for all primitives.
@@ -403,6 +405,12 @@ def actor_from_primitive(
         A mesh actor containing the generated primitive, with the specified
         material and properties.
     """
+    from fury.colormap import normalize_colors
+
+    if repeat_primitive:
+        colors = normalize_colors(colors, n_points=len(centers))
+    else:
+        colors = normalize_colors(colors)
 
     if repeat_primitive:
         res = fp.repeat_primitive(
@@ -484,7 +492,9 @@ def arrow(
     directions : ndarray, shape (N, 3) or tuple (3,), optional
         The orientation vector of the arrow.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA (for opacity) R, G, B, and A should be in the range [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     height : float or ndarray, shape (N,), optional
         The total height of the arrow, including the shaft and tip. A single
         value applies to all arrows, while an array specifies a value per arrow.
@@ -800,7 +810,9 @@ def line(
     lines : list of ndarray of shape (P, 3) or ndarray of shape (N, P, 3)
         Lines points.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA (for opacity) R, G, B and A should be at the range [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     opacity : float, optional
         Takes values from 0 (fully transparent) to 1 (opaque).
     material : str, optional
@@ -827,6 +839,13 @@ def line(
     >>> show_manager = window.ShowManager(scene=scene, size=(600, 600))
     >>> show_manager.start()
     """
+    from fury.colormap import normalize_colors
+
+    if colors is not None:
+        colors = normalize_colors(colors)
+        # Squeeze single-color back to 1D for line_buffer_separator compatibility
+        if colors.ndim == 2 and len(colors) == 1:
+            colors = colors[0]
 
     lines_positions, lines_colors = line_buffer_separator(lines, color=colors)
 

--- a/fury/actor/core.py
+++ b/fury/actor/core.py
@@ -840,7 +840,6 @@ def line(
     """
     if colors is not None:
         colors = normalize_colors(colors)
-        # Squeeze single-color back to 1D for line_buffer_separator compatibility
         if colors.ndim == 2 and len(colors) == 1:
             colors = colors[0]
 

--- a/fury/actor/core.py
+++ b/fury/actor/core.py
@@ -6,6 +6,7 @@ import numpy as np
 from scipy.spatial.transform import Rotation as Rot
 
 from fury.actor import set_opacity
+from fury.colormap import normalize_colors
 from fury.geometry import (
     buffer_to_geometry,
     line_buffer_separator,
@@ -405,8 +406,6 @@ def actor_from_primitive(
         A mesh actor containing the generated primitive, with the specified
         material and properties.
     """
-    from fury.colormap import normalize_colors
-
     if repeat_primitive:
         colors = normalize_colors(colors, n_points=len(centers))
     else:
@@ -839,8 +838,6 @@ def line(
     >>> show_manager = window.ShowManager(scene=scene, size=(600, 600))
     >>> show_manager.start()
     """
-    from fury.colormap import normalize_colors
-
     if colors is not None:
         colors = normalize_colors(colors)
         # Squeeze single-color back to 1D for line_buffer_separator compatibility

--- a/fury/actor/curved.py
+++ b/fury/actor/curved.py
@@ -6,6 +6,7 @@ import itertools
 import numpy as np
 
 from fury.actor import Group, Line, Mesh, actor_from_primitive, create_mesh, read_buffer
+from fury.colormap import normalize_colors
 from fury.geometry import buffer_to_geometry, line_buffer_separator
 from fury.lib import (
     Buffer,
@@ -64,9 +65,8 @@ def sphere(
     centers : ndarray, shape (N, 3)
         Spheres positions.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA colors. When ``impostor=False``, accepts values in
-        [0, 255] (int), [0, 1] (float), or hex strings (e.g. "#FF0000").
-        When ``impostor=True`` (default), values must be in [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1]
+        (float), or hex strings (e.g. "#FF0000").
     radii : float or ndarray, shape (N,), optional
         Sphere radius. Can be a single value for all spheres or an array of
         radii for each sphere.
@@ -115,6 +115,8 @@ def sphere(
     if centers_arr.ndim == 1:
         centers_arr = centers_arr.reshape(1, 3)
     count = len(centers_arr)
+
+    colors = normalize_colors(colors)
 
     radii_arr = np.asarray(radii, dtype=np.float32)
     if radii_arr.ndim == 0:

--- a/fury/actor/curved.py
+++ b/fury/actor/curved.py
@@ -239,7 +239,7 @@ def ellipsoid(
 
     orientation_matrices = np.asarray(orientation_matrices)
     lengths = np.asarray(lengths)
-    colors = np.asarray(colors)
+    colors = normalize_colors(colors)
 
     if centers.ndim == 1:
         centers = centers.reshape(1, 3)

--- a/fury/actor/curved.py
+++ b/fury/actor/curved.py
@@ -64,7 +64,9 @@ def sphere(
     centers : ndarray, shape (N, 3)
         Spheres positions.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA (for opacity) R, G, B, and A should be in the range [0, 1].
+        RGB or RGBA colors. When ``impostor=False``, accepts values in
+        [0, 255] (int), [0, 1] (float), or hex strings (e.g. "#FF0000").
+        When ``impostor=True`` (default), values must be in [0, 1].
     radii : float or ndarray, shape (N,), optional
         Sphere radius. Can be a single value for all spheres or an array of
         radii for each sphere.
@@ -189,7 +191,9 @@ def ellipsoid(
     lengths : ndarray (N, 3) or (3,) or tuple (3,), optional
         Scaling factors along each axis.
     colors : array-like or tuple, optional
-        RGB/RGBA colors for each ellipsoid.
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     opacity : float, optional
         Opacity of the ellipsoids. Takes values from 0 (fully transparent) to
         1 (opaque). If both `opacity` and RGBA are provided, the final alpha
@@ -321,7 +325,9 @@ def cylinder(
     centers : ndarray, shape (N, 3)
         Cylinder positions.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA (for opacity) R, G, B, and A should be in the range [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     height : float or ndarray, shape (N,), optional
         The height of the cylinder. A single value applies to all cylinders,
         while an array specifies a height for each cylinder individually.
@@ -444,7 +450,9 @@ def cone(
     centers : ndarray, shape (N, 3)
         Cone positions.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA (for opacity) R, G, B, and A should be in the range [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     height : float or ndarray, shape (N,), optional
         The height of the cone. A single value applies to all cones,
         while an array specifies a height for each cone individually.

--- a/fury/actor/planar.py
+++ b/fury/actor/planar.py
@@ -55,7 +55,9 @@ def square(
     directions : ndarray, shape (N, 3) or tuple (3,), optional
         The orientation vector of the square.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA (for opacity) R, G, B, and A should be in the range [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     scales : ndarray, shape (N, 3) or tuple (3,) or float, optional
         The size of the square in each dimension. If a single value is provided,
         the same size will be used for all squares.
@@ -130,7 +132,9 @@ def star(
     directions : ndarray, shape (N, 3) or tuple (3,), optional
         The orientation vector of the star.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA (for opacity) R, G, B, and A should be in the range [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     scales : ndarray, shape (N, 3) or tuple (3,) or float, optional
         The size of the star in each dimension. If a single value is
         provided, the same size will be used for all stars.
@@ -202,7 +206,9 @@ def disk(
     centers : ndarray, shape (N, 3)
         Disk positions.
     colors : ndarray (N,3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA (for opacity) R, G, B and A should be at the range [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     radii : float or ndarray (N,) or tuple, optional
         The radius of the disks, single value applies to all disks,
         while an array specifies a radius for each disk individually.
@@ -308,7 +314,9 @@ def triangle(
     directions : ndarray, shape (N, 3) or tuple (3,), optional
         The orientation vector of the triangle.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA (for opacity) R, G, B, and A should be in the range [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     scales : ndarray, shape (N, 3) or tuple (3,) or float, optional
         The size of the triangle in each dimension. If a single value is provided,
         the same size will be used for all triangles.
@@ -379,7 +387,9 @@ def point(
     size : float, optional
         The size (diameter) of the points in logical pixels.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA values in the range [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     material : str, optional
         The material type for the points.
         Options are 'basic', 'gaussian'.
@@ -410,30 +420,13 @@ def point(
     >>> show_manager = window.ShowManager(scene=scene, size=(600, 600))
     >>> show_manager.start()
     """
-    if colors is None:
-        colors = np.array([1.0, 0.0, 0.0], dtype=float)
-    else:
-        colors = np.asarray(colors, dtype=float)
-    if colors.ndim == 1:
-        if colors.size not in (3, 4):
-            raise ValueError(
-                f"1D colors must have 3 or 4 channels; got size {colors.size}"
-            )
-        colors = np.tile(colors, (len(centers), 1))
-    elif colors.ndim == 2:
-        if colors.shape[1] not in (3, 4):
-            raise ValueError(
-                f"2D colors must have 3 or 4 channels; got shape {colors.shape}"
-            )
-        n_points = len(centers)
-        if colors.shape[0] not in (1, n_points):
-            raise ValueError(
-                f"colors must have 1 row or match number of points "
-                f"({n_points}); got {colors.shape[0]}"
-            )
+    from fury.colormap import normalize_colors
+
+    colors = normalize_colors(colors, n_points=len(centers))
+
     geo = buffer_to_geometry(
         positions=centers.astype("float32"),
-        colors=colors.astype("float32"),
+        colors=colors,
     )
 
     mat = _create_points_material(
@@ -469,7 +462,9 @@ def marker(
     size : float, optional
         The size (diameter) of the points in logical pixels.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA values in the range [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     marker : str or MarkerShape, optional
         The shape of the marker.
         Options are "●": "circle", "+": "plus", "x": "cross", "♥": "heart",
@@ -501,9 +496,13 @@ def marker(
     >>> show_manager = window.ShowManager(scene=scene, size=(600, 600))
     >>> show_manager.start()
     """
+    from fury.colormap import normalize_colors
+
+    colors = normalize_colors(colors, n_points=len(centers))
+
     geo = buffer_to_geometry(
         positions=centers.astype("float32"),
-        colors=colors.astype("float32"),
+        colors=colors,
     )
 
     mat = _create_points_material(
@@ -815,7 +814,9 @@ def ring(
     directions : ndarray, shape (N, 3) or tuple (3,), optional
         The orientation vector of the ring.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA (for opacity) R, G, B, and A should be in the range [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     scales : ndarray, shape (N, 3) or tuple (3,) or float, optional
         The size of the ring in each dimension. If a single value is provided,
         the same size will be used for all rings.

--- a/fury/actor/planar.py
+++ b/fury/actor/planar.py
@@ -14,6 +14,7 @@ from fury.actor import (
     create_point,
     create_text,
 )
+from fury.colormap import normalize_colors
 from fury.geometry import (
     buffer_to_geometry,
     line_buffer_separator,
@@ -420,8 +421,6 @@ def point(
     >>> show_manager = window.ShowManager(scene=scene, size=(600, 600))
     >>> show_manager.start()
     """
-    from fury.colormap import normalize_colors
-
     colors = normalize_colors(colors, n_points=len(centers))
 
     geo = buffer_to_geometry(
@@ -496,8 +495,6 @@ def marker(
     >>> show_manager = window.ShowManager(scene=scene, size=(600, 600))
     >>> show_manager.start()
     """
-    from fury.colormap import normalize_colors
-
     colors = normalize_colors(colors, n_points=len(centers))
 
     geo = buffer_to_geometry(

--- a/fury/actor/polyhedron.py
+++ b/fury/actor/polyhedron.py
@@ -26,7 +26,9 @@ def box(
     directions : ndarray, shape (N, 3) or tuple (3,), optional
         The orientation vector of the box.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA (for opacity) R, G, B, and A should be in the range [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     scales : ndarray, shape (N, 3) or tuple (3,) or float, optional
         The size of the box in each dimension. If a single value is provided,
         the same size will be used for all boxes.
@@ -101,7 +103,9 @@ def frustum(
     directions : ndarray, shape (N, 3) or tuple (3,), optional
         The orientation vector of the frustum.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA (for opacity) R, G, B, and A should be in the range [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     scales : ndarray, shape (N, 3) or tuple (3,) or float, optional
         The size of the frustum in each dimension. If a single value is provided,
         the same size will be used for all frustums.
@@ -173,7 +177,9 @@ def tetrahedron(
     directions : ndarray, shape (N, 3) or tuple (3,), optional
         The orientation vector of the tetrahedron.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA (for opacity) R, G, B, and A should be in the range [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     scales : ndarray, shape (N, 3) or tuple (3,) or float, optional
         The size of the tetrahedron in each dimension. If a single value is provided,
         the same size will be used for all tetrahedrons.
@@ -245,7 +251,9 @@ def icosahedron(
     directions : ndarray, shape (N, 3) or tuple (3,), optional
         The orientation vector of the icosahedron.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA (for opacity) R, G, B, and A should be in the range [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     scales : ndarray, shape (N, 3) or tuple (3,) or float, optional
         The size of the icosahedron in each dimension. If a single value is provided,
         the same size will be used for all icosahedrons.
@@ -317,7 +325,9 @@ def rhombicuboctahedron(
     directions : ndarray, shape (N, 3) or tuple (3,), optional
         The orientation vector of the rhombicuboctahedron.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA (for opacity) R, G, B, and A should be in the range [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     scales : ndarray, shape (N, 3) or tuple (3,) or float, optional
         The size of the rhombicuboctahedron in each dimension. If a single value is
         provided, the same size will be used for all rhombicuboctahedrons.
@@ -390,7 +400,9 @@ def triangularprism(
     directions : ndarray, shape (N, 3) or tuple (3,), optional
         The orientation vector of the triangular prism.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA (for opacity) R, G, B, and A should be in the range [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     scales : ndarray, shape (N, 3) or tuple (3,) or float, optional
         The size of the triangular prism in each dimension. If a single value is
         provided, the same size will be used for all triangular prisms.
@@ -462,7 +474,9 @@ def pentagonalprism(
     directions : ndarray, shape (N, 3) or tuple (3,), optional
         The orientation vector of the pentagonal prism.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA (for opacity) R, G, B, and A should be in the range [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     scales : ndarray, shape (N, 3) or tuple (3,) or float, optional
         The size of the pentagonal prism in each dimension. If a single value is
         provided, the same size will be used for all pentagonal prisms.
@@ -534,7 +548,9 @@ def octagonalprism(
     directions : ndarray, shape (N, 3) or tuple (3,), optional
         The orientation vector of the octagonal prism.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA (for opacity) R, G, B, and A should be in the range [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     scales : ndarray, shape (N, 3) or tuple (3,) or float, optional
         The size of the octagonal prism in each dimension. If a single value is
         provided, the same size will be used for all octagonal prisms.
@@ -609,7 +625,9 @@ def superquadric(
     roundness : tuple, optional
         Parameters (Phi and Theta) that control the shape of the superquadric.
     colors : ndarray, shape (N, 3) or (N, 4) or tuple (3,) or tuple (4,), optional
-        RGB or RGBA (for opacity) R, G, B, and A should be in the range [0, 1].
+        RGB or RGBA colors. Accepts values in [0, 255] (int), [0, 1] (float),
+        or hex strings (e.g. "#FF0000"). Values above 1.0 are treated as
+        [0, 255] and normalized internally.
     scales : ndarray, shape (N, 3) or tuple (3,) or float, optional
         The size of the superquadric in each dimension. If a single value is
         provided, the same size will be used for all superquadrics.

--- a/fury/actor/tests/test_core.py
+++ b/fury/actor/tests/test_core.py
@@ -390,3 +390,31 @@ def test_create_axes_helper_axis_vector_order():
     )
 
     np.testing.assert_array_equal(axis_vectors, expected)
+
+
+def test_actor_accepts_255_colors():
+    """Colors in [0, 255] produce same result as [0, 1]."""
+    centers = np.array([[0, 0, 0]])
+    a1 = actor.arrow(centers=centers, colors=(255, 0, 0))
+    a2 = actor.arrow(centers=centers, colors=(1.0, 0.0, 0.0))
+    np.testing.assert_array_almost_equal(
+        a1.geometry.colors.view, a2.geometry.colors.view
+    )
+
+
+def test_actor_accepts_hex_colors():
+    """Hex color strings produce same result as [0, 1]."""
+    centers = np.array([[0, 0, 0]])
+    a1 = actor.arrow(centers=centers, colors="#FF0000")
+    a2 = actor.arrow(centers=centers, colors=(1.0, 0.0, 0.0))
+    np.testing.assert_array_almost_equal(
+        a1.geometry.colors.view, a2.geometry.colors.view
+    )
+
+
+def test_actor_accepts_255_array_colors():
+    """Array of [0, 255] colors works for multiple centers."""
+    centers = np.array([[0, 0, 0], [1, 0, 0], [2, 0, 0]])
+    colors_255 = np.array([[255, 0, 0], [0, 255, 0], [0, 0, 255]])
+    a = actor.arrow(centers=centers, colors=colors_255)
+    assert a.prim_count == 3

--- a/fury/actor/tests/test_curved.py
+++ b/fury/actor/tests/test_curved.py
@@ -554,3 +554,13 @@ def test_sphere_accepts_hex_colors():
     np.testing.assert_array_almost_equal(
         a1.geometry.colors.view, a2.geometry.colors.view
     )
+
+
+def test_ellipsoid_accepts_hex_colors():
+    """Ellipsoid actor accepts hex color strings."""
+    centers = np.array([[0, 0, 0]])
+    a1 = actor.ellipsoid(centers=centers, colors="#FF0000")
+    a2 = actor.ellipsoid(centers=centers, colors=(1.0, 0.0, 0.0))
+    np.testing.assert_array_almost_equal(
+        a1.geometry.colors.view, a2.geometry.colors.view
+    )

--- a/fury/actor/tests/test_curved.py
+++ b/fury/actor/tests/test_curved.py
@@ -534,3 +534,23 @@ def test_actor_from_primitive_wireframe():
     new_thickness = 5.0
     sphere_actor.material.wireframe_thickness = new_thickness
     assert sphere_actor.material.wireframe_thickness == new_thickness
+
+
+def test_cylinder_accepts_255_colors():
+    """Cylinder actor accepts [0, 255] colors."""
+    centers = np.array([[0, 0, 0]])
+    a1 = actor.cylinder(centers=centers, colors=(255, 0, 0))
+    a2 = actor.cylinder(centers=centers, colors=(1.0, 0.0, 0.0))
+    np.testing.assert_array_almost_equal(
+        a1.geometry.colors.view, a2.geometry.colors.view
+    )
+
+
+def test_sphere_accepts_hex_colors():
+    """Sphere actor (non-impostor) accepts hex color strings."""
+    centers = np.array([[0, 0, 0]])
+    a1 = actor.sphere(centers=centers, colors="#FF0000", impostor=False)
+    a2 = actor.sphere(centers=centers, colors=(1.0, 0.0, 0.0), impostor=False)
+    np.testing.assert_array_almost_equal(
+        a1.geometry.colors.view, a2.geometry.colors.view
+    )

--- a/fury/actor/tests/test_planar.py
+++ b/fury/actor/tests/test_planar.py
@@ -630,3 +630,33 @@ def test_line_projection_material_properties():
     assert projection.material.size == 5.0
     assert projection.material.edge_width == 1.0
     assert np.round(projection.material.opacity, 1) == 0.5
+
+
+def test_disk_accepts_255_colors():
+    """Disk actor accepts [0, 255] colors."""
+    centers = np.array([[0, 0, 0]])
+    a1 = actor.disk(centers=centers, colors=(255, 0, 0))
+    a2 = actor.disk(centers=centers, colors=(1.0, 0.0, 0.0))
+    np.testing.assert_array_almost_equal(
+        a1.geometry.colors.view, a2.geometry.colors.view
+    )
+
+
+def test_point_accepts_255_colors():
+    """Point actor accepts [0, 255] colors."""
+    centers = np.array([[0, 0, 0]])
+    a1 = actor.point(centers=centers, colors=(255, 0, 0))
+    a2 = actor.point(centers=centers, colors=(1.0, 0.0, 0.0))
+    np.testing.assert_array_almost_equal(
+        a1.geometry.colors.view, a2.geometry.colors.view
+    )
+
+
+def test_marker_accepts_hex_colors():
+    """Marker actor accepts hex color strings."""
+    centers = np.array([[0, 0, 0]])
+    a1 = actor.marker(centers=centers, colors="#FF0000")
+    a2 = actor.marker(centers=centers, colors=(1.0, 0.0, 0.0))
+    np.testing.assert_array_almost_equal(
+        a1.geometry.colors.view, a2.geometry.colors.view
+    )

--- a/fury/colormap.py
+++ b/fury/colormap.py
@@ -808,6 +808,97 @@ def hex_to_rgb(color):
     return np.array([r, g, b])
 
 
+def normalize_colors(colors, n_points=None):
+    """Normalize colors to float32 arrays in [0, 1] range.
+
+    Accepts colors in multiple formats and converts them to a consistent
+    float32 ndarray with values in [0, 1], suitable for the GPU pipeline.
+
+    Parameters
+    ----------
+    colors : tuple, list, ndarray, str, or None
+        Input colors. Supported formats:
+
+        - Hex string: ``"#FF0000"`` or list of hex strings.
+        - Numeric RGB ``[0, 255]``: values > 1.0 are divided by 255.
+        - Numeric RGB ``[0, 1]``: float values <= 1.0 pass through.
+        - RGBA variants of the above.
+        - ``None``: returns default red ``[[1.0, 0.0, 0.0]]``.
+    n_points : int, optional
+        Expected number of points. If given and a single color is provided,
+        it will be broadcast (tiled) to ``(n_points, C)``. If the number of
+        colors doesn't match ``n_points`` and isn't 1, a ``ValueError``
+        is raised.
+
+    Returns
+    -------
+    ndarray, shape (N, 3) or (N, 4), dtype float32
+        Normalized colors in [0, 1].
+    """
+    if colors is None:
+        colors = np.array([[1.0, 0.0, 0.0]], dtype=np.float32)
+        if n_points is not None:
+            colors = np.tile(colors, (n_points, 1))
+        return colors
+
+    # Handle hex strings
+    if isinstance(colors, str):
+        colors = np.array([hex_to_rgb(colors)], dtype=np.float32)
+        if n_points is not None:
+            colors = np.tile(colors, (n_points, 1))
+        return colors
+
+    if isinstance(colors, (list, tuple)) and len(colors) > 0:
+        if isinstance(colors[0], str):
+            colors = np.array([hex_to_rgb(c) for c in colors], dtype=np.float32)
+            if n_points is not None:
+                if len(colors) == 1:
+                    colors = np.tile(colors, (n_points, 1))
+                elif len(colors) != n_points:
+                    raise ValueError(
+                        f"Number of colors ({len(colors)}) must be 1 or match "
+                        f"n_points ({n_points})."
+                    )
+            return colors
+
+    # Numeric input
+    colors = np.asarray(colors, dtype=np.float64)
+
+    if colors.size == 0:
+        return colors.astype(np.float32).reshape(-1, 3)
+
+    # Ensure 2D; pass through higher-dimensional arrays with range normalization
+    if colors.ndim == 1:
+        if colors.size not in (3, 4):
+            raise ValueError(f"1D colors must have 3 or 4 elements; got {colors.size}.")
+        colors = colors.reshape(1, -1)
+    elif colors.ndim > 2:
+        if colors.max() > 1.0:
+            colors = colors / 255.0
+        return colors.astype(np.float32)
+
+    if colors.shape[1] not in (3, 4):
+        raise ValueError(f"colors must have 3 or 4 channels; got {colors.shape[1]}.")
+
+    # Detect [0, 255] range and normalize
+    if colors.max() > 1.0:
+        colors = colors / 255.0
+
+    colors = colors.astype(np.float32)
+
+    # Broadcasting
+    if n_points is not None:
+        if len(colors) == 1:
+            colors = np.tile(colors, (n_points, 1))
+        elif len(colors) != n_points:
+            raise ValueError(
+                f"Number of colors ({len(colors)}) must be 1 or match "
+                f"n_points ({n_points})."
+            )
+
+    return colors
+
+
 def rgb2hsv(rgb):
     """Convert RGB color values to HSV color space.
 

--- a/fury/colormap.py
+++ b/fury/colormap.py
@@ -886,7 +886,6 @@ def normalize_colors(colors, n_points=None):
 
     colors = colors.astype(np.float32)
 
-    # Broadcasting
     if n_points is not None:
         if len(colors) == 1:
             colors = np.tile(colors, (n_points, 1))

--- a/fury/colormap.py
+++ b/fury/colormap.py
@@ -835,67 +835,61 @@ def normalize_colors(colors, n_points=None):
     ndarray, shape (N, 3) or (N, 4), dtype float32
         Normalized colors in [0, 1].
     """
-    if colors is None:
-        colors = np.array([[1.0, 0.0, 0.0]], dtype=np.float32)
-        if n_points is not None:
-            colors = np.tile(colors, (n_points, 1))
+
+    def _tile_colors(colors):
+        """Tile a single color when a point count is requested.
+
+        Parameters
+        ----------
+        colors : ndarray
+            Color array to validate and tile.
+
+        Returns
+        -------
+        ndarray
+            Color array broadcast to ``n_points`` when needed.
+        """
+        if n_points is None:
+            return colors
+        if len(colors) == 1:
+            return np.tile(colors, (n_points, 1))
+        if len(colors) != n_points:
+            raise ValueError(
+                f"Number of colors ({len(colors)}) must be 1 or match "
+                f"n_points ({n_points})."
+            )
         return colors
 
-    # Handle hex strings
+    if colors is None:
+        colors = np.array([[1.0, 0.0, 0.0]], dtype=np.float32)
+        return _tile_colors(colors)
+
     if isinstance(colors, str):
         colors = np.array([hex_to_rgb(colors)], dtype=np.float32)
-        if n_points is not None:
-            colors = np.tile(colors, (n_points, 1))
-        return colors
+        return _tile_colors(colors)
 
     if isinstance(colors, (list, tuple)) and len(colors) > 0:
         if isinstance(colors[0], str):
             colors = np.array([hex_to_rgb(c) for c in colors], dtype=np.float32)
-            if n_points is not None:
-                if len(colors) == 1:
-                    colors = np.tile(colors, (n_points, 1))
-                elif len(colors) != n_points:
-                    raise ValueError(
-                        f"Number of colors ({len(colors)}) must be 1 or match "
-                        f"n_points ({n_points})."
-                    )
-            return colors
+            return _tile_colors(colors)
 
-    # Numeric input
     colors = np.asarray(colors, dtype=np.float64)
 
     if colors.size == 0:
         return colors.astype(np.float32).reshape(-1, 3)
 
-    # Ensure 2D; pass through higher-dimensional arrays with range normalization
+    if colors.shape[-1] not in (3, 4):
+        raise ValueError(f"colors must have 3 or 4 channels; got {colors.shape[-1]}.")
+
     if colors.ndim == 1:
-        if colors.size not in (3, 4):
-            raise ValueError(f"1D colors must have 3 or 4 elements; got {colors.size}.")
         colors = colors.reshape(1, -1)
-    elif colors.ndim > 2:
-        if colors.max() > 1.0:
-            colors = colors / 255.0
-        return colors.astype(np.float32)
 
-    if colors.shape[1] not in (3, 4):
-        raise ValueError(f"colors must have 3 or 4 channels; got {colors.shape[1]}.")
-
-    # Detect [0, 255] range and normalize
     if colors.max() > 1.0:
         colors = colors / 255.0
 
     colors = colors.astype(np.float32)
 
-    if n_points is not None:
-        if len(colors) == 1:
-            colors = np.tile(colors, (n_points, 1))
-        elif len(colors) != n_points:
-            raise ValueError(
-                f"Number of colors ({len(colors)}) must be 1 or match "
-                f"n_points ({n_points})."
-            )
-
-    return colors
+    return _tile_colors(colors)
 
 
 def rgb2hsv(rgb):

--- a/fury/tests/test_colormap.py
+++ b/fury/tests/test_colormap.py
@@ -194,3 +194,83 @@ def test_color_converters():
         hsv_color = colormap.rgb2hsv(color)
         rgb_from_hsv_color = colormap.hsv2rgb(hsv_color)
         npt.assert_almost_equal(rgb_from_hsv_color, color)
+
+
+def test_normalize_colors():
+    from fury.colormap import normalize_colors
+
+    # [0, 255] RGB tuple
+    result = normalize_colors((255, 0, 0))
+    npt.assert_array_almost_equal(result, [[1.0, 0.0, 0.0]])
+    assert result.dtype == np.float32
+
+    # [0, 1] RGB tuple (backward compat)
+    result = normalize_colors((0.5, 0.5, 0.5))
+    npt.assert_array_almost_equal(result, [[0.5, 0.5, 0.5]])
+    assert result.dtype == np.float32
+
+    # [0, 255] ndarray
+    colors_255 = np.array([[255, 0, 0], [0, 255, 0]])
+    result = normalize_colors(colors_255)
+    expected = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+    npt.assert_array_almost_equal(result, expected)
+    assert result.shape == (2, 3)
+
+    # RGBA [0, 255]
+    result = normalize_colors((255, 0, 0, 128))
+    npt.assert_array_almost_equal(result, [[1.0, 0.0, 0.0, 128 / 255.0]])
+    assert result.shape == (1, 4)
+
+    # RGBA [0, 1]
+    result = normalize_colors((1.0, 0.0, 0.0, 0.5))
+    npt.assert_array_almost_equal(result, [[1.0, 0.0, 0.0, 0.5]])
+
+    # Hex string
+    result = normalize_colors("#FF0000")
+    npt.assert_array_almost_equal(result, [[1.0, 0.0, 0.0]])
+
+    # Hex list
+    result = normalize_colors(["#FF0000", "#00FF00"])
+    npt.assert_array_almost_equal(result, [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+    assert result.shape == (2, 3)
+
+    # n_points broadcasting
+    result = normalize_colors((255, 0, 0), n_points=5)
+    assert result.shape == (5, 3)
+    npt.assert_array_almost_equal(result[0], [1.0, 0.0, 0.0])
+    npt.assert_array_almost_equal(result[4], [1.0, 0.0, 0.0])
+
+    # None → default red
+    result = normalize_colors(None)
+    npt.assert_array_almost_equal(result, [[1.0, 0.0, 0.0]])
+
+    # Single color with n_points broadcasts (no error)
+    result = normalize_colors((255, 0, 0), n_points=3)
+    assert result.shape == (3, 3)
+
+    # Multiple colors mismatching n_points → ValueError
+    with pytest.raises(ValueError):
+        normalize_colors(np.array([[255, 0, 0], [0, 255, 0]]), n_points=5)
+
+    # Output dtype is always float32
+    result = normalize_colors(np.array([[0.1, 0.2, 0.3]], dtype=np.float64))
+    assert result.dtype == np.float32
+
+    # Black (0, 0, 0) passes through correctly
+    result = normalize_colors((0, 0, 0))
+    npt.assert_array_almost_equal(result, [[0.0, 0.0, 0.0]])
+
+    # Hex string with n_points broadcasting
+    result = normalize_colors("#FF0000", n_points=3)
+    assert result.shape == (3, 3)
+
+    # Hex list with n_points mismatch
+    with pytest.raises(ValueError):
+        normalize_colors(["#FF0000", "#00FF00"], n_points=5)
+
+    # Invalid channel count
+    with pytest.raises(ValueError):
+        normalize_colors((1, 2))
+
+    with pytest.raises(ValueError):
+        normalize_colors((1, 2, 3, 4, 5))

--- a/fury/tests/test_colormap.py
+++ b/fury/tests/test_colormap.py
@@ -252,6 +252,9 @@ def test_normalize_colors():
     with pytest.raises(ValueError):
         normalize_colors(np.array([[255, 0, 0], [0, 255, 0]]), n_points=5)
 
+    with pytest.raises(ValueError):
+        normalize_colors(np.zeros((2, 2, 3)), n_points=5)
+
     # Output dtype is always float32
     result = normalize_colors(np.array([[0.1, 0.2, 0.3]], dtype=np.float64))
     assert result.dtype == np.float32


### PR DESCRIPTION
Work Towards #1089 

This pull request improves color handling for various actor creation functions in the FURY library. It enhances the flexibility of color inputs by allowing colors to be specified as floats in [0, 1], integers in [0, 255], or hex strings (e.g., "#FF0000"), and ensures consistent normalization internally. It also refactors the code to use a centralized `normalize_colors` function, simplifying color validation and processing across multiple modules.

**Color Input Flexibility and Normalization**

* Updated docstrings for all relevant actor functions (e.g., `arrow`, `line`, `sphere`, `cylinder`, `box`, etc.) to clarify that color arguments can now be provided as floats in [0, 1], integers in [0, 255], or hex strings. Values above 1.0 are treated as [0, 255] and normalized internally. [[1]](diffhunk://#diff-617222f9136febde936fe929a4e4f975e848b39554dd734ef68de870bd86a4c4L368-R370) [[2]](diffhunk://#diff-617222f9136febde936fe929a4e4f975e848b39554dd734ef68de870bd86a4c4L478-R488) [[3]](diffhunk://#diff-617222f9136febde936fe929a4e4f975e848b39554dd734ef68de870bd86a4c4L745-R757) [[4]](diffhunk://#diff-833e9c0540fa4a5eac47e1e1f9e1a6bc835704fbb03bbe60460d8030c7d04bfeL67-R69) [[5]](diffhunk://#diff-833e9c0540fa4a5eac47e1e1f9e1a6bc835704fbb03bbe60460d8030c7d04bfeL192-R196) [[6]](diffhunk://#diff-833e9c0540fa4a5eac47e1e1f9e1a6bc835704fbb03bbe60460d8030c7d04bfeL324-R330) [[7]](diffhunk://#diff-833e9c0540fa4a5eac47e1e1f9e1a6bc835704fbb03bbe60460d8030c7d04bfeL413-R421) [[8]](diffhunk://#diff-aa5c00574844974e2fca98de7ae59a6ffdfb1ba2a4b1659657c4fba286ea71cfL57-R59) [[9]](diffhunk://#diff-aa5c00574844974e2fca98de7ae59a6ffdfb1ba2a4b1659657c4fba286ea71cfL132-R136) [[10]](diffhunk://#diff-aa5c00574844974e2fca98de7ae59a6ffdfb1ba2a4b1659657c4fba286ea71cfL204-R210) [[11]](diffhunk://#diff-aa5c00574844974e2fca98de7ae59a6ffdfb1ba2a4b1659657c4fba286ea71cfL285-R293) [[12]](diffhunk://#diff-aa5c00574844974e2fca98de7ae59a6ffdfb1ba2a4b1659657c4fba286ea71cfL356-R366) [[13]](diffhunk://#diff-aa5c00574844974e2fca98de7ae59a6ffdfb1ba2a4b1659657c4fba286ea71cfL446-R441) [[14]](diffhunk://#diff-aa5c00574844974e2fca98de7ae59a6ffdfb1ba2a4b1659657c4fba286ea71cfL720-R721) [[15]](diffhunk://#diff-64a012894b4152f45bda13ba850a3c0245c166137784baa772ec5ae4ba3e6b67L29-R31) [[16]](diffhunk://#diff-64a012894b4152f45bda13ba850a3c0245c166137784baa772ec5ae4ba3e6b67L104-R108) [[17]](diffhunk://#diff-64a012894b4152f45bda13ba850a3c0245c166137784baa772ec5ae4ba3e6b67L176-R182) [[18]](diffhunk://#diff-64a012894b4152f45bda13ba850a3c0245c166137784baa772ec5ae4ba3e6b67L248-R256) [[19]](diffhunk://#diff-64a012894b4152f45bda13ba850a3c0245c166137784baa772ec5ae4ba3e6b67L320-R330) [[20]](diffhunk://#diff-64a012894b4152f45bda13ba850a3c0245c166137784baa772ec5ae4ba3e6b67L393-R405) [[21]](diffhunk://#diff-64a012894b4152f45bda13ba850a3c0245c166137784baa772ec5ae4ba3e6b67L465-R479)

**Centralized Color Normalization**

* Introduced and utilized the `normalize_colors` function from `fury.colormap` in key actor functions (`actor_from_primitive`, `line`, `point`, `marker`) to standardize and simplify color input handling. [[1]](diffhunk://#diff-7b523032a8cd9c56f3e821525bab88914ed802166af18a357413bdce6f4ab0e6R167) [[2]](diffhunk://#diff-617222f9136febde936fe929a4e4f975e848b39554dd734ef68de870bd86a4c4R400-R405) [[3]](diffhunk://#diff-617222f9136febde936fe929a4e4f975e848b39554dd734ef68de870bd86a4c4R784-R790) [[4]](diffhunk://#diff-aa5c00574844974e2fca98de7ae59a6ffdfb1ba2a4b1659657c4fba286ea71cfL387-R403) [[5]](diffhunk://#diff-aa5c00574844974e2fca98de7ae59a6ffdfb1ba2a4b1659657c4fba286ea71cfR473-R479)

**Codebase Simplification and Consistency**

* Removed redundant color validation and broadcasting logic from functions like `point` and `marker`, replacing them with calls to `normalize_colors` for cleaner, more maintainable code. [[1]](diffhunk://#diff-aa5c00574844974e2fca98de7ae59a6ffdfb1ba2a4b1659657c4fba286ea71cfL387-R403) [[2]](diffhunk://#diff-aa5c00574844974e2fca98de7ae59a6ffdfb1ba2a4b1659657c4fba286ea71cfR473-R479)

These changes make the API more user-friendly and robust, allowing a wider variety of color specifications and reducing duplicated code for color handling.Add normalize_colors() to fury/colormap.py that accepts colors in [0, 255] int, [0, 1] float, hex strings, and RGBA formats, converting them to float32 [0, 1] arrays for the GPU pipeline. Wire it into actor_from_primitive(), line(), point(), and marker() so all actors built through these paths now accept the new formats. Update docstrings for all affected actors and add unit + integration tests.