### PR TITLE
DOC: Fix lowercase 'returns' to 'Returns' in rotate_vector docstring

### DIFF
--- a/fury/geometry.py
+++ b/fury/geometry.py
@@ -124,7 +124,7 @@ def rotate_vector(v, axis, angle):
     angle : float
         The angle of rotation in radians.
 
-    returns
+    Returns
     -------
     array_like
         The rotated vector.
@@ -198,3 +198,5 @@ def axes_for_dir(d, prev_x=None):
     x /= np.linalg.norm(x)
     y = np.cross(d, x)
     return x, y
+
+


### PR DESCRIPTION
## What does this PR do?
Fixes a minor docstring formatting issue in `geometry.py`.

The `rotate_vector` function had a lowercase `returns` section header 
instead of the correct NumPy docstring standard `Returns`.

## Type of change
- [x] Documentation fix

## Related issue
This fix is part of the broader documentation quality improvements 
related to the GSoC 2026 project: "Improving FURY Documentation Generation"