### PR TITLE
CI: skip deploy and cron jobs on forks

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -50,7 +50,7 @@ jobs:
         cd docs
         make -C . html-no-examples SPHINXOPTS="-W --keep-going"
     - name: Deploy Devs
-      if: success() && github.ref == 'refs/heads/master'
+      if: success() && github.ref == 'refs/heads/master' && github.repository == 'fury-gl/fury'
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         ssh-key: ${{ secrets.ACTIONS_DEPLOY_KEY }}

--- a/.github/workflows/precommit_update.yml
+++ b/.github/workflows/precommit_update.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   auto-update:
+    if: github.repository == 'fury-gl/fury'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
This pull request makes minor but important adjustments to the GitHub Actions workflows to ensure that certain jobs only run on the main repository and not on forks. This helps prevent unintended deployments or automated updates from running in external repositories.