### PR TITLE
UI: Combobox expands on `TextBlock` clicks

### DIFF
--- a/fury/ui/elements.py
+++ b/fury/ui/elements.py
@@ -2668,6 +2668,7 @@ class ComboBox2D(UI):
         self._menu_visibility = False
         self._selection_ID = None
         self._drag_offset = None
+        self._is_dragging = False
         self.draggable = draggable
         self.sel_text_color = selection_text_color
         self.sel_bg_color = selection_bg_color
@@ -2753,17 +2754,22 @@ class ComboBox2D(UI):
 
     def _setup_drag_events(self):
         """Attach drag event handlers to all interactive surfaces."""
-        if self.draggable:
-            drag_targets = [
-                self.selection_box,
-                self.selection_box.background,
-            ]
+        drag_targets = [
+            self.selection_box,
+            self.selection_box.background,
+        ]
 
+        for target in drag_targets:
+            target.on_left_mouse_button_released = self.left_button_released
+
+        if self.draggable:
             for target in drag_targets:
                 target.on_left_mouse_button_dragged = self.left_button_dragged
                 target.on_left_mouse_button_pressed = self.left_button_pressed
         else:
             self.panel.background.on_left_mouse_button_dragged = lambda event: None
+            for target in drag_targets:
+                target.on_left_mouse_button_pressed = self.left_button_pressed
 
     def _get_actors(self):
         """
@@ -2968,6 +2974,7 @@ class ComboBox2D(UI):
         """
         click_pos = np.array([event.x, event.y])
         self._drag_offset = click_pos - self.get_position()
+        self._is_dragging = False
 
     def left_button_dragged(self, event):
         """
@@ -2979,9 +2986,25 @@ class ComboBox2D(UI):
             The PyGfx pointer event.
         """
         if self._drag_offset is not None:
+            self._is_dragging = True
             click_position = np.array([event.x, event.y])
             new_position = click_position - self._drag_offset
             self.set_position(new_position)
+
+    def left_button_released(self, event):
+        """
+        Handle left mouse button release event.
+
+        Parameters
+        ----------
+        event : PointerEvent
+            The PyGfx pointer event.
+        """
+        if self._is_dragging:
+            self._is_dragging = False
+        else:
+            self.menu_toggle_callback(event)
+        self._drag_offset = None
 
 
 class ListBox2D(UI):

--- a/fury/ui/tests/test_elements.py
+++ b/fury/ui/tests/test_elements.py
@@ -1743,112 +1743,6 @@ def test_range_slider_size_vertical():
 #             show_manager.start()
 
 
-# def test_ui_combobox_2d(interactive=False):
-#     filename = "test_ui_combobox_2d"
-#     recording_filename = pjoin(DATA_DIR, filename + ".log.gz")
-#     expected_events_counts_filename = pjoin(DATA_DIR, filename + ".json")
-
-#     values = ["An Item" + str(i) for i in range(0, 5)]
-#     new_values = ["An Item5", "An Item6"]
-
-#     combobox = ui.ComboBox2D(items=values, position=(400, 400), size=(300, 200))
-
-#     # Assign the counter callback to every possible event.
-#     event_counter = EventCounter()
-#     event_counter.monitor(combobox)
-
-#     current_size = (800, 800)
-#     show_manager = window.ShowManager(size=current_size, title="ComboBox UI Example")
-#     show_manager.scene.add(combobox)
-
-#     values.extend(new_values)
-#     combobox.append_item(*new_values)
-#     npt.assert_equal(values, combobox.items)
-
-#     values.append("An Item7")
-#     combobox.append_item("An Item7")
-#     npt.assert_equal(values, combobox.items)
-
-#     values.append("An Item8")
-#     values.append("An Item9")
-#     combobox.append_item("An Item8", "An Item9")
-#     npt.assert_equal(values, combobox.items)
-
-#     complex_list = [[0], (1, [[2, 3], 4], 5)]
-#     combobox.append_item(*complex_list)
-#     values.extend([str(i) for i in range(6)])
-#     npt.assert_equal(values, combobox.items)
-
-#     invalid_item = {"Hello": 1, "World": 2}
-#     npt.assert_raises(TypeError, combobox.append_item, invalid_item)
-
-#     npt.assert_equal(values, combobox.items)
-#     npt.assert_equal((30, 20), combobox.drop_button_size)
-#     npt.assert_equal([270, 140], combobox.drop_menu_size)
-#     npt.assert_equal([300, 200], combobox.size)
-
-#     ui.ComboBox2D(items=values, draggable=False)
-
-#     if interactive:
-#         show_manager.record_events_to_file(recording_filename)
-#         print(list(event_counter.events_counts.items()))
-#         event_counter.save(expected_events_counts_filename)
-
-#     else:
-#         show_manager.play_events_from_file(recording_filename)
-#         expected = EventCounter.load(expected_events_counts_filename)
-#         event_counter.check_counts(expected)
-
-#     npt.assert_equal("An Item1", combobox.selected_text)
-#     npt.assert_equal(1, combobox.selected_text_index)
-
-#     combobox.resize((450, 300))
-#     npt.assert_equal((405, 30), combobox.text_block_size)
-#     npt.assert_equal((45, 30), combobox.drop_button_size)
-#     npt.assert_equal((405, 210), combobox.drop_menu_size)
-
-
-# def test_ui_combobox_2d_dropdown_visibility(interactive=False):
-#     values = ["An Item" + str(i) for i in range(0, 5)]
-
-#     tab_ui = ui.TabUI(position=(49, 94), size=(400, 400), nb_tabs=1, draggable=True)
-#     combobox = ui.ComboBox2D(items=values, position=(400, 400), size=(300, 200))
-
-#     tab_ui.add_element(0, combobox, (0.1, 0.3))
-
-#     # Assign the counter callback to every possible event.
-#     event_counter = EventCounter()
-#     event_counter.monitor(combobox)
-#     event_counter.monitor(tab_ui)
-
-#     current_size = (800, 800)
-#     show_manager = window.ShowManager(size=current_size, title="ComboBox UI Example")
-#     show_manager.scene.add(tab_ui)
-
-#     tab_ui.tabs[0].content_panel.set_visibility(True)
-#     npt.assert_equal(False, combobox._menu_visibility)
-#     npt.assert_equal(False, combobox.drop_down_menu.panel.actors[0].GetVisibility())
-#     npt.assert_equal(0, combobox.drop_down_button.current_icon_id)
-#     npt.assert_equal(True, combobox.drop_down_button.actors[0].GetVisibility())
-#     npt.assert_equal(True, combobox.selection_box.actors[0].GetVisibility())
-
-#     tab_ui.tabs[0].content_panel.set_visibility(False)
-#     npt.assert_equal(False, combobox._menu_visibility)
-#     npt.assert_equal(False, combobox.drop_down_menu.panel.actors[0].GetVisibility())
-#     npt.assert_equal(0, combobox.drop_down_button.current_icon_id)
-#     npt.assert_equal(False, combobox.drop_down_button.actors[0].GetVisibility())
-#     npt.assert_equal(False, combobox.selection_box.actors[0].GetVisibility())
-
-#     iren = show_manager.scene.GetRenderWindow().GetInteractor().GetInteractorStyle()
-#     combobox.menu_toggle_callback(iren, None, None)
-#     tab_ui.tabs[0].content_panel.set_visibility(True)
-#     npt.assert_equal(True, combobox._menu_visibility)
-#     npt.assert_equal(True, combobox.drop_down_menu.panel.actors[0].GetVisibility())
-#     npt.assert_equal(1, combobox.drop_down_button.current_icon_id)
-#     npt.assert_equal(True, combobox.drop_down_button.actors[0].GetVisibility())
-#     npt.assert_equal(True, combobox.selection_box.actors[0].GetVisibility())
-
-
 def test_ui_combobox_2d_initialization_and_properties():
     """Test ComboBox2D initialization, default parameters, layout, and properties."""
     fetch_viz_icons()
@@ -2004,6 +1898,26 @@ def test_ui_combobox_2d_drag_events():
 
     cb3 = ui.ComboBox2D(items=["A"], draggable=False)
     assert cb3.draggable is False
+
+    assert combobox._menu_visibility is False
+    event_press2 = window.PointerEvent(
+        x=20, y=20, type=window.EventType.POINTER_DOWN, target="target"
+    )
+    combobox.left_button_pressed(event_press2)
+    event_release = window.PointerEvent(
+        x=20, y=20, type=window.EventType.POINTER_UP, target="target"
+    )
+    combobox.left_button_released(event_release)
+    assert combobox._menu_visibility is True
+    assert combobox._drag_offset is None
+
+    combobox.left_button_pressed(event_press2)
+    combobox.left_button_dragged(event_drag)
+    assert combobox._is_dragging is True
+    combobox.left_button_released(event_release)
+    assert combobox._is_dragging is False
+    assert combobox._menu_visibility is True
+    assert combobox._drag_offset is None
 
 
 #     skip_osx,


### PR DESCRIPTION
Combobox previously needed to be clicked specifically on the arrow icon to expand and collapse which wasnt very convenient as we usually click on the textblock too to expand. So added that accessibility.