### PR TITLE
BUG: Replace distutils.LooseVersion with packaging.Version in testing.py

### DIFF
--- a/fury/testing.py
+++ b/fury/testing.py
@@ -1,7 +1,7 @@
 """Utilities for testing."""
 
 from contextlib import contextmanager
-from distutils.version import LooseVersion
+from packaging.version import Version
 from functools import partial
 import io
 import json
@@ -339,7 +339,7 @@ def setup_test():
     https://github.com/numpy/numpy/commit/734b907fc2f7af6e40ec989ca49ee6d87e21c495
     https://github.com/nipy/nibabel/pull/556
     """
-    if LooseVersion(np.__version__) >= LooseVersion("1.14"):
+    if Version(np.__version__) >= Version("1.14"):
         np.set_printoptions(legacy="1.13")
 
     # Temporary fix until scipy release in October 2018
@@ -347,8 +347,8 @@ def setup_test():
     # print the first occurrence of matching warnings for each location
     # (module + line number) where the warning is issued
     if (
-        LooseVersion(np.__version__) >= LooseVersion("1.15")
-        and LooseVersion(scipy.version.short_version) <= "1.1.0"
+        Version(np.__version__) >= Version("1.15")
+        and Version(scipy.version.short_version) <= Version("1.1.0")
     ):
         warnings.simplefilter("default")
 


### PR DESCRIPTION
distutils was removed in Python 3.12 (PEP 632), causing 11 test files to fail during collection with ModuleNotFoundError.

Replace distutils.version.LooseVersion with packaging.version.Version, which is already a project dependency.

Closes #1173