### PR TITLE
BF: Fixed chipping of text.

### DIFF
--- a/fury/tests/test_window.py
+++ b/fury/tests/test_window.py
@@ -341,7 +341,8 @@ def test_show_manager_initialization_default():
     show_m = ShowManager(window_type="offscreen")
     assert show_m.title == "FURY 2.0"
     assert show_m.size == (800, 800)
-    assert show_m.pixel_ratio == 1.25
+    assert show_m.pixel_ratio != 1.25
+    assert float(show_m.pixel_ratio).is_integer()
     assert show_m.enable_events is True
     assert show_m._show_fps is False
     assert show_m._max_fps == 60

--- a/fury/ui/core.py
+++ b/fury/ui/core.py
@@ -13,7 +13,12 @@ from fury.lib import (
 from fury.material import _create_mesh_material
 from fury.primitive import prim_ring
 from fury.ui import UIContext
-from fury.ui.helpers import UI_Z_RANGE, Anchor, get_anchor_to_multiplier
+from fury.ui.helpers import (
+    UI_SUBLAYER_SCALE,
+    UI_Z_RANGE,
+    Anchor,
+    get_anchor_to_multiplier,
+)
 
 
 class UI(object, metaclass=abc.ABCMeta):
@@ -178,7 +183,7 @@ class UI(object, metaclass=abc.ABCMeta):
                 f"y_anchor should be one of these {', '.join([Anchor.TOP, Anchor.CENTER, Anchor.BOTTOM])} but received {y_anchor}"  # noqa: E501
             )
 
-    def set_actor_position(self, actor, center_position, z_order):
+    def set_actor_position(self, actor, center_position, z_order, *, sub_order=0):
         """
         Set the position of the PyGfx actor.
 
@@ -191,12 +196,18 @@ class UI(object, metaclass=abc.ABCMeta):
             position of the actor.
         z_order : int
             The Z-order of the UI component.
+        sub_order : int, optional
+            Ordering of this actor relative to other actors of the *same*
+            component (and `z_order`). Higher values are drawn on top. This
+            disambiguates coplanar actors, such as a text actor and its
+            background, whose draw order would otherwise be undefined.
         """
         canvas_size = UIContext.canvas_size
 
         actor.local.x = center_position[0]
         actor.local.y = canvas_size[1] - center_position[1]
         actor.local.z = np.interp(z_order, UIContext.z_order_bounds, UI_Z_RANGE)
+        actor.render_order = float(z_order * UI_SUBLAYER_SCALE + sub_order)
 
     def set_position(self, coords, x_anchor=Anchor.LEFT, y_anchor=Anchor.TOP):
         """
@@ -1040,6 +1051,7 @@ class TextBlock2D(UI):
         self.actor = Text(
             markdown=self._message, screen_space=True, anchor="middle-center"
         )
+        self.actor.material.aa = True
         self.background = Rectangle2D()
         self._children.append(self.background)
         self.handle_events(self.actor)
@@ -1501,7 +1513,9 @@ class TextBlock2D(UI):
             msg = "Vertical justification must be: top, middle or bottom."
             raise ValueError(msg)
 
-        self.set_actor_position(self.actor, updated_text_position, self.z_order)
+        self.set_actor_position(
+            self.actor, updated_text_position, self.z_order, sub_order=1
+        )
 
     def update_bounding_box(self, *, size=None):
         """

--- a/fury/ui/helpers.py
+++ b/fury/ui/helpers.py
@@ -17,6 +17,7 @@ class Anchor(str, Enum):
 
 TWO_PI = 2 * np.pi
 UI_Z_RANGE = np.array([0.9, 0.1])
+UI_SUBLAYER_SCALE = 16
 
 
 def clip_overflow(textblock, width, *, side="right"):

--- a/fury/ui/tests/test_core.py
+++ b/fury/ui/tests/test_core.py
@@ -564,3 +564,87 @@ def test_slider2d_base_logic():
     slider.on_change = on_change
     slider.value = 25
     assert hook_data["called"] is True
+
+
+def test_textblock2d_text_renders_above_background():
+    """
+    Text must draw on top of its own background.
+
+    The text actor and its background share the component's z_order, so they
+    are coplanar. The text is given a higher render_order so its anti-aliased
+    edges blend against the background instead of whatever lies behind the UI
+    (which produced ragged, clipped-looking glyphs). Anti-aliasing is also
+    enabled for smooth glyph edges.
+    """
+    tb = ui.TextBlock2D(
+        text="Above background",
+        size=(200, 100),
+        position=(50, 50),
+        bg_color=(1.0, 1.0, 1.0),
+        color=(0.0, 0.0, 0.0),
+    )
+
+    background_actor = tb.background.actors[0]
+    assert tb.actor.render_order > background_actor.render_order
+    assert tb.actor.material.aa is True
+
+
+def test_textblock2d_render_order_tracks_z_order():
+    """
+    render_order increases with z_order while text stays above its background.
+
+    Draw order is derived from z_order so overlapping components stack
+    predictably, with a fixed sub-order keeping a component's text above its
+    own background.
+    """
+    tb = ui.TextBlock2D(
+        text="Layered",
+        size=(200, 100),
+        position=(50, 50),
+        bg_color=(1.0, 1.0, 1.0),
+    )
+    background_actor = tb.background.actors[0]
+
+    low_text = tb.actor.render_order
+    low_bg = background_actor.render_order
+    assert low_text > low_bg
+
+    tb.z_order = 5
+    tb.update_bounding_box()
+
+    assert tb.actor.render_order > low_text
+    assert background_actor.render_order > low_bg
+    assert tb.actor.render_order > background_actor.render_order
+
+
+def test_textblock2d_solid_text_over_background_snapshot():
+    """
+    Black text on a white background renders as solid dark glyphs.
+
+    End-to-end guard for the coplanar draw order: over a red scene, the white
+    background fills the box and the black text on top is the only source of
+    near-black pixels, so its presence confirms the text composites over its
+    background rather than bleeding into the scene behind the UI.
+    """
+    tb = ui.TextBlock2D(
+        text="Solid",
+        font_size=40,
+        size=(200, 60),
+        position=(50, 50),
+        bg_color=(1.0, 1.0, 1.0),
+        color=(0.0, 0.0, 0.0),
+    )
+
+    scene = window.Scene(background=(1.0, 0.0, 0.0, 1.0))
+    scene.add(tb)
+
+    fname = "textblock_solid_over_bg.png"
+    window.snapshot(scene=scene, fname=fname)
+
+    img_array = np.array(Image.open(fname))[:, :, :3]
+
+    white_box = np.all(img_array > 200, axis=2).sum()
+    dark_text = np.all(img_array < 40, axis=2).sum()
+
+    assert white_box > 0
+    assert dark_text > 0

--- a/fury/window.py
+++ b/fury/window.py
@@ -649,8 +649,10 @@ class ShowManager:
         The size (width, height) of the window in pixels.
     window_type : str
         The type of window canvas to create ('default', 'qt', 'jupyter', 'offscreen').
-    pixel_ratio : float
-        The ratio between render buffer and display buffer pixels.
+    pixel_ratio : float, optional
+        The ratio between render buffer and display buffer pixels. If None,
+        the display's native ratio is used. Avoid fractional values,
+        which resample screen-space text and soften its strokes.
     camera_light : bool
         Whether to attach a DirectionalLight to the camera.
     screen_config : list
@@ -682,7 +684,7 @@ class ShowManager:
         title="FURY 2.0",
         size=(800, 800),
         window_type="default",
-        pixel_ratio=1.25,
+        pixel_ratio=None,
         camera_light=True,
         screen_config=None,
         enable_events=True,
@@ -717,7 +719,8 @@ class ShowManager:
         if renderer is None:
             renderer = Renderer(self.window)
         self.renderer = renderer
-        self.renderer.pixel_ratio = pixel_ratio
+        if pixel_ratio is not None:
+            self.renderer.pixel_ratio = pixel_ratio
         self.renderer.add_event_handler(
             lambda event: self._resize(size=(event.width, event.height)),
             EventType.RESIZE,


### PR DESCRIPTION
- Updated render_order for coplanar elements.
- Unset the pixel_ratio to decide from the system by default.
- Introduced the sub_order param to arrange the child element's actor.
- Provided the test cases for the same.

<img width="276" height="443" alt="Screenshot 2026-06-25 123400" src="https://github.com/user-attachments/assets/e4ef8556-e4f6-4d66-a8d5-6a7a96871325" />


NOTE: you can run any tutorial with UI text element to see the fix working.