### PR TITLE
docs: add missing examples to _valid_examples.toml

### DIFF
--- a/docs/examples/_valid_examples.toml
+++ b/docs/examples/_valid_examples.toml
@@ -21,7 +21,10 @@ files = [
     "viz_multi_screen.py",
     "viz_show.py",
     "viz_imgui.py",
-    "viz_shapes.py"
+    "viz_shapes.py",
+    "viz_billboard_spheres.py",
+    "viz_streamtube.py",
+    "viz_textblock.py"
 
 ]
 


### PR DESCRIPTION
I built the documentation locally on the v2 branch and identified warnings for missing example files. This PR adds viz_billboard_spheres.py, viz_streamtube.py, and viz_textblock.py to the _valid_examples.toml configuration to ensure they appear in the gallery. I have verified the fix locally.