### PR TITLE
Feature/text box 2d

### DIFF
--- a/docs/examples/_valid_examples.toml
+++ b/docs/examples/_valid_examples.toml
@@ -48,6 +48,7 @@ files = [
     "viz_shapes.py",
     "viz_panel.py",
     "viz_textblock.py",
+    "viz_textbox.py",
     "viz_sliders.py",
     "viz_button.py",
 ]

--- a/docs/examples/viz_textbox.py
+++ b/docs/examples/viz_textbox.py
@@ -1,0 +1,34 @@
+"""
+=========
+TextBox2D
+=========
+
+This example shows how to use TextBox2D.
+"""
+
+from fury.ui import TextBox2D
+from fury.window import Scene, ShowManager
+
+scene = Scene()
+
+textbox = TextBox2D(
+    width=20,
+    height=5,
+    text="1",
+    position=(100, 100),
+    color=(0, 0, 0),
+    font_size=50,
+)
+
+
+def on_off_focus(tb):
+    print("TextBox2D:", tb.message)
+
+
+textbox.off_focus = on_off_focus
+scene.add(textbox)
+
+if __name__ == "__main__":
+    show_manager = ShowManager(scene=scene, size=(800, 600), title="FURY TextBox2D Example")
+    show_manager.start()
+

--- a/fury/ui/__init__.pyi
+++ b/fury/ui/__init__.pyi
@@ -10,7 +10,7 @@ __all__ = [
     "TexturedButton2D",
     "TextButton2D",
     "LineSlider2D",
-    #     "TextBox2D",
+    "TextBox2D",
     #     "LineDoubleSlider2D",
     #     "RingSlider2D",
     #     "RangeSlider",
@@ -46,6 +46,7 @@ __all__ = [
 # from .core import UI, Button2D, Disk2D, Rectangle2D, TextBlock2D
 
 from .containers import Panel2D
+from .containers import TextBox2D
 from .context import UIContext
 from .core import UI, Anchor, Disk2D, Rectangle2D, TextBlock2D
 from .elements import LineSlider2D, TextButton2D, TexturedButton2D

--- a/fury/ui/containers.py
+++ b/fury/ui/containers.py
@@ -4,7 +4,329 @@
 
 import numpy as np
 
-from fury.ui.core import UI, Anchor, Rectangle2D
+from fury.ui.context import UIContext
+from fury.ui.core import UI, Anchor, Rectangle2D, TextBlock2D
+import re
+import string
+
+
+class TextBox2D(UI):
+    """An editable 2D text box UI component.
+
+    Parameters
+    ----------
+    width : int
+        Number of characters per line (logical width).
+    height : int
+        Number of lines (logical height).
+    text : str, optional
+        Initial text.
+    position : (float, float), optional
+        Top-left position in pixels.
+    color : (float, float, float), optional
+        Text color (0-1).
+    font_size : int, optional
+        Font size in pixels.
+    font_family : str, optional
+        Font family.
+    justification : str, optional
+        left, center, right.
+    bold : bool, optional
+        Bold text.
+    italic : bool, optional
+        Italic text.
+    shadow : bool, optional
+        Unused in v2 for now (kept for API compatibility).
+    """
+
+    def __init__(
+        self,
+        width,
+        height,
+        *,
+        text="Enter Text",
+        position=(100, 10),
+        color=(0, 0, 0),
+        font_size=18,
+        font_family="Arial",
+        justification="left",
+        bold=False,
+        italic=False,
+        shadow=False,
+    ):
+        self.width = int(width)
+        self.height = int(height)
+
+        self.message = text
+        self.window_left = 0
+        self.window_right = 0
+        self.caret_pos = 0
+        self.init = True
+
+        self.off_focus = lambda ui: None
+
+        self._font_size = font_size
+        self._font_family = font_family
+        self._justification = justification
+        self._bold = bold
+        self._italic = italic
+        self._shadow = shadow
+        self._color = color
+        self._bg_color = (1, 1, 1)
+        self._padding_px = 0
+        self._inner_size = (1, 1)
+        self._bg_size = (1, 1)
+
+        super(TextBox2D, self).__init__(position=position, x_anchor=Anchor.LEFT, y_anchor=Anchor.TOP)
+
+        self.on_key_press = self._key_press
+
+        self.text.message = text
+        self.text.font_size = font_size
+        self.text.font_family = font_family
+        self.text.justification = justification
+        self.text.bold = bold
+        self.text.italic = italic
+        self.text.color = color
+
+        self.window_right = len(self.message)
+        self.caret_pos = self.window_right
+        self.render_text(show_caret=False)
+
+    def _setup(self):
+        self.text = TextBlock2D(
+            text="",
+            dynamic_bbox=True,
+            bg_color=self._bg_color,
+            font_size=self._font_size,
+            font_family=self._font_family,
+            justification=self._justification,
+            vertical_justification="middle",
+            bold=self._bold,
+            italic=self._italic,
+            color=self._color,
+        )
+
+        self.text.on_left_mouse_button_pressed = self._left_button_press
+        self.text.background.on_left_mouse_button_pressed = self._left_button_press
+
+    def _get_actors(self):
+        return self.text.actors
+
+    def _get_size(self):
+        return self.text.size
+
+    def _update_actors_position(self):
+        pos = self.get_position(x_anchor=Anchor.LEFT, y_anchor=Anchor.TOP)
+        self.text.set_position(pos, x_anchor=Anchor.LEFT, y_anchor=Anchor.TOP)
+
+    def set_message(self, message):
+        self.message = message
+        self.text.message = message
+        self.init = False
+        self.window_right = len(self.message)
+        self.window_left = 0
+        self.caret_pos = self.window_right
+
+    def width_set_text(self, text):
+        multi_line_text = ""
+        for i, t in enumerate(text):
+            multi_line_text += t
+            if (i + 1) % self.width == 0:
+                multi_line_text += "\n"
+        return multi_line_text.rstrip("\n")
+
+    def move_caret_right(self):
+        self.caret_pos = min(self.caret_pos + 1, len(self.message))
+
+    def move_caret_left(self):
+        self.caret_pos = max(self.caret_pos - 1, 0)
+
+    def right_move_right(self):
+        if self.window_right <= len(self.message):
+            self.window_right += 1
+
+    def right_move_left(self):
+        if self.window_right > 0:
+            self.window_right -= 1
+
+    def left_move_right(self):
+        if self.window_left <= len(self.message):
+            self.window_left += 1
+
+    def left_move_left(self):
+        if self.window_left > 0:
+            self.window_left -= 1
+
+    def add_character(self, character):
+        if len(character) > 1 and character.lower() != "space":
+            return
+        if character.lower() == "space":
+            character = " "
+        self.message = self.message[: self.caret_pos] + character + self.message[self.caret_pos :]
+        self.move_caret_right()
+        if self.window_right - self.window_left == self.height * self.width - 1:
+            self.left_move_right()
+        self.right_move_right()
+
+    def remove_character(self):
+        if self.caret_pos == 0:
+            return
+        self.message = self.message[: self.caret_pos - 1] + self.message[self.caret_pos :]
+        self.move_caret_left()
+        if len(self.message) < self.height * self.width - 1:
+            self.right_move_left()
+        if self.window_right - self.window_left == self.height * self.width - 1:
+            if self.window_left > 0:
+                self.left_move_left()
+                self.right_move_left()
+
+    def move_left(self):
+        self.move_caret_left()
+        if self.caret_pos == self.window_left - 1:
+            if self.window_right - self.window_left == self.height * self.width - 1:
+                self.left_move_left()
+                self.right_move_left()
+
+    def move_right(self):
+        self.move_caret_right()
+        if self.caret_pos == self.window_right + 1:
+            if self.window_right - self.window_left == self.height * self.width - 1:
+                self.left_move_right()
+                self.right_move_right()
+
+    def showable_text(self, show_caret):
+        if show_caret:
+            ret_text = self.message[: self.caret_pos] + "_" + self.message[self.caret_pos :]
+        else:
+            ret_text = self.message
+        return ret_text[self.window_left : self.window_right + 1]
+
+    def render_text(self, *, show_caret=True):
+        text = self.showable_text(show_caret)
+        if text == "":
+            text = "Enter Text"
+        display_text = text.replace(" ", "\u00A0")
+        self.text.message = self.width_set_text(display_text)
+
+    def edit_mode(self):
+        if self.init:
+            self.message = ""
+            self.init = False
+            self.caret_pos = 0
+            self.window_left = 0
+            self.window_right = 0
+        UIContext.active_ui = self
+        self.render_text()
+
+    def _left_button_press(self, _event):
+        self.edit_mode()
+
+    def _key_press(self, event):
+        if UIContext.active_ui is not self:
+            return
+
+        ev_t = str(getattr(event, "type", "")).lower()
+        if "key_up" in ev_t:
+            return
+
+        key_raw = getattr(event, "key", "") or ""
+        key = key_raw if key_raw == " " else key_raw.strip()
+        key_l = key.lower()
+        modifiers = getattr(event, "modifiers", None) or ()
+
+        if key_l in {
+            "shift",
+            "control",
+            "ctrl",
+            "alt",
+            "meta",
+            "capslock",
+            "numlock",
+            "scrolllock",
+            "tab",
+            "escape",
+            "esc",
+        }:
+            return
+
+        if key_l in {"enter", "return"}:
+            self.render_text(show_caret=False)
+            UIContext.active_ui = None
+            self.off_focus(self)
+            return
+
+        if key_l == "backspace":
+            self.remove_character()
+        elif key_l in {"arrowleft", "left"}:
+            self.move_left()
+        elif key_l in {"arrowright", "right"}:
+            self.move_right()
+        else:
+            key_char = ""
+
+            if key_l in {"space", "spacebar"}:
+                key_char = " "
+            elif len(key) == 1 and key in string.printable and key not in "\r\n\t":
+                key_char = key
+            elif "numpad" in key_l or key_l.startswith("kp") or key_l.startswith("kp_"):
+                m = re.search(r"([0-9])", key_l)
+                if m:
+                    key_char = m.group(1)
+            elif key_l in {
+                "end",
+                "down",
+                "pagedown",
+                "left",
+                "clear",
+                "right",
+                "home",
+                "up",
+                "pageup",
+                "insert",
+            }:
+                nav_to_digit = {
+                    "end": "1",
+                    "down": "2",
+                    "pagedown": "3",
+                    "left": "4",
+                    "clear": "5",
+                    "right": "6",
+                    "home": "7",
+                    "up": "8",
+                    "pageup": "9",
+                    "insert": "0",
+                }
+                key_char = nav_to_digit.get(key_l, "")
+            elif key_l.startswith("key") and len(key) >= 4:
+                key_char = key[-1]
+            elif key_l.startswith("digit") and len(key) >= 6:
+                key_char = key[-1]
+            else:
+                named = {
+                    "minus": "-",
+                    "equal": "=",
+                    "comma": ",",
+                    "period": ".",
+                    "slash": "/",
+                    "backslash": "\\",
+                    "semicolon": ";",
+                    "quote": "'",
+                    "bracketleft": "[",
+                    "bracketright": "]",
+                    "backquote": "`",
+                }
+                if key_l in named:
+                    key_char = named[key_l]
+                else:
+                    m = re.search(r"([A-Za-z0-9])$", key)
+                    if m:
+                        key_char = m.group(1)
+
+            if key_char:
+                self.add_character(key_char)
+
+        self.render_text()
 
 
 class Panel2D(UI):

--- a/fury/ui/tests/test_textbox2d.py
+++ b/fury/ui/tests/test_textbox2d.py
@@ -1,0 +1,76 @@
+import types
+
+from fury.ui import TextBox2D, UIContext
+from fury.lib import EventType
+
+
+def _key_event(key: str):
+    return types.SimpleNamespace(key=key, modifiers=[], type=EventType.KEY_DOWN)
+
+
+def test_textbox2d_set_message_and_init_state():
+    tb = TextBox2D(width=10, height=2, text="Enter Text")
+    tb.set_message("abc")
+    assert tb.message == "abc"
+    assert tb.init is False
+    assert tb.caret_pos == len("abc")
+
+
+def test_textbox2d_basic_editing_and_caret_moves():
+    tb = TextBox2D(width=10, height=2, text="Enter Text")
+    tb.edit_mode()
+    tb._key_press(_key_event("a"))
+    tb._key_press(_key_event("b"))
+    tb._key_press(_key_event("c"))
+    assert tb.message == "abc"
+    assert tb.caret_pos == 3
+
+    tb._key_press(_key_event("ArrowLeft"))
+    tb._key_press(_key_event("Backspace"))
+    assert tb.message == "ac"
+    assert tb.caret_pos == 1
+
+
+def test_textbox2d_num_pad_inserts_digit():
+    tb = TextBox2D(width=10, height=2, text="Enter Text")
+    tb.edit_mode()
+    tb._key_press(_key_event("Numpad3"))
+    tb._key_press(_key_event("KP_1"))
+    assert tb.message == "31"
+
+
+def test_textbox2d_num_pad_variants_and_numlock_off():
+    tb = TextBox2D(width=10, height=2, text="Enter Text")
+    tb.edit_mode()
+    tb._key_press(_key_event("Numpad0"))
+    tb._key_press(_key_event("KP_8"))
+    tb._key_press(_key_event("KP9"))
+    tb._key_press(_key_event("Digit4"))
+    tb._key_press(_key_event("End"))
+    tb._key_press(_key_event("Down"))
+    tb._key_press(_key_event("PageDown"))
+    tb._key_press(_key_event("Insert"))
+    assert tb.message == "08941230"
+
+
+def test_textbox2d_wraps_text_for_multiline():
+    tb = TextBox2D(width=3, height=2, text="Enter Text")
+    tb.set_message("abcdef")
+    assert tb.width_set_text("abcdef") == "abc\ndef"
+
+
+def test_textbox2d_focus_and_off_focus_on_enter():
+    tb = TextBox2D(width=10, height=2, text="Enter Text")
+    called = {"value": False}
+
+    def _off_focus(_ui):
+        called["value"] = True
+
+    tb.off_focus = _off_focus
+
+    tb.edit_mode()
+    assert UIContext.active_ui is tb
+    tb._key_press(_key_event("Enter"))
+    assert UIContext.active_ui is None
+    assert called["value"] is True
+

--- a/fury/window.py
+++ b/fury/window.py
@@ -12,6 +12,7 @@ from functools import reduce
 import logging
 import os
 import sys
+import types
 
 from PIL.Image import fromarray as image_from_array
 import numpy as np
@@ -38,6 +39,7 @@ from fury.lib import (
     ScreenCoordsCamera,
     Stats,
     TrackballController,
+    KeyboardEvent,
     UIRenderer,
     Viewport,
     call_later,
@@ -641,7 +643,8 @@ class ShowManager:
             lambda event: self._resize(size=(event.width, event.height)),
             EventType.RESIZE,
         )
-        self.renderer.add_event_handler(
+
+        self.window.add_event_handler(
             self._set_key_long_press_event, EventType.KEY_DOWN, EventType.KEY_UP
         )
         self.renderer.add_event_handler(
@@ -669,6 +672,7 @@ class ShowManager:
         self._key_long_press = None
         self._on_resize = lambda _size: None
         self._resize(self._size)
+        self.set_enable_events(enable_events)
 
     def _handle_drag(self, event):
         """Handle drag events for pointer interactions.
@@ -829,33 +833,49 @@ class ShowManager:
         reposition_ui(self.screens)
         self.render()
 
-    async def _handle_key_long_press(self, event):
-        """Handle long press events for key inputs.
+    def _set_key_long_press_event(self, event):
+        """Handle key events for input routing.
 
         Parameters
         ----------
         event : KeyEvent
             The PyGfx key event object."""
+
+        from_canvas_dict = isinstance(event, dict)
+        if from_canvas_dict:
+            ev_type = (
+                event.get("event_type", "")
+                or event.get("type", "")
+                or ""
+            ).lower()
+            ev_key = (
+                event.get("key", "")
+                or event.get("text", "")
+                or event.get("value", "")
+                or event.get("code", "")
+                or ""
+            )
+            ev_mods = event.get("modifiers", None)
+            if isinstance(ev_mods, (list, tuple)):
+                ev_mods = tuple(ev_mods)
+            elif ev_mods is None:
+                ev_mods = ()
+
+            if ev_type not in {"key_down", "key_up"}:
+                return
+            pseudo_type = EventType.KEY_DOWN if ev_type == "key_down" else EventType.KEY_UP
+            event = types.SimpleNamespace(
+                type=pseudo_type, key=ev_key, modifiers=ev_mods, target=None
+            )
 
         if self._key_long_press is not None:
-            await asyncio.sleep(0.05)
-            self.renderer.dispatch_event(event)
-
-    def _set_key_long_press_event(self, event):
-        """Handle long press events for key inputs.
-
-        Parameters
-        ----------
-        event : KeyEvent
-            The PyGfx key event object."""
-
-        if event.type == EventType.KEY_DOWN:
-            self._key_long_press = asyncio.create_task(
-                self._handle_key_long_press(event)
-            )
-        elif self._key_long_press is not None:
             self._key_long_press.cancel()
             self._key_long_press = None
+
+        if UIContext.active_ui is not None:
+            UIContext.active_ui.on_key_press(event)
+
+        self.window.request_draw(self._draw_function)
 
     def _on_repeat_callback(self, func, time, name, *args):
         """Internal method to handle the timing and execution of callbacks.


### PR DESCRIPTION
### Summary
Ports `TextBox2D` from the legacy branch to the `v2` UI architecture, following the same patterns used by existing `v2` components (e.g. `Panel2D`). Implements keyboard-driven editing with caret movement, multiline rendering, and numpad digit input.

### Changes
- Added `TextBox2D` to `fury/ui/containers.py` using the `v2` UI structure (`UI`, `Anchor`, `TextBlock2D`).
- Focus + keyboard input routing:
  - `TextBox2D` becomes active on click and receives key events via `UIContext.active_ui`.
  - Handles `Enter`, `Backspace`, `ArrowLeft`, `ArrowRight`, and printable character input.
- Numpad support:
  - Normalizes multiple backend `event.key` naming variants (`Numpad*`, `KP_*` / `KP*`, `Digit*`).
  - Supports NumLock-off cases via navigation-style keys (`End/Down/PageDown/Insert`) -> digits `1/2/3/0`.
- Added demo and docs registration:
  - `docs/examples/viz_textbox.py`
  - Registered in `docs/examples/_valid_examples.toml`
- Added unit tests:
  - `fury/ui/tests/test_textbox2d.py` (caret movement, multiline wrapping, numpad variants)

### Bug Fix
- Updated key routing in `fury/window.py` so the currently focused UI (active textbox) receives keyboard events correctly.

### Known Limitations
- Mouse click currently focuses the textbox and enters edit mode; caret placement is primarily keyboard-driven (not full mouse caret positioning).
- Numpad `event.key` naming may vary by backend/OS; `TextBox2D` normalizes common variants, but other exotic mappings may still differ.

### Tests
- `python -m pytest -q fury/ui/tests/test_textbox2d.py`

Closes #1109