### PR TITLE
Add automated GIF recording support for animation examples

### DIFF
--- a/docs/examples/_valid_examples.toml
+++ b/docs/examples/_valid_examples.toml
@@ -30,13 +30,19 @@ readme = "file: _demos.rst"
 position = 4
 enable = true
 files = [
+    "viz_animated_surfaces.py",
+    "viz_fractals.py",
+    "viz_helical_motion.py",
+    "viz_tesseract.py",
     "viz_slicer.py",
     "viz_skybox.py",
+    "viz_emwave_animation.py",
     "viz_vector_field.py",
     "viz_spherical_harmonics.py",
     "viz_line_projections.py",
     "viz_streamlines_roi.py",
     "viz_contour.py",
+    "viz_brownian_motion.py",
 
 ]
 

--- a/docs/source/ext/scrap.py
+++ b/docs/source/ext/scrap.py
@@ -19,7 +19,7 @@ class ImageFileScraper:
         # Iterate through files, copy them to the SG output directory
         image_names = []
         image_path_iterator = block_vars["image_path_iterator"]
-        for path_orig in image_files:
+        for path_orig in sorted(image_files):
             # If we already know about this image and it hasn't been modified
             # since starting, then skip it
             mod_time = os.stat(path_orig).st_mtime
@@ -32,6 +32,10 @@ class ImageFileScraper:
                 continue
             # Else, we assume the image has just been modified and is displayed
             path_new = next(image_path_iterator)
+            orig_ext = os.path.splitext(path_orig)[1].lower()
+            new_ext = os.path.splitext(path_new)[1].lower()
+            if orig_ext != new_ext:
+                path_new = os.path.splitext(path_new)[0] + orig_ext
             self.embedded_images[path_orig] = mod_time
             image_names.append(path_new)
             shutil.copyfile(path_orig, path_new)

--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -1,9 +1,12 @@
 import logging
+import os
+from unittest import mock
 from unittest.mock import patch
 
 import numpy as np
 import pytest
 
+from fury import actor, window
 from fury.actor import sphere
 from fury.io import load_image
 from fury.lib import (
@@ -803,3 +806,40 @@ def test_show_manager_register_drag():
     assert show_m._drag_target is None
     for screen in show_m.screens:
         assert screen.controller.enabled is True
+
+
+def test_offscreen_animation_recording():
+
+    # Create a simple scene
+    scene = window.Scene()
+    scene.add(actor.axes(scale=(1, 1, 1)))
+
+    show_m = window.ShowManager(scene=scene, size=(200, 200), title="test_anim")
+
+    # to trigger animation logic
+    def dummy_callback():
+        pass
+
+    show_m.register_callback(dummy_callback, time=1.0, repeat=True, name="dummy")
+
+    # test 1: record animation is FALSE
+    with mock.patch.dict(
+        os.environ, {"FURY_OFFSCREEN": "1", "FURY_RECORD_ANIMATION": "0"}
+    ):
+        show_m.start()
+        assert os.path.exists("test_anim.png")
+        assert not os.path.exists("test_anim.gif")
+
+        os.remove("test_anim.png")
+
+    # test 2: record animation is TRUE
+    with mock.patch.dict(
+        os.environ, {"FURY_OFFSCREEN": "1", "FURY_RECORD_ANIMATION": "1"}
+    ):
+        show_m2 = window.ShowManager(scene=scene, size=(200, 200), title="test_anim")
+        show_m2.register_callback(dummy_callback, time=1.0, repeat=True, name="dummy")
+        show_m2.start()
+        assert os.path.exists("test_anim.gif")
+        assert not os.path.exists("test_anim.png")
+
+        os.remove("test_anim.gif")

--- a/fury/window.py
+++ b/fury/window.py
@@ -1460,8 +1460,38 @@ class ShowManager:
             "true",
             "1",
         ]:
-            self._draw_function()
-            self.snapshot(f"{self._title}.png")
+            frames = []
+            if self._callbacks:
+                max_frames = 300
+                env_max_frames = os.environ.get("FURY_OFFSCREEN_MAX_FRAMES")
+                if env_max_frames and env_max_frames.isdigit():
+                    max_frames = int(env_max_frames)
+
+                for _ in range(max_frames):
+                    if not self._callbacks:
+                        break
+
+                    for _name, cb_info in list(self._callbacks.items()):
+                        func, cb_time, repeat, args = cb_info
+                        func(*args)
+
+                    self._draw_function()
+                    arr = np.asarray(self.renderer.snapshot())
+                    frames.append(image_from_array(arr))
+
+            if frames:
+                gif_name = f"{self._title.replace(' ', '_')}.gif"
+                frames[0].save(
+                    gif_name,
+                    append_images=frames[1:],
+                    save_all=True,
+                    duration=30,
+                    loop=0,
+                )
+            else:
+                self._draw_function()
+                self.snapshot(f"{self._title}.png")
+
             self.window.close()
             return
 

--- a/fury/window.py
+++ b/fury/window.py
@@ -1461,7 +1461,11 @@ class ShowManager:
             "1",
         ]:
             frames = []
-            if self._callbacks:
+            record_animation = os.environ.get("FURY_RECORD_ANIMATION", "").lower() in [
+                "true",
+                "1",
+            ]
+            if self._callbacks and record_animation:
                 max_frames = 300
                 env_max_frames = os.environ.get("FURY_OFFSCREEN_MAX_FRAMES")
                 if env_max_frames and env_max_frames.isdigit():


### PR DESCRIPTION
This PR is based upon #1228.


[fury_gif_examples.webm](https://github.com/user-attachments/assets/53887b2c-fa9b-4f22-a053-89478b1ef202)

[gif_example_2.webm](https://github.com/user-attachments/assets/c15080b5-9019-479f-810e-cd3227cdf176)
