### PR TITLE
Skip viz_imgui example due to missing dependency

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -338,6 +338,8 @@ sphinx_gallery_conf = {
     },
     "filename_pattern": re.escape(os.sep),
     "plot_gallery": "'True'",
+    "ignore_pattern": r"viz_imgui.py",
+
 }
 
 # -- Options for Blog -------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,3 +40,14 @@ test
    Source Code <https://github.com/fury-gl/fury>
    File a bug <https://github.com/fury-gl/fury/issues/new/choose>
    Feature Request <https://github.com/fury-gl/fury/issues/new/choose>
+
+
+   Documentation Setup
+   -------------------
+
+   To build the documentation locally, install required dependencies:
+
+   pip install sphinx-gallery ipython sphinx-copybutton matplotlib numpydoc pillow imageio pydata-sphinx-theme
+
+   Optional dependency (for some examples):
+   pip install imgui-bundle


### PR DESCRIPTION
This PR skips the viz_imgui example in the documentation build due to a missing dependency (imgui-bundle).

While building the docs locally, this example failed because imgui-bundle is not installed by default. Skipping it ensures a smoother documentation build experience for new contributors.

A possible future improvement would be to document this dependency or provide conditional handling.