### PR TITLE
BF: Fix phantom sphere in the case of imposter (billboard) Sphere.

### DIFF
--- a/fury/actor/_billboard.py
+++ b/fury/actor/_billboard.py
@@ -88,7 +88,7 @@ def _create_billboard_actor(
     repeats = 6  # 2 triangles per quad
     pos = np.repeat(centers, repeats, axis=0).astype(np.float32)
     col = np.repeat(colors, repeats, axis=0).astype(np.float32)
-    indices = np.arange(pos.shape[0], dtype=np.uint32)
+    indices = np.arange(pos.shape[0], dtype=np.uint32).reshape(-1, 3)
 
     # Encode per-billboard size in normals so shaders can fetch dimensions
     normals = np.repeat(

--- a/fury/actor/tests/test_billboard.py
+++ b/fury/actor/tests/test_billboard.py
@@ -40,7 +40,8 @@ def test_basic_billboard(interactive: bool = False):
     npt.assert_equal(len(geom.normals.data), 18)
     normals = np.asarray(geom.normals.data).reshape(-1, 3)
     npt.assert_allclose(normals[0, :2], sizes[0])
-    npt.assert_equal(len(geom.indices.data), 18)
+    npt.assert_equal(geom.indices.data.shape, (6, 3))
+    npt.assert_equal(geom.indices.data.size, 18)
 
     # Check material opacity
     assert np.isclose(bb.material.opacity, 0.75)


### PR DESCRIPTION
- Updated the test case for the same.

Before:
<img width="900" height="500" alt="image" src="https://github.com/user-attachments/assets/5e954142-54e4-4d18-8ff1-7577f24c5eb4" />

After
<img width="900" height="500" alt="image" src="https://github.com/user-attachments/assets/d0f7bd13-aee0-410c-b356-5eef588dddc9" />

