### PR TITLE
Override Default CSS with Custom Styles to Update Doc Page Colors

### DIFF
--- a/docs/source/_static/css/fury_theme.css
+++ b/docs/source/_static/css/fury_theme.css
@@ -34,9 +34,11 @@ html[data-theme="dark"] .bd-header .search-button__kbd-shortcut {
     padding: 0.6rem 1.5rem;
 }
 
-/* Light mode navbar */
+/* Light mode navbar (Clean Glassmorphism) */
 html[data-theme="light"] .bd-header.navbar {
-    background-color: #faf5f2 !important;
+    background-color: rgba(250, 245, 242, 0.85) !important;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
 }
 
 html[data-theme="light"] .bd-header .navbar-brand,
@@ -55,10 +57,7 @@ html[data-theme="light"] .bd-header .navbar-btn {
     border-color: rgba(0,0,0,0.15) !important;
 }
 
-/* Dark mode navbar */
-html[data-theme="dark"] .bd-header.navbar {
-    background-color: transparent !important;
-}
+/* Dark mode navbar overrides are handled at the bottom of the file */
 
 html[data-theme="dark"] .bd-header .navbar-brand,
 html[data-theme="dark"] .bd-header .nav-link,
@@ -307,6 +306,22 @@ html[data-theme="dark"] {
     background-size: 900px 900px, 4.5rem 100%;
     background-position: top -50px right -50px, top left;
     background-repeat: no-repeat, repeat;
+    background-attachment: fixed;
+}
+
+/*
+ * Renders the global light mode background (cream + red glow + subtle grid).
+ * Just like dark mode, we force PyData's layout wrappers to be transparent
+ * so this premium gradient aesthetic is universally applied to all internal pages.
+ */
+html[data-theme="light"] {
+    --pst-color-background: transparent;
+
+    background-color: #faf5f2;
+    background-image: radial-gradient(circle, rgba(230,0,0,0.12) 0%, transparent 65%);
+    background-size: 900px 900px;
+    background-position: top -50px right -50px;
+    background-repeat: no-repeat;
     background-attachment: fixed;
 }
 

--- a/docs/source/_static/css/fury_theme.css
+++ b/docs/source/_static/css/fury_theme.css
@@ -57,7 +57,6 @@ html[data-theme="light"] .bd-header .navbar-btn {
     border-color: rgba(0,0,0,0.15) !important;
 }
 
-/* Dark mode navbar overrides are handled at the bottom of the file */
 
 html[data-theme="dark"] .bd-header .navbar-brand,
 html[data-theme="dark"] .bd-header .nav-link,
@@ -291,13 +290,19 @@ html[data-theme="dark"] .fury-footer__joss a:hover {
 }
 
 /* --- GLOBAL THEME BACKGROUND --- */
-/*
- * Renders the global dark mode background (grid + radial glow) on the html root.
- * PyData's base background variable is forced transparent to ensure all semantic
- * layout wrappers (body, main, sidebars) inherit the global design seamlessly.
- */
 html[data-theme="dark"] {
+    --pst-color-primary: #ff4444;
+    --pst-color-secondary: #ff1a1a;
+    --pst-color-accent: #d6b85c;
+    --pst-color-info: #151111;
     --pst-color-background: transparent;
+
+    /* Sphinx-Gallery Button Overrides (Outlined Style) */
+    --sg-download-a-background-color: transparent;
+    --sg-download-a-background-image: none;
+    --sg-download-a-border-color: #ff4444;
+    --sg-download-a-color: #ff4444;
+    --sg-download-a-hover-background-color: rgba(255, 68, 68, 0.1);
 
     background-color: #0d0808;
     background-image:
@@ -309,13 +314,20 @@ html[data-theme="dark"] {
     background-attachment: fixed;
 }
 
-/*
- * Renders the global light mode background (cream + red glow + subtle grid).
- * Just like dark mode, we force PyData's layout wrappers to be transparent
- * so this premium gradient aesthetic is universally applied to all internal pages.
- */
+/* Light mode: cream base + red radial glow, fixed to viewport. */
 html[data-theme="light"] {
+    --pst-color-primary: #e60000;
+    --pst-color-secondary: #cc0000;
+    --pst-color-accent: #a88b32;
+    --pst-color-info: #faf5f2;
     --pst-color-background: transparent;
+
+    /* Sphinx-Gallery Button Overrides (Outlined Style) */
+    --sg-download-a-background-color: transparent;
+    --sg-download-a-background-image: none;
+    --sg-download-a-border-color: #e60000;
+    --sg-download-a-color: #e60000;
+    --sg-download-a-hover-background-color: rgba(230, 0, 0, 0.05);
 
     background-color: #faf5f2;
     background-image: radial-gradient(circle, rgba(230,0,0,0.12) 0%, transparent 65%);
@@ -325,14 +337,97 @@ html[data-theme="light"] {
     background-attachment: fixed;
 }
 
-/* 
- * Create a clean "glassmorphism" effect for the sticky header.
- * We keep it minimalistic to match the light mode header (no borders or drop shadows),
- * but use a semi-transparent background + blur so scrolling text remains hidden
- * while the global red glow and grid gently show through.
- */
+/* Dark navbar: glassmorphism blur over the dark background. */
 html[data-theme="dark"] .bd-header.navbar {
     background-color: rgba(13, 8, 8, 0.85) !important;
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
+}
+
+/* Scope FURY red inline-code style to article content only; sidebar nav links are unaffected. */
+html[data-theme="light"] .bd-article code.docutils.literal:not(.download),
+html[data-theme="light"] .bd-article code.xref:not(.download) {
+    color: #e60000;
+    background-color: rgba(230, 0, 0, 0.05);
+    border: 1px solid rgba(230, 0, 0, 0.15);
+}
+
+html[data-theme="dark"] .bd-article code.docutils.literal:not(.download),
+html[data-theme="dark"] .bd-article code.xref:not(.download) {
+    color: #ff4444;
+    background-color: rgba(255, 68, 68, 0.1);
+    border: 1px solid rgba(255, 68, 68, 0.2);
+}
+
+/* Reset PyData's code-badge styling on sidebar nav links so they render as plain text. */
+.bd-sidebar-primary li a code.literal,
+.bd-sidebar-primary li a code.xref,
+.bd-sidebar-primary li a code.docutils {
+    background-color: transparent !important;
+    border: none !important;
+    border-radius: 0 !important;
+    padding: 0 !important;
+    font-family: inherit !important;
+    font-size: inherit !important;
+    color: inherit !important;
+}
+
+/* --- CODE BLOCK OVERRIDES --- */
+/* PyData sets `pre { background: var(--pst-color-surface) }` globally, which covers our
+   custom div.highlight background. We override div.highlight and reset pre inside it. */
+html[data-theme="light"] div.highlight {
+    background-color: #fcfcfc !important;
+    border: 1px solid #e0e0e0 !important;
+    border-radius: 4px;
+}
+html[data-theme="light"] div.highlight pre {
+    background-color: transparent !important;
+    border: none !important;
+}
+
+html[data-theme="dark"] div.highlight {
+    background-color: #151111 !important;
+    border: 1px solid #332b2b !important;
+    border-radius: 4px;
+}
+html[data-theme="dark"] div.highlight pre {
+    background-color: transparent !important;
+    border: none !important;
+}
+
+
+/* --- SPHINX GALLERY DOWNLOAD BUTTON --- */
+div.sphx-glr-download a code.download {
+    color: inherit !important;
+}
+
+/* --- ADMONITION OVERRIDES --- */
+html[data-theme="light"] .admonition.note,
+html[data-theme="light"] .admonition.info {
+    border-color: #cc0000 !important;
+    background-color: #faf5f2 !important;
+}
+html[data-theme="light"] .admonition.note > .admonition-title,
+html[data-theme="light"] .admonition.info > .admonition-title {
+    background-color: rgba(230, 0, 0, 0.08) !important;
+    color: #e60000 !important;
+}
+html[data-theme="light"] .admonition.note > .admonition-title::before,
+html[data-theme="light"] .admonition.info > .admonition-title::before {
+    color: #e60000 !important;
+}
+
+html[data-theme="dark"] .admonition.note,
+html[data-theme="dark"] .admonition.info {
+    border-color: rgba(255, 68, 68, 0.4) !important;
+    background-color: #151111 !important;
+}
+html[data-theme="dark"] .admonition.note > .admonition-title,
+html[data-theme="dark"] .admonition.info > .admonition-title {
+    background-color: rgba(255, 68, 68, 0.1) !important;
+    color: #ff4444 !important;
+}
+html[data-theme="dark"] .admonition.note > .admonition-title::before,
+html[data-theme="dark"] .admonition.info > .admonition-title::before {
+    color: #ff4444 !important;
 }

--- a/docs/source/_static/css/fury_theme.css
+++ b/docs/source/_static/css/fury_theme.css
@@ -431,3 +431,9 @@ html[data-theme="dark"] .admonition.note > .admonition-title::before,
 html[data-theme="dark"] .admonition.info > .admonition-title::before {
     color: #ff4444 !important;
 }
+
+/* --- BACK TO TOP BUTTON --- */
+#pst-back-to-top,
+#pst-back-to-top * {
+    color: #ffffff !important;
+}

--- a/docs/source/_static/css/homepage.css
+++ b/docs/source/_static/css/homepage.css
@@ -32,7 +32,6 @@
     width: 100%;
     position: relative;
     overflow: hidden;
-    background: #faf5f2;
     color: var(--pst-color-text);
 }
 
@@ -274,13 +273,15 @@ html[data-theme="dark"] .hero-title .fury-red {
 
 /* --- DARK MODE COMPONENT OVERRIDES --- */
 
-/* Hero container is transparent in dark mode — background comes from global html rule */
-html[data-theme="dark"] .hero-container {
+/* Hero container is transparent — background comes from global html rule */
+html[data-theme="dark"] .hero-container,
+html[data-theme="light"] .hero-container {
     background: transparent;
 }
 
 /* Hide hero's own glow pseudo-element — global html rule provides the glow */
-html[data-theme="dark"] .hero-container::before {
+html[data-theme="dark"] .hero-container::before,
+html[data-theme="light"] .hero-container::before {
     display: none;
 }
 
@@ -404,7 +405,6 @@ html[data-theme="dark"] .code-editor__copy-button.is-copy-success {
 /* --- FEATURES COMPONENT --- */
 .fury-features {
     width: 100%;
-    background: #faf5f2; /* Light mode only background */
     color: #1c1919;
     padding: 0 0 6rem 0; /* Removing top padding entirely to keep it flush, but using overflow to trap margins */
     margin: 0;
@@ -537,7 +537,8 @@ html[data-theme="dark"] .code-editor__copy-button.is-copy-success {
 
 /* --- DARK MODE OVERRIDES FOR FEATURES AND HERO VISUALS --- */
 /* Transparent so global html grid/glow shows through */
-html[data-theme="dark"] .fury-features {
+html[data-theme="dark"] .fury-features,
+html[data-theme="light"] .fury-features {
     background: transparent;
 }
 
@@ -576,7 +577,6 @@ html[data-theme="dark"] .fury-feature-card__caption {
 /* --- SCIENCES COMPONENT --- */
 .fury-sciences {
     width: 100%;
-    background: #faf5f2; /* Match the features/hero background exactly */
     color: #1c1919;
     padding: 6rem 0;
     margin: 0;
@@ -809,7 +809,8 @@ html[data-theme="dark"] .fury-feature-card__caption {
 
 /* --- DARK MODE OVERRIDES FOR SCIENCES --- */
 /* Transparent so global html grid/glow shows through */
-html[data-theme="dark"] .fury-sciences {
+html[data-theme="dark"] .fury-sciences,
+html[data-theme="light"] .fury-sciences {
     background: transparent;
 }
 
@@ -886,7 +887,6 @@ html[data-theme="dark"] .fury-sciences__image-wrapper {
 /* --- EXAMPLES COMPONENT --- */
 .fury-examples {
     width: 100%;
-    background: #faf5f2; /* Light mode */
     color: #1c1919;
     padding: 6rem 0;
     margin: 0;
@@ -990,7 +990,8 @@ html[data-theme="dark"] .fury-sciences__image-wrapper {
 
 /* DARK MODE EXAMPLES */
 /* Transparent so global html grid/glow shows through */
-html[data-theme="dark"] .fury-examples {
+html[data-theme="dark"] .fury-examples,
+html[data-theme="light"] .fury-examples {
     background: transparent;
 }
 
@@ -1182,7 +1183,6 @@ html[data-theme="dark"] .fury-example-card__title {
 /* --- COMMUNITY COMPONENT --- */
 .fury-community {
     width: 100%;
-    background: #faf5f2;
     color: #1c1919;
     padding: 6rem 0;
     margin: 0;
@@ -1327,7 +1327,8 @@ html[data-theme="dark"] .fury-example-card__title {
 
 /* Dark mode overrides */
 /* Transparent so global html grid/glow shows through */
-html[data-theme="dark"] .fury-community {
+html[data-theme="dark"] .fury-community,
+html[data-theme="light"] .fury-community {
     background: transparent;
 }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -184,12 +184,13 @@ github_project_url = "https://github.com/fury-gl/fury"
 
 import github_tools as ght
 
-all_versions = ght.get_all_versions(ignore="micro")
+# Skip GitHub fetching for now
+all_versions = [] # ght.get_all_versions(ignore="micro")
 html_context = {
     "all_versions": all_versions,
     "versions_list": ["dev", "latest"] + all_versions,
-    "basic_stats": ght.fetch_basic_stats(),
-    "contributors": ght.fetch_contributor_stats(),
+    "basic_stats": {}, # ght.fetch_basic_stats(),
+    "contributors": {"total_contributors": 0, "contributors": [], "total_commits": 0}, # ght.fetch_contributor_stats(),
     "default_mode": "light",
 }
 


### PR DESCRIPTION
To be merged after: #1281 
<img width="1920" height="925" alt="image" src="https://github.com/user-attachments/assets/b21c4ea8-847e-4e42-ab76-b6c9880253a8" />
<img width="1920" height="925" alt="image" src="https://github.com/user-attachments/assets/7c77ebab-cea5-416f-a177-40274a7d4116" />



The goal of this PR is to identify and override the default colors for the doc pages. This is a temporary change for now. Once the final designs for the internal pages are ready, I will update the styles to match the approved design.
