### PR TITLE
NF: Vector Field Actor chunked based on device limits.

### DIFF
--- a/docs/examples/viz_vector_field.py
+++ b/docs/examples/viz_vector_field.py
@@ -106,13 +106,13 @@ show_manager = window.ShowManager(
 
 def handle_key_event(event):
     print("Key pressed:", event.key)
-    position = vector_field_slicer_actor.cross_section
+    position = actor.get_slices(vector_field_slicer_actor)
     if event.key == "ArrowUp":
         position = (position[0], position[1], position[2] + sparse_step)
     elif event.key == "ArrowDown":
         position = (position[0], position[1], position[2] - sparse_step)
 
-    vector_field_slicer_actor.cross_section = position
+    actor.show_slices(vector_field_slicer_actor, position)
     show_manager.render()
 
 

--- a/fury/actor/bio.py
+++ b/fury/actor/bio.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from fury.actor import (
     Group,
-    apply_affine_to_actor,
     apply_affine_to_group,
     contour_from_volume,
     data_slicer,
@@ -133,14 +132,17 @@ def peaks_slicer(
     )
 
     if affine is not None:
-        apply_affine_to_actor(obj, affine)
         bounds = obj.get_bounding_box()
+        for child in obj.children:
+            child.local.matrix = affine @ child.local.matrix
         obj.bounds = get_transformed_cube_bounds(
             affine,
             bounds[0],
             bounds[1],
         )
-        obj.cross_section = np.asarray(obj.bounds).mean(axis=0)
+        for child in obj.children:
+            child.bounds = obj.bounds
+        show_slices(obj, np.asarray(obj.bounds).mean(axis=0))
 
     return obj
 

--- a/fury/actor/slicer.py
+++ b/fury/actor/slicer.py
@@ -1,7 +1,5 @@
 """Slicer actor for Fury."""
 
-import math
-
 import numpy as np
 
 from fury.actor import (
@@ -311,9 +309,8 @@ class VectorField(WorldObject, Actor):
             raise ValueError(f"Cross section must have length 3, but got {len(value)}")
         value = np.asarray(value, dtype=np.float32)
         bounds = self.bounds if hasattr(self, "bounds") else self.get_bounding_box()
-        offset = np.asarray(self.local.position[:3], dtype=np.float32)
-        world_min = np.asarray(bounds[0], dtype=np.float32) + offset
-        world_max = np.asarray(bounds[1], dtype=np.float32) + offset
+        world_min = np.asarray(bounds[0], dtype=np.float32)
+        world_max = np.asarray(bounds[1], dtype=np.float32)
         value = np.maximum(world_min, value)
         value = np.minimum(world_max, value)
         self.material.cross_section = value.astype(np.int32)
@@ -378,6 +375,80 @@ def _max_voxels_per_chunk(*, max_buffer_size, max_workgroups):
     return min(from_buffer, from_dispatch)
 
 
+def _create_chunked_vector_field(
+    field,
+    *,
+    group_name,
+    scales,
+    actor_params,
+    chunk_actor_postprocess=None,
+):
+    """Create a VectorField group, chunking when required by device limits.
+
+    Parameters
+    ----------
+    field : ndarray, shape {(X, Y, Z, N, 3), (X, Y, Z, 3)}
+        Vector field data.
+    group_name : str
+        Name for the returned Group.
+    scales : {float, ndarray}
+        Scalar value or per-voxel scales array.
+    actor_params : dict
+        Keyword arguments passed to each VectorField actor.
+    chunk_actor_postprocess : callable, optional
+        Callback invoked as ``fn(actor, x_start)`` for each chunk actor after
+        chunk positioning, used for chunk-specific updates.
+
+    Returns
+    -------
+    Group
+        A Group containing one or more VectorField actors.
+    """
+    wgpu_device = gfx_wgpu.get_shared().device
+    max_buffer_size = wgpu_device.limits.get(
+        "max-storage-buffer-binding-size", 256 * 1024 * 1024
+    )
+    max_workgroups = wgpu_device.limits.get(
+        "max-compute-workgroups-per-dimension", 65535
+    )
+
+    total_voxels = int(np.prod(field.shape[:3]))
+    max_voxels = _max_voxels_per_chunk(
+        max_buffer_size=max_buffer_size,
+        max_workgroups=max_workgroups,
+    )
+    group = Group(name=group_name)
+
+    if total_voxels <= max_voxels:
+        actor = VectorField(field, scales=scales, **actor_params)
+        group.add(actor)
+        return group
+
+    voxels_per_x_slice = int(np.prod(field.shape[1:3]))
+    chunk_x = max(1, max_voxels // voxels_per_x_slice)
+
+    x_size = field.shape[0]
+    n_chunks = int(np.ceil(x_size / chunk_x))
+
+    for i in range(n_chunks):
+        x_start = i * chunk_x
+        x_end = min(x_start + chunk_x, x_size)
+        chunk_field = field[x_start:x_end]
+
+        if isinstance(scales, np.ndarray):
+            chunk_scales = scales[x_start:x_end]
+        else:
+            chunk_scales = scales
+
+        actor = VectorField(chunk_field, scales=chunk_scales, **actor_params)
+        actor.local.position = [x_start, 0, 0]
+        if chunk_actor_postprocess is not None:
+            chunk_actor_postprocess(actor, x_start)
+        group.add(actor)
+
+    return group
+
+
 def vector_field(
     field,
     *,
@@ -413,61 +484,18 @@ def vector_field(
     Group
         A Group of VectorField chunks.
     """
-    wgpu_device = gfx_wgpu.get_shared().device
-    max_buffer_size = wgpu_device.limits.get(
-        "max-storage-buffer-binding-size", 256 * 1024 * 1024
+    actor_params = {
+        "actor_type": actor_type,
+        "colors": colors,
+        "opacity": opacity,
+        "thickness": thickness,
+    }
+    return _create_chunked_vector_field(
+        field,
+        group_name="VectorField",
+        scales=scales,
+        actor_params=actor_params,
     )
-    max_workgroups = wgpu_device.limits.get(
-        "max-compute-workgroups-per-dimension", 65535
-    )
-
-    total_voxels = int(np.prod(field.shape[:3]))
-    max_voxels = _max_voxels_per_chunk(
-        max_buffer_size=max_buffer_size,
-        max_workgroups=max_workgroups,
-    )
-    group = Group(name="VectorField")
-
-    if total_voxels <= max_voxels:
-        actor = VectorField(
-            field,
-            actor_type=actor_type,
-            colors=colors,
-            scales=scales,
-            opacity=opacity,
-            thickness=thickness,
-        )
-        group.add(actor)
-        return group
-
-    voxels_per_x_slice = int(np.prod(field.shape[1:3]))
-    chunk_x = max(1, max_voxels // voxels_per_x_slice)
-
-    x_size = field.shape[0]
-    n_chunks = math.ceil(x_size / chunk_x)
-
-    for i in range(n_chunks):
-        x_start = i * chunk_x
-        x_end = min(x_start + chunk_x, x_size)
-        chunk_field = field[x_start:x_end]
-
-        if isinstance(scales, np.ndarray):
-            chunk_scales = scales[x_start:x_end]
-        else:
-            chunk_scales = scales
-
-        actor = VectorField(
-            chunk_field,
-            actor_type=actor_type,
-            colors=colors,
-            scales=chunk_scales,
-            opacity=opacity,
-            thickness=thickness,
-        )
-        actor.local.position = [x_start, 0, 0]
-        group.add(actor)
-
-    return group
 
 
 def vector_field_slicer(
@@ -519,67 +547,23 @@ def vector_field_slicer(
 
     cross_section = np.asarray(cross_section, dtype=np.int32)
 
-    wgpu_device = gfx_wgpu.get_shared().device
-    max_buffer_size = wgpu_device.limits.get(
-        "max-storage-buffer-binding-size", 256 * 1024 * 1024
+    actor_params = {
+        "actor_type": actor_type,
+        "cross_section": cross_section,
+        "colors": colors,
+        "opacity": opacity,
+        "thickness": thickness,
+        "visibility": visibility,
+    }
+    return _create_chunked_vector_field(
+        field,
+        group_name="VectorFieldSlicer",
+        scales=scales,
+        actor_params=actor_params,
+        chunk_actor_postprocess=lambda actor, _: setattr(
+            actor, "cross_section", cross_section.copy()
+        ),
     )
-    max_workgroups = wgpu_device.limits.get(
-        "max-compute-workgroups-per-dimension", 65535
-    )
-
-    total_voxels = int(np.prod(field.shape[:3]))
-    max_voxels = _max_voxels_per_chunk(
-        max_buffer_size=max_buffer_size,
-        max_workgroups=max_workgroups,
-    )
-    group = Group(name="VectorFieldSlicer")
-
-    if total_voxels <= max_voxels:
-        actor = VectorField(
-            field,
-            actor_type=actor_type,
-            cross_section=cross_section,
-            colors=colors,
-            scales=scales,
-            opacity=opacity,
-            thickness=thickness,
-            visibility=visibility,
-        )
-        group.add(actor)
-        return group
-
-    voxels_per_x_slice = int(np.prod(field.shape[1:3]))
-    chunk_x = max(1, max_voxels // voxels_per_x_slice)
-
-    x_size = field.shape[0]
-    n_chunks = math.ceil(x_size / chunk_x)
-
-    for i in range(n_chunks):
-        x_start = i * chunk_x
-        x_end = min(x_start + chunk_x, x_size)
-        chunk_field = field[x_start:x_end]
-
-        if isinstance(scales, np.ndarray):
-            chunk_scales = scales[x_start:x_end]
-        else:
-            chunk_scales = scales
-
-        actor = VectorField(
-            chunk_field,
-            actor_type=actor_type,
-            colors=colors,
-            scales=chunk_scales,
-            opacity=opacity,
-            thickness=thickness,
-            visibility=visibility,
-        )
-        actor.local.position = [x_start, 0, 0]
-        chunk_cs = cross_section.copy()
-        actor.cross_section = chunk_cs
-
-        group.add(actor)
-
-    return group
 
 
 @register_wgpu_render_function(VectorField, VectorFieldThinLineMaterial)

--- a/fury/actor/slicer.py
+++ b/fury/actor/slicer.py
@@ -1,5 +1,7 @@
 """Slicer actor for Fury."""
 
+import math
+
 import numpy as np
 
 from fury.actor import (
@@ -18,6 +20,7 @@ from fury.lib import (
     Texture,
     VolumeSliceMaterial,
     WorldObject,
+    gfx_wgpu,
     register_wgpu_render_function,
 )
 from fury.material import (
@@ -294,7 +297,10 @@ class VectorField(WorldObject, Actor):
         Parameters
         ----------
         value : {list, tuple, ndarray}
-            The cross section dimensions to set.
+            The cross section in world-space coordinates.  When this actor is
+            part of a chunked group its ``local.position`` offset is already
+            baked in, so the caller always works in the same coordinate frame
+            as the full field.
         """
         if not isinstance(value, (list, tuple, np.ndarray)):
             raise ValueError(
@@ -305,8 +311,11 @@ class VectorField(WorldObject, Actor):
             raise ValueError(f"Cross section must have length 3, but got {len(value)}")
         value = np.asarray(value, dtype=np.float32)
         bounds = self.bounds if hasattr(self, "bounds") else self.get_bounding_box()
-        value = np.maximum(bounds[0], value)
-        value = np.minimum(bounds[1], value)
+        offset = np.asarray(self.local.position[:3], dtype=np.float32)
+        world_min = np.asarray(bounds[0], dtype=np.float32) + offset
+        world_max = np.asarray(bounds[1], dtype=np.float32) + offset
+        value = np.maximum(world_min, value)
+        value = np.minimum(world_max, value)
         self.material.cross_section = value.astype(np.int32)
 
     @property
@@ -334,6 +343,39 @@ class VectorField(WorldObject, Actor):
         if not isinstance(value, (list, tuple)) or len(value) != 3:
             raise ValueError("Visibility must be a tuple of three boolean values.")
         self.material.visibility = value
+
+
+def _max_voxels_per_chunk(*, max_buffer_size, max_workgroups):
+    """Compute the maximum number of voxels that fit in one VectorField chunk.
+
+    Two independent device limits constrain how large a single VectorField
+    actor may be:
+
+    * **Storage-buffer binding size** – the largest individual buffer that the
+      GPU accepts.  The bottleneck buffer holds two float32 (x, y, z) vertices
+      per vector (start + end point), so it costs ``n_vectors × 2 × 3 × 4``
+      bytes.
+    * **Compute workgroup dispatch dimension** – the compute pass dispatches
+      ``ceil(n_voxels / workgroup_size)`` workgroups along the X axis.  WebGPU
+      limits this to ``max-compute-workgroups-per-dimension`` (typically
+      65 535).
+
+    Parameters
+    ----------
+    max_buffer_size : int
+        Device limit ``max-storage-buffer-binding-size`` in bytes.
+    max_workgroups : int
+        Device limit ``max-compute-workgroups-per-dimension``.
+
+    Returns
+    -------
+    int
+        Maximum number of voxels per chunk that satisfies both limits.
+    """
+    _VECTOR_FIELD_WORKGROUP_SIZE = 64
+    from_buffer = max_buffer_size // (2 * 3 * 4)
+    from_dispatch = max_workgroups * _VECTOR_FIELD_WORKGROUP_SIZE
+    return min(from_buffer, from_dispatch)
 
 
 def vector_field(
@@ -368,19 +410,64 @@ def vector_field(
 
     Returns
     -------
-    VectorField
-        A vector field object.
+    Group
+        A Group of VectorField chunks.
     """
-
-    obj = VectorField(
-        field,
-        actor_type=actor_type,
-        colors=colors,
-        scales=scales,
-        opacity=opacity,
-        thickness=thickness,
+    wgpu_device = gfx_wgpu.get_shared().device
+    max_buffer_size = wgpu_device.limits.get(
+        "max-storage-buffer-binding-size", 256 * 1024 * 1024
     )
-    return obj
+    max_workgroups = wgpu_device.limits.get(
+        "max-compute-workgroups-per-dimension", 65535
+    )
+
+    total_voxels = int(np.prod(field.shape[:3]))
+    max_voxels = _max_voxels_per_chunk(
+        max_buffer_size=max_buffer_size,
+        max_workgroups=max_workgroups,
+    )
+    group = Group(name="VectorField")
+
+    if total_voxels <= max_voxels:
+        actor = VectorField(
+            field,
+            actor_type=actor_type,
+            colors=colors,
+            scales=scales,
+            opacity=opacity,
+            thickness=thickness,
+        )
+        group.add(actor)
+        return group
+
+    voxels_per_x_slice = int(np.prod(field.shape[1:3]))
+    chunk_x = max(1, max_voxels // voxels_per_x_slice)
+
+    x_size = field.shape[0]
+    n_chunks = math.ceil(x_size / chunk_x)
+
+    for i in range(n_chunks):
+        x_start = i * chunk_x
+        x_end = min(x_start + chunk_x, x_size)
+        chunk_field = field[x_start:x_end]
+
+        if isinstance(scales, np.ndarray):
+            chunk_scales = scales[x_start:x_end]
+        else:
+            chunk_scales = scales
+
+        actor = VectorField(
+            chunk_field,
+            actor_type=actor_type,
+            colors=colors,
+            scales=chunk_scales,
+            opacity=opacity,
+            thickness=thickness,
+        )
+        actor.local.position = [x_start, 0, 0]
+        group.add(actor)
+
+    return group
 
 
 def vector_field_slicer(
@@ -423,24 +510,76 @@ def vector_field_slicer(
 
     Returns
     -------
-    VectorField
-        A vector field object.
+    VectorField or Group
+        A single VectorField when the data fits within the device limits,
+        or a Group of VectorField chunks otherwise.
     """
-
     if cross_section is None:
         cross_section = np.asarray(field.shape[:3], dtype=np.int32) // 2
 
-    obj = VectorField(
-        field,
-        actor_type=actor_type,
-        cross_section=cross_section,
-        colors=colors,
-        scales=scales,
-        opacity=opacity,
-        thickness=thickness,
-        visibility=visibility,
+    cross_section = np.asarray(cross_section, dtype=np.int32)
+
+    wgpu_device = gfx_wgpu.get_shared().device
+    max_buffer_size = wgpu_device.limits.get(
+        "max-storage-buffer-binding-size", 256 * 1024 * 1024
     )
-    return obj
+    max_workgroups = wgpu_device.limits.get(
+        "max-compute-workgroups-per-dimension", 65535
+    )
+
+    total_voxels = int(np.prod(field.shape[:3]))
+    max_voxels = _max_voxels_per_chunk(
+        max_buffer_size=max_buffer_size,
+        max_workgroups=max_workgroups,
+    )
+    group = Group(name="VectorFieldSlicer")
+
+    if total_voxels <= max_voxels:
+        actor = VectorField(
+            field,
+            actor_type=actor_type,
+            cross_section=cross_section,
+            colors=colors,
+            scales=scales,
+            opacity=opacity,
+            thickness=thickness,
+            visibility=visibility,
+        )
+        group.add(actor)
+        return group
+
+    voxels_per_x_slice = int(np.prod(field.shape[1:3]))
+    chunk_x = max(1, max_voxels // voxels_per_x_slice)
+
+    x_size = field.shape[0]
+    n_chunks = math.ceil(x_size / chunk_x)
+
+    for i in range(n_chunks):
+        x_start = i * chunk_x
+        x_end = min(x_start + chunk_x, x_size)
+        chunk_field = field[x_start:x_end]
+
+        if isinstance(scales, np.ndarray):
+            chunk_scales = scales[x_start:x_end]
+        else:
+            chunk_scales = scales
+
+        actor = VectorField(
+            chunk_field,
+            actor_type=actor_type,
+            colors=colors,
+            scales=chunk_scales,
+            opacity=opacity,
+            thickness=thickness,
+            visibility=visibility,
+        )
+        actor.local.position = [x_start, 0, 0]
+        chunk_cs = cross_section.copy()
+        actor.cross_section = chunk_cs
+
+        group.add(actor)
+
+    return group
 
 
 @register_wgpu_render_function(VectorField, VectorFieldThinLineMaterial)

--- a/fury/actor/tests/test_bio.py
+++ b/fury/actor/tests/test_bio.py
@@ -5,6 +5,7 @@ from fury.actor import (
     Group,
     contour_from_label,
     contour_from_roi,
+    get_slices,
     peaks_slicer,
     volume_slicer,
 )
@@ -70,10 +71,13 @@ def test_peaks_slicer_basic_functionality():
     result = peaks_slicer(peak_dirs)
 
     assert result is not None
+    assert isinstance(result, Group)
+    assert result.name == "VectorFieldSlicer"
     assert hasattr(result, "get_bounding_box")
     assert np.all(result.get_bounding_box() == np.array([[0, 0, 0], [4, 4, 4]]))
-    assert np.all(result.cross_section == np.array([2, 2, 2]))
-    assert result.material.opacity == 1.0  # Default value
+    vf = result.children[0]
+    assert np.all(vf.cross_section == np.array([2, 2, 2]))
+    assert vf.material.opacity == 1.0  # Default value
 
 
 def test_peaks_slicer_with_affine_transform():
@@ -84,13 +88,13 @@ def test_peaks_slicer_with_affine_transform():
 
     result = peaks_slicer(peak_dirs, affine=affine)
     assert result is not None
+    assert isinstance(result, Group)
     # Verify bounding box was transformed
     assert hasattr(result, "get_bounding_box")
     assert hasattr(result, "bounds")
-    assert np.allclose(result.get_bounding_box()[0], (0, 0, 0))
     assert np.allclose(result.bounds[0], np.array([10, 20, 30]))
     assert np.allclose(result.bounds[1], np.array([12, 22, 32]))
-    assert np.allclose(result.cross_section, np.array([11, 21, 31]))
+    assert np.allclose(get_slices(result), np.array([11, 21, 31]))
 
 
 def test_peaks_slicer_invalid_peak_dirs_shape():
@@ -137,7 +141,8 @@ def test_peaks_slicer_visual_properties():
     )
 
     assert result is not None
-    assert result.material.opacity == 0.5
+    assert isinstance(result, Group)
+    assert result.children[0].material.opacity == 0.5
 
 
 def test_peaks_slicer_cross_section():
@@ -148,7 +153,7 @@ def test_peaks_slicer_cross_section():
 
     assert result_default is not None
 
-    with pytest.raises(ValueError):
+    with pytest.raises((ValueError, TypeError)):
         peaks_slicer(peak_dirs, cross_section=0.0)
 
 

--- a/fury/actor/tests/test_slicer.py
+++ b/fury/actor/tests/test_slicer.py
@@ -5,7 +5,9 @@ import pytest
 
 from fury import actor
 from fury.actor import Group
+from fury.actor.slicer import _max_voxels_per_chunk
 from fury.actor.utils import get_slices, set_group_visibility, show_slices
+from fury.lib import gfx_wgpu
 from fury.material import (
     VectorFieldArrowMaterial,
     VectorFieldLineMaterial,
@@ -236,21 +238,106 @@ def test_vector_field_helper_functions():
     field = np.random.rand(5, 5, 5, 3)
 
     # Test vector_field
-    vf = actor.vector_field(field, actor_type="arrow", opacity=0.5, thickness=2.0)
+    vf_group = actor.vector_field(field, actor_type="arrow", opacity=0.5, thickness=2.0)
+    assert vf_group.name == "VectorField"
+    assert len(vf_group.children) == 1
+    vf = vf_group.children[0]
     assert isinstance(vf.material, VectorFieldArrowMaterial)
     assert vf.material.opacity == 0.5
     assert vf.material.thickness == 2.0
 
     # Test vector_field_slicer
-    vf = actor.vector_field_slicer(
+    slicer_group = actor.vector_field_slicer(
         field,
         actor_type="line",
         cross_section=[2, 2, 2],
         visibility=(True, False, True),
     )
-    assert isinstance(vf.material, VectorFieldLineMaterial)
-    assert np.all(vf.cross_section == np.array([2, 2, 2]))
-    assert np.all(vf.visibility == np.asarray((True, False, True)))
+    assert slicer_group.name == "VectorFieldSlicer"
+    assert len(slicer_group.children) == 1
+    vfs = slicer_group.children[0]
+    assert isinstance(vfs.material, VectorFieldLineMaterial)
+    assert np.all(vfs.cross_section == np.array([2, 2, 2]))
+    assert np.all(vfs.visibility == np.asarray((True, False, True)))
+
+
+@pytest.mark.parametrize(
+    ("max_buffer_size", "max_workgroups", "expected"),
+    [
+        (24, 65535, 1),
+        (24 * 100, 1, 64),
+        (2 * 3 * 4 * 100, 2, min(100, 2 * 64)),
+    ],
+)
+def test_max_voxels_per_chunk(max_buffer_size, max_workgroups, expected):
+    """Storage-buffer and dispatch limits both cap chunk voxel count."""
+    got = _max_voxels_per_chunk(
+        max_buffer_size=max_buffer_size,
+        max_workgroups=max_workgroups,
+    )
+    assert got == expected
+
+
+def test_vector_field_cross_section_world_bounds_with_chunk_offset():
+    """Cross section clamps in world space when the actor has a local X offset."""
+    field = np.random.rand(5, 5, 5, 3)
+    vf = actor.VectorField(field)
+    vf.local.position = [10.0, 0.0, 0.0]
+    vf.cross_section = [20, 2, 2]
+    np.testing.assert_array_equal(vf.cross_section, np.array([4, 2, 2]))
+
+
+def test_vector_field_chunks_when_exceeding_device_limits():
+    """Large fields are split into several actors along X with contiguous offsets."""
+    device = gfx_wgpu.get_shared().device
+    max_voxels = _max_voxels_per_chunk(
+        max_buffer_size=device.limits.get(
+            "max-storage-buffer-binding-size", 256 * 1024 * 1024
+        ),
+        max_workgroups=device.limits.get("max-compute-workgroups-per-dimension", 65535),
+    )
+    y, z = 32, 32
+    x = int(max_voxels // (y * z)) + 5
+    shape = (x, y, z, 3)
+    total = int(np.prod(shape[:3]))
+    field = np.random.default_rng(0).random(shape, dtype=np.float32)
+    scales = np.random.default_rng(1).random(shape[:3], dtype=np.float32)
+
+    group = actor.vector_field(field, scales=scales)
+    assert group.name == "VectorField"
+    if total > max_voxels:
+        assert len(group.children) >= 2
+        assert sum(ch.field_shape[0] for ch in group.children) == x
+        x_cursor = 0
+        for ch in group.children:
+            assert ch.local.position[0] == x_cursor
+            x_cursor += ch.field_shape[0]
+
+
+def test_vector_field_slicer_chunks_when_exceeding_device_limits():
+    """vector_field_slicer uses the same chunking strategy as vector_field."""
+    device = gfx_wgpu.get_shared().device
+    max_voxels = _max_voxels_per_chunk(
+        max_buffer_size=device.limits.get(
+            "max-storage-buffer-binding-size", 256 * 1024 * 1024
+        ),
+        max_workgroups=device.limits.get("max-compute-workgroups-per-dimension", 65535),
+    )
+    y, z = 24, 24
+    x = int(max_voxels // (y * z)) + 3
+    shape = (x, y, z, 3)
+    total = int(np.prod(shape[:3]))
+    field = np.random.default_rng(2).random(shape, dtype=np.float32)
+    cs = np.array([min(5, x - 1), y // 2, z // 2], dtype=np.int32)
+
+    group = actor.vector_field_slicer(field, cross_section=cs)
+    assert group.name == "VectorFieldSlicer"
+    if total > max_voxels:
+        assert len(group.children) >= 2
+        assert sum(ch.field_shape[0] for ch in group.children) == x
+    else:
+        assert len(group.children) == 1
+        np.testing.assert_array_equal(group.children[0].cross_section, cs)
 
 
 def test_vector_field_edge_cases():

--- a/fury/actor/tests/test_utils.py
+++ b/fury/actor/tests/test_utils.py
@@ -13,6 +13,7 @@ from fury.actor import (
     set_group_visibility,
     set_opacity,
     show_slices,
+    vector_field_slicer,
 )
 import fury.actor.utils as actor_utils
 from fury.lib import (
@@ -67,7 +68,7 @@ def group_line_projection():
         outline_color=(1, 1, 1),
     )
 
-    obj = Group()
+    obj = Group(name="Slicer")
     obj.add(projection_z)
     obj.add(projection_y)
     obj.add(projection_x)
@@ -150,14 +151,14 @@ def test_get_slices_type_error():
 
 
 def test_get_slices_value_error(actor):
-    group = Group()
+    group = Group(name="Slicer")
     group.add(actor, Mesh())
     with pytest.raises(ValueError):
         get_slices(group)
 
 
 def test_get_slices_attribute_error(actor):
-    group = Group()
+    group = Group(name="Slicer")
     group.add(actor, Mesh(), Mesh())
     with pytest.raises(AttributeError):
         get_slices(group)
@@ -169,6 +170,30 @@ def test_get_slices_valid(group_slicer):
     result = get_slices(group_slicer)
     expected = np.array([0, 10, 20])
     assert np.array_equal(result, expected)
+
+
+def test_get_slices_vector_field_slicer_group():
+    """get_slices reads cross_section from the first VectorField child."""
+    field = np.random.rand(3, 3, 3, 3).astype(np.float32)
+    group = vector_field_slicer(field, cross_section=[1, 1, 1])
+    assert group.name == "VectorFieldSlicer"
+    np.testing.assert_array_equal(get_slices(group), np.array([1, 1, 1]))
+
+
+def test_show_slices_vector_field_slicer_group():
+    """show_slices sets the same cross_section on every chunked VectorField."""
+    field = np.random.rand(3, 3, 3, 3).astype(np.float32)
+    group = vector_field_slicer(field, cross_section=[0, 1, 2])
+    show_slices(group, [2, 2, 2])
+    for child in group.children:
+        np.testing.assert_array_equal(child.cross_section, np.array([2, 2, 2]))
+
+
+def test_get_slices_vector_field_slicer_validates_cross_section():
+    group = Group(name="VectorFieldSlicer")
+    group.add(Mesh(Geometry(), Material()))
+    with pytest.raises(AttributeError, match="cross_section"):
+        get_slices(group)
 
 
 def test_show_slices_type_error():

--- a/fury/actor/utils.py
+++ b/fury/actor/utils.py
@@ -104,7 +104,13 @@ def validate_slices_group(group):
         raise TypeError("group must be an instance of Group.")
 
     if group.name == "VectorFieldSlicer":
-        if not hasattr(group.children[0], "cross_section"):
+        if not hasattr(group, "children"):
+            raise AttributeError("Group must have a children attribute.")
+        elif not isinstance(group.children, (list, tuple)):
+            raise TypeError("Group must have a children attribute that is a list.")
+        elif not len(group.children) >= 1:
+            raise ValueError("Group must contain at least one child.")
+        elif not hasattr(group.children[0], "cross_section"):
             raise AttributeError(
                 "Children do not have the required cross_section attribute."
             )
@@ -142,6 +148,11 @@ def get_slices(group):
         return np.asarray([child.material.plane[-1] for child in group.children])
     elif group.name == "VectorFieldSlicer":
         return np.asarray(group.children[0].cross_section)
+    else:
+        raise ValueError(
+            f"Group {group.name} is not a valid slices group. "
+            "Must be either 'Slicer' or 'VectorFieldSlicer'."
+        )
 
 
 def show_slices(group, position):

--- a/fury/actor/utils.py
+++ b/fury/actor/utils.py
@@ -103,18 +103,25 @@ def validate_slices_group(group):
     if not isinstance(group, GfxGroup):
         raise TypeError("group must be an instance of Group.")
 
-    if len(group.children) != 3:
-        raise ValueError(
-            f"Group must contain exactly 3 children. {len(group.children)}"
-        )
+    if group.name == "VectorFieldSlicer":
+        if not hasattr(group.children[0], "cross_section"):
+            raise AttributeError(
+                "Children do not have the required cross_section attribute."
+            )
 
-    if not (
-        hasattr(group.children[0].material, "plane")
-        or hasattr(group.children[0], "plane")
-    ):
-        raise AttributeError(
-            "Children do not have the required material plane attribute for slices."
-        )
+    elif group.name == "Slicer":
+        if len(group.children) != 3:
+            raise ValueError(
+                f"Group must contain exactly 3 children. {len(group.children)}"
+            )
+
+        if not (
+            hasattr(group.children[0].material, "plane")
+            or hasattr(group.children[0], "plane")
+        ):
+            raise AttributeError(
+                "Children do not have the required material plane attribute for slices."
+            )
 
 
 def get_slices(group):
@@ -131,7 +138,10 @@ def get_slices(group):
         An array containing the current positions of the slices.
     """
     validate_slices_group(group)
-    return np.asarray([child.material.plane[-1] for child in group.children])
+    if group.name == "Slicer":
+        return np.asarray([child.material.plane[-1] for child in group.children])
+    elif group.name == "VectorFieldSlicer":
+        return np.asarray(group.children[0].cross_section)
 
 
 def show_slices(group, position):
@@ -148,13 +158,18 @@ def show_slices(group, position):
     """
     validate_slices_group(group)
 
-    for i, child in enumerate(group.children):
-        if hasattr(child, "plane"):
-            a, b, c, _ = child.plane
-            child.plane = (a, b, c, position[i] + 1e-3)
-        else:
-            a, b, c, _ = child.material.plane
-            child.material.plane = (a, b, c, position[i] + 1e-3)
+    if group.name == "Slicer":
+        for i, child in enumerate(group.children):
+            if hasattr(child, "plane"):
+                a, b, c, _ = child.plane
+                child.plane = (a, b, c, position[i] + 1e-3)
+            else:
+                a, b, c, _ = child.material.plane
+                child.material.plane = (a, b, c, position[i] + 1e-3)
+
+    elif group.name == "VectorFieldSlicer":
+        for child in group.children:
+            child.cross_section = position
 
 
 def apply_affine_to_group(group, affine):


### PR DESCRIPTION
## Description

This PR introduces the changes for chunking the vector field actor beyond the allowed size of workgroups by webgpu.

## Motivation

The current implementation of the vector field fails when you have more than 65535 * 64 i.e. ~4M voxels the `vector_field_slicer` and in turn `peaks_slicer` fails with a webgpu error.

## How to Test

You are free to use any data beyond 4M voxels or you can use the tutorial `viz_vector_field.py`. Change the grid size from 20, 20, 20 to 200, 200, 200 and it will still work as expected.

## Changes

Brings no changes to the user. Just that the user should you use `get_slice` and `show_slice` methods rather than directly changing the `cross_section` for better user experience.