### PR TITLE
DOC: refresh contributing guide lint and python support

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -92,13 +92,14 @@ Ready to contribute? Here's how to set up `FURY` for local development.
 
     $ pip install -r requirements/optional.txt
     $ pip install -r requirements/test.txt
+    $ pip install -r requirements/style.txt
 
-8. When you're done making changes, check that your changes pass flake8 and pytest::
+8. When you're done making changes, check that your changes pass ruff and pytest::
 
-    $ flake8 fury
-    $ pytest -svv fury
+    $ ruff check fury
+    $ pytest fury
 
-   To get flake8 and pytest, just pip install them into your virtualenv.
+    To get ruff and pytest, install style and test requirements into your virtualenv.
 
 9. Submit a pull request through the GitHub website.
 
@@ -111,7 +112,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.md.
-3. The pull request should work for Python 3.6, 3.7, 3.8, 3.9 and for PyPy. Check
+3. The pull request should work for supported Python versions (3.10+). Check
    https://github.com/fury-gl/fury/actions
    and make sure that the tests pass for all supported Python versions.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -88,20 +88,24 @@ Ready to contribute? Here's how to set up `FURY` for local development.
     $ git commit -m "Your detailed description of your changes."
     $ git push origin name-of-your-bugfix-or-feature
 
-7. Install the required packages for running the unittests::
+7. Install the required packages for running the unittests and linting::
 
     $ pip install -r requirements/optional.txt
     $ pip install -r requirements/test.txt
     $ pip install -r requirements/style.txt
 
-8. When you're done making changes, check that your changes pass ruff and pytest::
+8. Set up pre-commit hooks for automatic code formatting::
+
+    $ pre-commit install
+
+   This will ensure that your code is automatically formatted according to the project's style guidelines before you push your changes.
+
+9. When you're done making changes, check that your changes pass ruff and pytest::
 
     $ ruff check fury
     $ pytest fury
 
-    To get ruff and pytest, install style and test requirements into your virtualenv.
-
-9. Submit a pull request through the GitHub website.
+10. Submit a pull request through the GitHub website.
 
 Pull Request Guidelines
 -----------------------


### PR DESCRIPTION
Title

Update outdated contributor guide to match current project setup

Description

The CONTRIBUTING.rst file contains outdated instructions, including references to flake8 and older Python versions (3.6–3.9). However, the project has already migrated to a newer configuration and updated testing/linting workflow. This mismatch can confuse new contributors and lead to incorrect setup.

Changes

Removed flake8 command and updated linting instructions to match the current tooling

Updated supported Python versions to align with the versions used in CI

Refreshed testing commands (pytest) and dependency installation steps

Improved clarity of setup instructions for contributors

Results

The contributor guide is now aligned with the current project configuration, making it easier for contributors to set up the environment correctly and follow the proper development workflow.