### PR TITLE
DOC: Register missing examples in _valid_examples.toml

### DIFF
--- a/docs/examples/_valid_examples.toml
+++ b/docs/examples/_valid_examples.toml
@@ -37,7 +37,8 @@ files = [
     "viz_line_projections.py",
     "viz_streamlines_roi.py",
     "viz_contour.py",
-
+    "viz_billboard_spheres.py",
+    "viz_streamtube.py",
 ]
 
 [ui]
@@ -49,6 +50,7 @@ files = [
     "viz_panel.py",
     "viz_sliders.py",
     "viz_button.py",
+    "viz_textblock.py",
 ]
 
 [animation]

--- a/docs/examples/viz_billboard_spheres.py
+++ b/docs/examples/viz_billboard_spheres.py
@@ -1,7 +1,7 @@
 """
-===========================
+=============================
 Billboard vs Geometry Spheres
-===========================
+=============================
 
 This example demonstrates the difference between billboard-based sphere impostors
 and traditional geometry-based spheres. Billboard spheres are rendered as textured


### PR DESCRIPTION
## Summary

This PR registers three existing example files in `docs/examples/_valid_examples.toml`:

- `viz_billboard_spheres.py`
- `viz_streamtube.py`
- `viz_textblock.py`

This removes the corresponding "not found in examples description file" warnings during the docs build.

While testing, I also fixed a too-short RST title underline in `viz_billboard_spheres.py` that became visible once the file was included in the gallery.

## Testing

Ran the docs build locally and confirmed:
- the three missing-example warnings are gone
- the title underline warning is gone
- no new warnings were introduced