### PR TITLE
Fix blog title underlines

### DIFF
--- a/docs/examples/_valid_examples.toml
+++ b/docs/examples/_valid_examples.toml
@@ -21,7 +21,10 @@ files = [
     "viz_multi_screen.py",
     "viz_show.py",
     "viz_imgui.py",
-    "viz_shapes.py"
+    "viz_shapes.py",
+    "viz_billboard_spheres.py",
+    "viz_streamtube.py",
+    "viz_textblock.py"
 
 ]
 

--- a/docs/examples/_valid_examples.toml
+++ b/docs/examples/_valid_examples.toml
@@ -21,10 +21,6 @@ files = [
     "viz_multi_screen.py",
     "viz_show.py",
     "viz_imgui.py",
-    "viz_shapes.py",
-    "viz_billboard_spheres.py",
-    "viz_streamtube.py",
-    "viz_textblock.py"
 
 ]
 

--- a/docs/source/posts/2025/2025-06-19-release-announcement.rst
+++ b/docs/source/posts/2025/2025-06-19-release-announcement.rst
@@ -1,6 +1,6 @@
 
 FURY 2.0.0a1 Released
-====================
+======================
 
 .. post:: June 19, 2025
    :author: skoudoro

--- a/docs/source/posts/2025/2025-08-22-release-announcement.rst
+++ b/docs/source/posts/2025/2025-08-22-release-announcement.rst
@@ -1,6 +1,6 @@
 
 FURY 2.0.0a2 Released
-====================
+======================
 
 .. post:: August 22, 2025
    :author: skoudoro

--- a/docs/source/posts/2025/2025-10-01-release-announcement.rst
+++ b/docs/source/posts/2025/2025-10-01-release-announcement.rst
@@ -1,6 +1,6 @@
 
 FURY 2.0.0a3 Released
-====================
+======================
 
 .. post:: October 01, 2025
    :author: skoudoro

--- a/docs/source/posts/2025/2025-12-19-release-announcement.rst
+++ b/docs/source/posts/2025/2025-12-19-release-announcement.rst
@@ -1,6 +1,6 @@
 
 FURY 2.0.0a4 Released
-====================
+======================
 
 .. post:: December 19, 2025
    :author: maharshi-gor

--- a/docs/source/posts/2026/2026-01-23-release-announcement.rst
+++ b/docs/source/posts/2026/2026-01-23-release-announcement.rst
@@ -1,6 +1,6 @@
 
 FURY 2.0.0a5 Released
-====================
+======================
 
 .. post:: January 23, 2026
    :author: maharshi-gor


### PR DESCRIPTION
While building the documentation locally for the v2 branch, I identified several 'Title underline too short' warnings in the 2025 and 2026 release announcement posts.

This PR fixes those underlines to match the title lengths, reducing the total build warning count. I have verified the fix locally by running the Sphinx build.