### PR TITLE
Add test for TextBox2D font size background update

### DIFF
--- a/fury/ui/tests/test_elements.py
+++ b/fury/ui/tests/test_elements.py
@@ -843,6 +843,25 @@ def test_textbox_handle_character_returns_false():
     result = tb.handle_character("Backspace", "")
     assert result is False
 
+def test_textbox_font_size_updates_background():
+    """Test that the textbox background updates when font size changes."""
+    textbox = ui.TextBox2D(
+        width=10,
+        height=2,
+        font_size=20,
+    )
+
+    initial_size = textbox.text.size
+
+    textbox.font_size = 40
+
+    updated_size = textbox.text.size
+
+    assert textbox.font_size == 40
+    assert textbox.text.font_size == 40
+    assert updated_size[0] > initial_size[0]
+    assert updated_size[1] > initial_size[1]
+
 
 def test_ui_line_slider_2d_variations(recording=False):
     for orientation in ["horizontal", "vertical"]:


### PR DESCRIPTION
Added a regression test to verify that changing the font size of TextBox2D updates the associated text and background size.

The test verifies that:
- TextBox2D font_size is updated correctly.
- The internal TextBlock2D font_size is updated.
- The background width increases when the font size increases.
- The background height increases when the font size increases.

If GitHub asks for a short commit message only, just use: