### PR TITLE
Add support for saving frames as GIF

### DIFF
--- a/fury/io.py
+++ b/fury/io.py
@@ -263,6 +263,54 @@ def save_image(
     im.save(filename, **save_kwargs)
 
 
+def save_as_gif(arr, filename, *, duration=100, loop=0):
+    """
+    Save multiple image frames as an animated GIF.
+
+    Parameters
+    ----------
+    arr : ndarray
+        Array containing animation frames with shape (N, H, W),
+        (N, H, W, 3), or (N, H, W, 4).
+    filename : str
+        Output filename. Should be a gif file.
+    duration : int, optional
+        Duration of each frame in milliseconds.
+    loop : int, optional
+        Number of times the animation should loop. 0 means infinite looping.
+    """
+    extension = get_extension(filename).lower()
+
+    if extension != "gif":
+        raise OSError(
+            f"Impossible to save the file {filename}: Unknown extension {extension}"
+        )
+
+    if arr.ndim not in (3, 4):
+        raise ValueError(
+            "GIF frames should have shape (N, H, W), "
+            "(N, H, W, 3), or (N, H, W, 4)."
+        )
+
+    if arr.ndim == 4 and arr.shape[-1] not in (3, 4):
+        raise ValueError(
+            "GIF frames must have 3 (RGB) or 4 (RGBA) channels."
+        )
+
+    if arr.shape[0] == 0:
+        raise ValueError("At least one frame is required to create a GIF.")
+
+    frames = [Image.fromarray(frame) for frame in arr]
+
+    frames[0].save(
+        filename,
+        save_all=True,
+        append_images=frames[1:],
+        duration=duration,
+        loop=loop,
+    )
+
+
 def get_extension(file_path):
     """
     Get the file extension.
@@ -312,53 +360,6 @@ def load_network(file_path, format=None):
         data = f.read()
 
     return parse_network(data, format)
-
-def save_as_gif(arr, filename, *, duration=100, loop=0):
-    """
-    Save multiple image frames as an animated GIF.
-
-    Parameters
-    ----------
-    arr : ndarray
-        Array containing animation frames with shape (N, H, W),
-        (N, H, W, 3), or (N, H, W, 4).
-    filename : str
-        Output filename. Should be a gif file.
-    duration : int, optional
-        Duration of each frame in milliseconds.
-    loop : int, optional
-        Number of times the animation should loop. 0 means infinite looping.
-    """
-    extension = get_extension(filename).lower()
-
-    if extension != "gif":
-        raise OSError(
-            f"Impossible to save the file {filename}: Unknown extension {extension}"
-        )
-
-    if arr.ndim not in (3, 4):
-        raise ValueError(
-            "GIF frames should have shape (N, H, W), "
-            "(N, H, W, 3), or (N, H, W, 4)."
-        )
-
-    if arr.ndim == 4 and arr.shape[-1] not in (3, 4):
-        raise ValueError(
-            "GIF frames must have 3 (RGB) or 4 (RGBA) channels."
-        )
-
-    if arr.shape[0] == 0:
-        raise ValueError("At least one frame is required to create a GIF.")
-
-    frames = [Image.fromarray(frame) for frame in arr]
-
-    frames[0].save(
-        filename,
-        save_all=True,
-        append_images=frames[1:],
-        duration=duration,
-        loop=loop,
-    )
 
 
 def save_network(network_data, file_path, format=None):

--- a/fury/io.py
+++ b/fury/io.py
@@ -313,6 +313,53 @@ def load_network(file_path, format=None):
 
     return parse_network(data, format)
 
+def save_as_gif(arr, filename, *, duration=100, loop=0):
+    """
+    Save multiple image frames as an animated GIF.
+
+    Parameters
+    ----------
+    arr : ndarray
+        Array containing animation frames with shape (N, H, W),
+        (N, H, W, 3), or (N, H, W, 4).
+    filename : str
+        Output filename. Should be a gif file.
+    duration : int, optional
+        Duration of each frame in milliseconds.
+    loop : int, optional
+        Number of times the animation should loop. 0 means infinite looping.
+    """
+    extension = get_extension(filename).lower()
+
+    if extension != "gif":
+        raise OSError(
+            f"Impossible to save the file {filename}: Unknown extension {extension}"
+        )
+
+    if arr.ndim not in (3, 4):
+        raise ValueError(
+            "GIF frames should have shape (N, H, W), "
+            "(N, H, W, 3), or (N, H, W, 4)."
+        )
+
+    if arr.ndim == 4 and arr.shape[-1] not in (3, 4):
+        raise ValueError(
+            "GIF frames must have 3 (RGB) or 4 (RGBA) channels."
+        )
+
+    if arr.shape[0] == 0:
+        raise ValueError("At least one frame is required to create a GIF.")
+
+    frames = [Image.fromarray(frame) for frame in arr]
+
+    frames[0].save(
+        filename,
+        save_all=True,
+        append_images=frames[1:],
+        duration=duration,
+        loop=loop,
+    )
+
 
 def save_network(network_data, file_path, format=None):
     """

--- a/fury/tests/test_io.py
+++ b/fury/tests/test_io.py
@@ -2,7 +2,7 @@ import os
 from os.path import join as pjoin
 from tempfile import TemporaryDirectory as InTemporaryDirectory
 
-# from PIL import Image
+from PIL import Image
 import numpy as np
 import numpy.testing as npt
 
@@ -26,6 +26,7 @@ from fury.io import (
     read_points,
     save_image,
     save_network,
+    save_as_gif,
 )
 
 # save_polydata,
@@ -398,7 +399,55 @@ def test_save_load_image():
         "test.tiff",
         compression_type="invalid",
     )
+def test_save_as_gif():
+    """Test saving multiple frames as an animated GIF."""
+    frames = np.zeros((3, 20, 20, 3), dtype=np.uint8)
 
+    frames[0] = [255, 0, 0]
+    frames[1] = [0, 255, 0]
+    frames[2] = [0, 0, 255]
+
+    with InTemporaryDirectory() as odir:
+        filename = pjoin(odir, "animation.gif")
+
+        save_as_gif(frames, filename)
+
+        assert os.path.isfile(filename)
+
+        with Image.open(filename) as gif:
+            assert gif.n_frames == 3
+def test_save_as_gif_colors():
+    """Test that GIF frame colors are preserved."""
+    frames = np.zeros((3, 10, 10, 3), dtype=np.uint8)
+
+    frames[0] = [255, 0, 0]
+    frames[1] = [0, 255, 0]
+    frames[2] = [0, 0, 255]
+
+    with InTemporaryDirectory() as odir:
+        filename = pjoin(odir, "colors.gif")
+
+        save_as_gif(frames, filename)
+
+        with Image.open(filename) as gif:
+            for i in range(3):
+                gif.seek(i)
+                saved_frame = np.asarray(gif.convert("RGB"))
+
+                npt.assert_array_equal(saved_frame, frames[i])
+def test_save_as_gif_invalid_extension():
+    """Test that saving a GIF with an invalid extension raises an error."""
+    frames = np.zeros((2, 10, 10, 3), dtype=np.uint8)
+
+    with InTemporaryDirectory() as odir:
+        filename = pjoin(odir, "animation.png")
+
+        npt.assert_raises(
+            OSError,
+            save_as_gif,
+            frames,
+            filename,
+        )
 
 # @pytest.mark.skipif(
 #     skip_osx,

--- a/fury/tests/test_io.py
+++ b/fury/tests/test_io.py
@@ -24,9 +24,9 @@ from fury.io import (
     read_lines,
     read_mesh,
     read_points,
+    save_as_gif,
     save_image,
     save_network,
-    save_as_gif,
 )
 
 # save_polydata,


### PR DESCRIPTION
Add tests for saving multiple frames as animated GIFs.

The tests verify GIF creation, frame count, color preservation, and handling of invalid file extensions.