### PR TITLE
Improve documentation setup instructions

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,3 +40,14 @@ test
    Source Code <https://github.com/fury-gl/fury>
    File a bug <https://github.com/fury-gl/fury/issues/new/choose>
    Feature Request <https://github.com/fury-gl/fury/issues/new/choose>
+
+
+   Documentation Setup
+   -------------------
+
+   To build the documentation locally, install required dependencies:
+
+   pip install sphinx-gallery ipython sphinx-copybutton matplotlib numpydoc pillow imageio pydata-sphinx-theme
+
+   Optional dependency (for some examples):
+   pip install imgui-bundle


### PR DESCRIPTION
This PR improves documentation setup instructions by adding required dependencies for building docs locally.

While setting up FURY, multiple missing dependencies caused build failures. This update provides a clear installation command to help new contributors.